### PR TITLE
fix(duckdb): rewrite DataFusion's btrim to DuckDB's trim (fixes #13794)

### DIFF
--- a/crates/accelerators/accelerator-duckdb/src/lib.rs
+++ b/crates/accelerators/accelerator-duckdb/src/lib.rs
@@ -3853,6 +3853,16 @@ mod tests {
             ("", Some("x")),
             ("  \u{e9}\u{e9}  ", None),
             ("\u{e9}\u{e9}u\u{e9}\u{e9}", Some("\u{e9}")),
+            // Unicode Zs separators. DataFusion's one-argument `btrim` strips
+            // ASCII U+0020 and nothing else; a `trim` that strips every Zs
+            // would silently disagree here rather than fail.
+            ("\u{a0}x\u{a0}", None),
+            ("\u{2003}x\u{2003}", None),
+            ("\u{3000}x\u{3000}", None),
+            ("\u{a0} x \u{a0}", None),
+            ("\u{a0}x\u{a0}", Some(" ")),
+            ("\u{a0}x\u{a0}", Some("\u{a0}")),
+            ("\tx\n", None),
         ];
 
         for (input, trim_chars) in cases {

--- a/crates/accelerators/accelerator-duckdb/src/lib.rs
+++ b/crates/accelerators/accelerator-duckdb/src/lib.rs
@@ -3820,8 +3820,11 @@ mod tests {
     /// The dialect rewrites it to `DuckDB`'s `trim`. A rewrite is only correct
     /// if the accelerator answers what `DataFusion` answers, so this evaluates
     /// the *same* expression both ways — through a real in-memory `DuckDB` and
-    /// through `DataFusion` — and compares. `assert_ne!` on the two engines is
-    /// what a plausible-looking but unfaithful rename would trip.
+    /// through `DataFusion` — and asserts the two results are equal. That
+    /// equality is what a plausible-looking but unfaithful rename trips: the
+    /// remote SQL is valid and `DuckDB` runs it happily, so nothing else here
+    /// would notice. It is how the one-argument `Zs` divergence below was
+    /// caught.
     #[test]
     fn duckdb_trim_rewrite_agrees_with_datafusion_btrim() {
         use arrow::array::Array as _;

--- a/crates/accelerators/accelerator-duckdb/src/lib.rs
+++ b/crates/accelerators/accelerator-duckdb/src/lib.rs
@@ -3810,4 +3810,100 @@ mod tests {
             "the nearest neighbour of a stored vector is itself, at distance 0, not {nearest}"
         );
     }
+
+    /// `trim(...)` resolves to `DataFusion`'s `btrim`, which is the name the
+    /// unparser emits — and `DuckDB` has no function called `btrim`, so a
+    /// federated call into the accelerated store failed outright with
+    /// `Catalog Error: Scalar Function with name btrim does not exist!`
+    /// (issue #13794).
+    ///
+    /// The dialect rewrites it to `DuckDB`'s `trim`. A rewrite is only correct
+    /// if the accelerator answers what `DataFusion` answers, so this evaluates
+    /// the *same* expression both ways — through a real in-memory `DuckDB` and
+    /// through `DataFusion` — and compares. `assert_ne!` on the two engines is
+    /// what a plausible-looking but unfaithful rename would trip.
+    #[test]
+    fn duckdb_trim_rewrite_agrees_with_datafusion_btrim() {
+        use arrow::array::Array as _;
+        use datafusion::logical_expr::expr::ScalarFunction;
+        use datafusion::prelude::Expr;
+        use datafusion::sql::unparser::Unparser;
+        use runtime_datafusion::dialect::new_duckdb_dialect;
+
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        let duck = duckdb::Connection::open_in_memory().expect("in-memory DuckDB");
+        let tokio_rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime");
+        let ctx = SessionContext::new();
+
+        // Spaces on both sides, a character set, both together, an empty trim
+        // set, a string that trims away entirely, and multi-byte characters —
+        // the shapes where a trim implementation can disagree.
+        let cases: &[(&str, Option<&str>)] = &[
+            ("  padded  ", None),
+            ("nopad", None),
+            ("", None),
+            ("   ", None),
+            ("xyhelloyx", Some("xy")),
+            ("x hello x", Some("xy")),
+            ("xxx", Some("x")),
+            ("nopad", Some("")),
+            ("", Some("x")),
+            ("  \u{e9}\u{e9}  ", None),
+            ("\u{e9}\u{e9}u\u{e9}\u{e9}", Some("\u{e9}")),
+        ];
+
+        for (input, trim_chars) in cases {
+            let mut args = vec![lit(*input)];
+            if let Some(chars) = trim_chars {
+                args.push(lit(*chars));
+            }
+            let call = Expr::ScalarFunction(ScalarFunction::new_udf(
+                datafusion::functions::string::btrim(),
+                args,
+            ));
+
+            let sql = unparser
+                .expr_to_sql(&call)
+                .expect("btrim unparses for DuckDB")
+                .to_string();
+            assert!(
+                sql.starts_with("trim("),
+                "DuckDB has no `btrim`; the dialect must emit `trim`, got {sql}"
+            );
+
+            let from_duckdb: Option<String> = duck
+                .query_row(&format!("SELECT {sql}"), [], |row| row.get(0))
+                .unwrap_or_else(|e| panic!("DuckDB rejected `SELECT {sql}`: {e}"));
+
+            let batches = tokio_rt
+                .block_on(async {
+                    ctx.read_empty()?
+                        .select(vec![call.alias("v")])?
+                        .collect()
+                        .await
+                })
+                .expect("DataFusion evaluates btrim");
+            let column = batches
+                .first()
+                .expect("one batch")
+                .column_by_name("v")
+                .expect("column v")
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+                .expect("btrim returns Utf8 for a Utf8 literal");
+            let from_datafusion = if column.is_null(0) {
+                None
+            } else {
+                Some(column.value(0).to_string())
+            };
+
+            assert_eq!(
+                from_duckdb, from_datafusion,
+                "DuckDB `{sql}` and DataFusion btrim({input:?}, {trim_chars:?}) must agree"
+            );
+        }
+    }
 }

--- a/crates/runtime-datafusion/src/dialect/duckdb.rs
+++ b/crates/runtime-datafusion/src/dialect/duckdb.rs
@@ -28,6 +28,63 @@ pub(crate) const REGEXP_MATCH_NAME: &str = "regexp_extract";
 pub(crate) const REGEXP_REPLACE_NAME: &str = "regexp_replace";
 pub(crate) const REGEXP_COUNT_NAME: &str = "regexp_extract_all";
 
+/// `DuckDB`'s name for the both-ends trim `DataFusion` calls `btrim`.
+pub(crate) const TRIM_NAME: &str = "trim";
+
+/// Renders `args` unchanged as a call to `duckdb_fn`.
+///
+/// For a function whose only difference from its `DuckDB` counterpart is the
+/// name: same arity, same argument order, same semantics. A function whose
+/// arguments need reordering, padding or checking does not belong here — see
+/// [`DuckDBRegexpFunction::to_datafusion_function`] for that shape.
+fn renamed_fn_to_sql(
+    unparser: &datafusion::sql::unparser::Unparser,
+    args: &[Expr],
+    duckdb_fn: &str,
+) -> Result<Option<ast::Expr>, DataFusionError> {
+    let ast_args: Vec<FunctionArg> = args
+        .iter()
+        .map(|arg| {
+            Ok::<FunctionArg, DataFusionError>(FunctionArg::Unnamed(FunctionArgExpr::Expr(
+                unparser.expr_to_sql(arg)?,
+            )))
+        })
+        .try_collect()?;
+
+    Ok(Some(ast::Expr::Function(Function {
+        name: ObjectName(vec![ast::ObjectNamePart::Identifier(Ident::new(duckdb_fn))]),
+        args: ast::FunctionArguments::List(ast::FunctionArgumentList {
+            duplicate_treatment: None,
+            args: ast_args,
+            clauses: vec![],
+        }),
+        filter: None,
+        null_treatment: None,
+        over: None,
+        within_group: vec![],
+        parameters: ast::FunctionArguments::None,
+        uses_odbc_syntax: false,
+    })))
+}
+
+/// Converts `DataFusion`'s `btrim` into `DuckDB`'s [`TRIM_NAME`].
+///
+/// `trim` is only an alias in `DataFusion`: the function's own name is `btrim`,
+/// so that is what the unparser emits, and `DuckDB` has no function of that
+/// name. `SELECT trim(name) FROM <a DuckDB-accelerated dataset>` therefore
+/// fails with `Catalog Error: Scalar Function with name btrim does not exist!`
+/// (issue #13794).
+///
+/// A rename is faithful here because `DuckDB`'s `trim` is the same function at
+/// both arities `btrim` accepts: `trim(str)` strips spaces from both ends, and
+/// `trim(str, chars)` strips any character of `chars` from both ends.
+pub(crate) fn btrim_to_trim(
+    unparser: &datafusion::sql::unparser::Unparser,
+    args: &[Expr],
+) -> Result<Option<ast::Expr>, DataFusionError> {
+    renamed_fn_to_sql(unparser, args, TRIM_NAME)
+}
+
 /// Shared conversion for Spice vector UDFs that have a native `DuckDB` ARRAY
 /// equivalent taking two equal-length `FLOAT[N]` operands (e.g.
 /// `array_cosine_distance`, `array_inner_product`).
@@ -586,6 +643,47 @@ mod tests {
             .expect("should execute successfully")
             .expect("should return expression");
         assert_eq!(result.to_string(), "random()");
+    }
+
+    /// `trim` is an alias of `btrim` in `DataFusion`, so the planner resolves
+    /// `trim(x)` to a `btrim` call and the unparser emits the function's own
+    /// name. `DuckDB` has no `btrim`, which is what issue #13794 hits.
+    #[test]
+    fn btrim_unparses_to_duckdb_trim() {
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        let column = Expr::Column(Column {
+            relation: Some(TableReference::bare("t")),
+            name: "name".to_string(),
+            spans: Spans::new(),
+        });
+
+        for (args, expected) in [
+            (vec![column.clone()], r#"trim("t"."name")"#),
+            (vec![column.clone(), lit("xy")], r#"trim("t"."name", 'xy')"#),
+        ] {
+            let rendered = btrim_to_trim(&unparser, &args)
+                .expect("should execute successfully")
+                .expect("should return expression");
+            assert_eq!(rendered.to_string(), expected);
+        }
+    }
+
+    /// The whole `btrim` call, planned from SQL and unparsed through the
+    /// dialect, so a handler that is written but never installed fails here.
+    #[test]
+    fn duckdb_dialect_installs_the_btrim_override() {
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        let call = Expr::ScalarFunction(ScalarFunction::new_udf(
+            datafusion::functions::string::btrim(),
+            vec![lit("  hi  ")],
+        ));
+
+        let rendered = unparser
+            .expr_to_sql(&call)
+            .expect("btrim unparses for DuckDB");
+        assert_eq!(rendered.to_string(), "trim('  hi  ')");
     }
 
     #[test]

--- a/crates/runtime-datafusion/src/dialect/duckdb.rs
+++ b/crates/runtime-datafusion/src/dialect/duckdb.rs
@@ -690,7 +690,7 @@ mod tests {
 
         for (args, expected) in [
             (vec![column.clone()], r#"trim("t"."name", ' ')"#),
-            (vec![column.clone(), lit("xy")], r#"trim("t"."name", 'xy')"#),
+            (vec![column, lit("xy")], r#"trim("t"."name", 'xy')"#),
         ] {
             let rendered = btrim_to_trim(&unparser, &args)
                 .expect("should execute successfully")

--- a/crates/runtime-datafusion/src/dialect/duckdb.rs
+++ b/crates/runtime-datafusion/src/dialect/duckdb.rs
@@ -31,12 +31,17 @@ pub(crate) const REGEXP_COUNT_NAME: &str = "regexp_extract_all";
 /// `DuckDB`'s name for the both-ends trim `DataFusion` calls `btrim`.
 pub(crate) const TRIM_NAME: &str = "trim";
 
-/// Renders `args` unchanged as a call to `duckdb_fn`.
+/// The trim set `btrim` uses when called with one argument — see
+/// [`btrim_to_trim`] for why it has to be passed to `DuckDB` explicitly.
+const ASCII_SPACE: &str = " ";
+
+/// Renders `args` as a call to `duckdb_fn`, in the order given.
 ///
-/// For a function whose only difference from its `DuckDB` counterpart is the
-/// name: same arity, same argument order, same semantics. A function whose
-/// arguments need reordering, padding or checking does not belong here — see
-/// [`DuckDBRegexpFunction::to_datafusion_function`] for that shape.
+/// The caller is responsible for having already put `args` into the shape
+/// `duckdb_fn` expects — see [`btrim_to_trim`], which has to supply a trim set
+/// the `DataFusion` call left implicit. A function needing per-argument
+/// inspection or rejection wants
+/// [`DuckDBRegexpFunction::to_datafusion_function`]'s shape instead.
 fn renamed_fn_to_sql(
     unparser: &datafusion::sql::unparser::Unparser,
     args: &[Expr],
@@ -75,14 +80,36 @@ fn renamed_fn_to_sql(
 /// fails with `Catalog Error: Scalar Function with name btrim does not exist!`
 /// (issue #13794).
 ///
-/// A rename is faithful here because `DuckDB`'s `trim` is the same function at
-/// both arities `btrim` accepts: `trim(str)` strips spaces from both ends, and
-/// `trim(str, chars)` strips any character of `chars` from both ends.
+/// **The one-argument form is not a bare rename.** `btrim(str)` strips ASCII
+/// `U+0020` and nothing else — `general_trim` calls `trim_ascii_char(s, b' ')` —
+/// whereas `DuckDB`'s one-argument `trim(str)` strips every Unicode `Zs`
+/// separator. On `U+00A0 'x' U+00A0` `DataFusion` returns the string unchanged
+/// and `DuckDB` returns `x`, so renaming it would turn a remote error into a
+/// silently different answer, which is worse. Passing the trim set explicitly
+/// as `trim(str, ' ')` puts `DuckDB` on the character-set path, where it strips
+/// exactly the characters given.
+///
+/// The two-argument form *is* a rename: both engines strip any character of the
+/// set from both ends.
 pub(crate) fn btrim_to_trim(
     unparser: &datafusion::sql::unparser::Unparser,
     args: &[Expr],
 ) -> Result<Option<ast::Expr>, DataFusionError> {
-    renamed_fn_to_sql(unparser, args, TRIM_NAME)
+    match args {
+        [input] => renamed_fn_to_sql(
+            unparser,
+            &[input.clone(), datafusion::prelude::lit(ASCII_SPACE)],
+            TRIM_NAME,
+        ),
+        [_, _] => renamed_fn_to_sql(unparser, args, TRIM_NAME),
+        // `btrim`'s signature admits one or two arguments, so the planner
+        // cannot build this. Fail rather than fall through to `Ok(None)`,
+        // which would put `btrim` back into the DuckDB SQL.
+        _ => Err(DataFusionError::Plan(format!(
+            "btrim takes one or two arguments, got {}; cannot render it as DuckDB SQL.",
+            args.len()
+        ))),
+    }
 }
 
 /// Shared conversion for Spice vector UDFs that have a native `DuckDB` ARRAY
@@ -648,6 +675,9 @@ mod tests {
     /// `trim` is an alias of `btrim` in `DataFusion`, so the planner resolves
     /// `trim(x)` to a `btrim` call and the unparser emits the function's own
     /// name. `DuckDB` has no `btrim`, which is what issue #13794 hits.
+    ///
+    /// The one-argument call must carry the trim set: a bare `trim(x)` puts
+    /// `DuckDB` on its Unicode-`Zs` path, which `btrim` is not.
     #[test]
     fn btrim_unparses_to_duckdb_trim() {
         let dialect = new_duckdb_dialect();
@@ -659,7 +689,7 @@ mod tests {
         });
 
         for (args, expected) in [
-            (vec![column.clone()], r#"trim("t"."name")"#),
+            (vec![column.clone()], r#"trim("t"."name", ' ')"#),
             (vec![column.clone(), lit("xy")], r#"trim("t"."name", 'xy')"#),
         ] {
             let rendered = btrim_to_trim(&unparser, &args)
@@ -667,6 +697,24 @@ mod tests {
                 .expect("should return expression");
             assert_eq!(rendered.to_string(), expected);
         }
+    }
+
+    /// `btrim`'s own signature admits only one or two arguments, so this is a
+    /// defensive arm — but it must be an error, not `Ok(None)`, which would
+    /// hand `btrim` straight back to `DuckDB`.
+    #[test]
+    fn btrim_with_an_impossible_arity_is_an_error_not_a_passthrough() {
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+
+        let error = btrim_to_trim(&unparser, &[lit("a"), lit("b"), lit("c")])
+            .expect_err("three arguments cannot be rendered");
+        assert!(
+            error
+                .to_string()
+                .contains("btrim takes one or two arguments"),
+            "unexpected error: {error}"
+        );
     }
 
     /// The whole `btrim` call, planned from SQL and unparsed through the
@@ -683,7 +731,7 @@ mod tests {
         let rendered = unparser
             .expr_to_sql(&call)
             .expect("btrim unparses for DuckDB");
-        assert_eq!(rendered.to_string(), "trim('  hi  ')");
+        assert_eq!(rendered.to_string(), "trim('  hi  ', ' ')");
     }
 
     #[test]

--- a/crates/runtime-datafusion/src/dialect/mod.rs
+++ b/crates/runtime-datafusion/src/dialect/mod.rs
@@ -32,6 +32,8 @@ const REGEXP_MATCH_FLAGS_POSITION: usize = 2; // The position of the flags argum
 const REGEXP_REPLACE_FLAGS_POSITION: usize = 3; // The position of the flags argument in regexp_replace function calls
 const REGEXP_COUNT_FLAGS_POSITION: usize = 3; // The position of the flags argument in regexp_count function calls
 
+const BTRIM_NAME: &str = "btrim";
+
 pub(crate) const REGEXP_LIKE_NAME: &str = "regexp_like";
 pub(crate) const REGEXP_MATCH_NAME: &str = "regexp_match";
 const REGEXP_REPLACE_NAME: &str = "regexp_replace";
@@ -102,8 +104,26 @@ fn duckdb_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
     ]
 }
 
-/// Names of the functions [`new_duckdb_dialect`] rewrites to native `DuckDB`
-/// SQL.
+/// The `DataFusion` built-ins the `DuckDB` dialect rewrites to native `DuckDB`
+/// SQL, paired with their handlers.
+///
+/// Separate from [`duckdb_scalar_overrides`], and deliberately absent from
+/// [`duckdb_native_function_names`]: that list is the federation deny-list's
+/// carve-out, and a built-in federates unless it is denied, so carving one out
+/// would do nothing. What a built-in needs is the handler — without one the
+/// unparser emits the `DataFusion` name verbatim into SQL `DuckDB` rejects.
+fn duckdb_builtin_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
+    vec![(
+        // DuckDB dialect: trim(string[, characters])
+        // DataFusion dialect: btrim(str[, trim_str]) — `trim` is only its alias
+        BTRIM_NAME,
+        Box::new(duckdb::btrim_to_trim) as ScalarFnToSqlHandler,
+    )]
+}
+
+/// Names of the Spice functions [`new_duckdb_dialect`] rewrites to native
+/// `DuckDB` SQL. The `DataFusion` built-ins it also rewrites are not here — see
+/// [`duckdb_builtin_scalar_overrides`] for why.
 ///
 /// Any Spice-specific function in this list has a real `DuckDB` equivalent and
 /// can therefore be federated (pushed down) to `DuckDB` rather than denied. The
@@ -118,10 +138,16 @@ pub fn duckdb_native_function_names() -> Vec<&'static str> {
         .collect()
 }
 
-/// Creates a new instance of the `DuckDB` dialect with support for Spice internal UDFs
+/// Creates a new instance of the `DuckDB` dialect with support for Spice
+/// internal UDFs ([`duckdb_scalar_overrides`]) and for the `DataFusion`
+/// built-ins `DuckDB` spells differently ([`duckdb_builtin_scalar_overrides`]).
 #[must_use]
 pub fn new_duckdb_dialect() -> Arc<dyn Dialect> {
-    let dialect = DuckDBDialect::new().with_custom_scalar_overrides(duckdb_scalar_overrides());
+    let overrides = duckdb_scalar_overrides()
+        .into_iter()
+        .chain(duckdb_builtin_scalar_overrides())
+        .collect();
+    let dialect = DuckDBDialect::new().with_custom_scalar_overrides(overrides);
 
     Arc::new(dialect) as Arc<dyn Dialect>
 }
@@ -186,7 +212,10 @@ pub fn new_bigquery_dialect() -> Arc<dyn Dialect> {
 
 #[cfg(test)]
 mod tests {
-    use super::{bigquery, bigquery_native_function_names};
+    use super::{
+        bigquery, bigquery_native_function_names, duckdb_builtin_scalar_overrides,
+        duckdb_native_function_names,
+    };
 
     #[test]
     fn every_carved_out_bigquery_name_is_a_function_the_deny_list_knows() {
@@ -212,6 +241,14 @@ mod tests {
                 !carved_out.contains(&entry.name),
                 "`{name}` is a DataFusion built-in and must not be in the Spice carve-out",
                 name = entry.name
+            );
+        }
+
+        let carved_out = duckdb_native_function_names();
+        for (name, _) in duckdb_builtin_scalar_overrides() {
+            assert!(
+                !carved_out.contains(&name),
+                "`{name}` is a DataFusion built-in and must not be in the Spice carve-out"
             );
         }
     }

--- a/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
+++ b/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
@@ -1,0 +1,169 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! `DataFusion` built-ins pushed down to a `DuckDB` accelerator must be
+//! unparsed to a function `DuckDB` actually has, and must answer the same as
+//! local evaluation.
+
+use app::AppBuilder;
+use datafusion::assert_batches_eq;
+use runtime::Runtime;
+use spicepod::acceleration::{Acceleration, Mode, RefreshMode};
+use spicepod::component::dataset::Dataset;
+use spicepod::param::Params;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::acceleration::load_runtime_datasets;
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{register_test_connectors, run_query, test_request_context, to_pretty_display},
+};
+
+const LOAD_TIMEOUT: Duration = Duration::from_mins(1);
+
+/// The rows the trims are measured on: padded with spaces, padded with a
+/// character set, padded with both, and NULL.
+fn write_csv_source(path: &Path) -> Result<(), anyhow::Error> {
+    std::fs::write(
+        path,
+        "id,name\n\
+         1,\"  padded  \"\n\
+         2,xyhelloyx\n\
+         3,\"x hello x\"\n\
+         4,\n",
+    )?;
+    Ok(())
+}
+
+fn duckdb_accelerated(from: &str, name: &str) -> Dataset {
+    let mut dataset = Dataset::new(from, name);
+    dataset.params = Some(Params::from_string_map(
+        vec![("file_format".to_string(), "csv".to_string())]
+            .into_iter()
+            .collect(),
+    ));
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        engine: Some("duckdb".to_string()),
+        mode: Mode::Memory,
+        refresh_mode: Some(RefreshMode::Full),
+        ..Acceleration::default()
+    });
+    dataset
+}
+
+fn unaccelerated(from: &str, name: &str) -> Dataset {
+    let mut dataset = Dataset::new(from, name);
+    dataset.params = Some(Params::from_string_map(
+        vec![("file_format".to_string(), "csv".to_string())]
+            .into_iter()
+            .collect(),
+    ));
+    dataset
+}
+
+/// `trim` is an alias of `btrim` in `DataFusion`, so a `trim(...)` call reaches
+/// the unparser under the name `btrim` — which `DuckDB` has no function for.
+/// Before the dialect rewrote it, this query failed against the accelerator
+/// with `Catalog Error: Scalar Function with name btrim does not exist!`
+/// (regression test for #13794).
+#[tokio::test]
+async fn duckdb_accelerator_answers_btrim_and_agrees_with_local() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let dir = tempfile::tempdir()?;
+            let csv = dir.path().join("names.csv");
+            write_csv_source(&csv)?;
+            let from = format!("file://{}", csv.display());
+
+            let app = AppBuilder::new("duckdb_builtin_pushdown")
+                .with_dataset(duckdb_accelerated(&from, "accelerated"))
+                .with_dataset(unaccelerated(&from, "local"))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            load_runtime_datasets(&rt, LOAD_TIMEOUT).await?;
+
+            // The call must reach DuckDB for this to be testing anything: an
+            // accelerated query that evaluated the trims locally would pass
+            // even with the rewrite removed. `base_sql` is the SQL the
+            // federated scan sends, so it is the only part of the plan that
+            // says what DuckDB is asked to evaluate — the logical plan above it
+            // names the DataFusion function either way.
+            let plan = to_pretty_display(
+                &run_query(
+                    &rt,
+                    "EXPLAIN SELECT trim(name), btrim(name, 'xy') FROM accelerated",
+                )
+                .await?,
+            )?
+            .to_string();
+            let remote_sql: String = plan
+                .split("base_sql=")
+                .skip(1)
+                .map(|tail| tail.split('\n').next().unwrap_or_default().to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                remote_sql.contains("trim("),
+                "the trims must be pushed down to DuckDB, not evaluated locally; plan was:\n{plan}"
+            );
+            assert!(
+                !remote_sql.contains("btrim("),
+                "DuckDB has no `btrim`; the pushed-down SQL must call `trim`: {remote_sql}"
+            );
+
+            let query = "SELECT id, \
+                         trim(name) AS spaces, \
+                         btrim(name, 'xy') AS chars, \
+                         trim(btrim(name, 'xy')) AS both \
+                         FROM {table} ORDER BY id";
+
+            let accelerated = run_query(&rt, &query.replace("{table}", "accelerated")).await?;
+            let local = run_query(&rt, &query.replace("{table}", "local")).await?;
+
+            let expected = [
+                "+----+---------+-----------+-----------+",
+                "| id | spaces  | chars     | both      |",
+                "+----+---------+-----------+-----------+",
+                "| 1  | padded  |   padded  |    padded |",
+                "| 2  | hello   | hello     | hello     |",
+                "| 3  | x hello |  hello    | hello     |",
+                "| 4  |         |           |           |",
+                "+----+---------+-----------+-----------+",
+            ];
+            assert_batches_eq!(expected, &accelerated);
+
+            // The accelerator's answer is only right if it is the same answer
+            // DataFusion gives; a rename that is not semantics-preserving
+            // shows up as a divergence here, not as a query error.
+            assert_eq!(
+                to_pretty_display(&accelerated)?.to_string(),
+                to_pretty_display(&local)?.to_string(),
+                "DuckDB-accelerated trims must agree with local evaluation"
+            );
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
+++ b/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
@@ -50,6 +50,25 @@ fn write_csv_source(path: &Path) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// A row padded with Unicode `Zs` separators rather than ASCII spaces:
+/// `U+00A0`, then `U+2003`, then `U+3000`.
+///
+/// `btrim(str)` strips ASCII `U+0020` and nothing else, so all three rows come
+/// back unchanged. DuckDB's *one-argument* `trim` strips every `Zs`, which is
+/// why the dialect renders the one-argument call as `trim(str, ' ')` — without
+/// that, these rows would come back shortened and the accelerated dataset would
+/// silently disagree with the unaccelerated one instead of erroring.
+fn write_unicode_space_source(path: &Path) -> Result<(), anyhow::Error> {
+    std::fs::write(
+        path,
+        "id,name\n\
+         1,\"\u{a0}x\u{a0}\"\n\
+         2,\"\u{2003}x\u{2003}\"\n\
+         3,\"\u{3000}x\u{3000}\"\n",
+    )?;
+    Ok(())
+}
+
 fn duckdb_accelerated(from: &str, name: &str) -> Dataset {
     let mut dataset = Dataset::new(from, name);
     dataset.params = Some(Params::from_string_map(
@@ -142,14 +161,14 @@ async fn duckdb_accelerator_answers_btrim_and_agrees_with_local() -> Result<(), 
             let local = run_query(&rt, &query.replace("{table}", "local")).await?;
 
             let expected = [
-                "+----+---------+-----------+-----------+",
-                "| id | spaces  | chars     | both      |",
-                "+----+---------+-----------+-----------+",
-                "| 1  | padded  |   padded  |    padded |",
-                "| 2  | hello   | hello     | hello     |",
-                "| 3  | x hello |  hello    | hello     |",
-                "| 4  |         |           |           |",
-                "+----+---------+-----------+-----------+",
+                "+----+-----------+------------+--------+",
+                "| id | spaces    | chars      | both   |",
+                "+----+-----------+------------+--------+",
+                "| 1  | padded    |   padded   | padded |",
+                "| 2  | xyhelloyx | hello      | hello  |",
+                "| 3  | x hello x |  hello     | hello  |",
+                "| 4  |           |            |        |",
+                "+----+-----------+------------+--------+",
             ];
             assert_batches_eq!(expected, &accelerated);
 
@@ -160,6 +179,63 @@ async fn duckdb_accelerator_answers_btrim_and_agrees_with_local() -> Result<(), 
                 to_pretty_display(&accelerated)?.to_string(),
                 to_pretty_display(&local)?.to_string(),
                 "DuckDB-accelerated trims must agree with local evaluation"
+            );
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}
+
+/// `btrim(str)` strips ASCII `U+0020` only, so a `Zs`-padded string is returned
+/// unchanged. DuckDB's one-argument `trim` strips every `Zs` instead, which
+/// would make the accelerated dataset answer differently from the
+/// unaccelerated one — a silently wrong result rather than the loud
+/// unknown-function error of #13794. Measured by length, so the comparison does
+/// not depend on how the separators render.
+#[tokio::test]
+async fn duckdb_accelerated_btrim_leaves_unicode_separators_alone() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let dir = tempfile::tempdir()?;
+            let csv = dir.path().join("unicode_spaces.csv");
+            write_unicode_space_source(&csv)?;
+            let from = format!("file://{}", csv.display());
+
+            let app = AppBuilder::new("duckdb_builtin_pushdown_unicode")
+                .with_dataset(duckdb_accelerated(&from, "accelerated"))
+                .with_dataset(unaccelerated(&from, "local"))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            load_runtime_datasets(&rt, LOAD_TIMEOUT).await?;
+
+            // Every input is separator + "x" + separator, so `btrim` leaves all
+            // three characters in place. A `trim` that stripped the separators
+            // would report 1.
+            let query = "SELECT id, character_length(trim(name)) AS len \
+                         FROM {table} ORDER BY id";
+            let accelerated = run_query(&rt, &query.replace("{table}", "accelerated")).await?;
+            let local = run_query(&rt, &query.replace("{table}", "local")).await?;
+
+            let expected = [
+                "+----+-----+",
+                "| id | len |",
+                "+----+-----+",
+                "| 1  | 3   |",
+                "| 2  | 3   |",
+                "| 3  | 3   |",
+                "+----+-----+",
+            ];
+            assert_batches_eq!(expected, &accelerated);
+            assert_eq!(
+                to_pretty_display(&accelerated)?.to_string(),
+                to_pretty_display(&local)?.to_string(),
+                "a Zs-padded string must trim identically accelerated and local"
             );
 
             rt.shutdown().await;

--- a/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
+++ b/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
@@ -54,7 +54,7 @@ fn write_csv_source(path: &Path) -> Result<(), anyhow::Error> {
 /// `U+00A0`, then `U+2003`, then `U+3000`.
 ///
 /// `btrim(str)` strips ASCII `U+0020` and nothing else, so all three rows come
-/// back unchanged. DuckDB's *one-argument* `trim` strips every `Zs`, which is
+/// back unchanged. `DuckDB`'s *one-argument* `trim` strips every `Zs`, which is
 /// why the dialect renders the one-argument call as `trim(str, ' ')` — without
 /// that, these rows would come back shortened and the accelerated dataset would
 /// silently disagree with the unaccelerated one instead of erroring.
@@ -188,7 +188,7 @@ async fn duckdb_accelerator_answers_btrim_and_agrees_with_local() -> Result<(), 
 }
 
 /// `btrim(str)` strips ASCII `U+0020` only, so a `Zs`-padded string is returned
-/// unchanged. DuckDB's one-argument `trim` strips every `Zs` instead, which
+/// unchanged. `DuckDB`'s one-argument `trim` strips every `Zs` instead, which
 /// would make the accelerated dataset answer differently from the
 /// unaccelerated one — a silently wrong result rather than the loud
 /// unknown-function error of #13794. Measured by length, so the comparison does

--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -44,6 +44,8 @@ mod checkpoint_turso;
 #[cfg(feature = "duckdb")]
 mod cron;
 #[cfg(feature = "duckdb")]
+mod duckdb_builtin_pushdown;
+#[cfg(feature = "duckdb")]
 mod file_create_duckdb;
 #[cfg(feature = "duckdb")]
 mod file_swap_duckdb;


### PR DESCRIPTION
## Summary

`trim` is not a function in `DataFusion` — it is an **alias** of `btrim`, whose own
`ScalarUDFImpl::name()` returns `"btrim"`. The unparser writes a call under the function's own
name, so every `trim(x)` a user types left Spice as `btrim(x)` in the SQL sent to the backend.
DuckDB has no function of that name, so `trim(...)` over a DuckDB-accelerated dataset — or the
DuckDB and DuckLake connectors, which share the same unparser dialect — failed outright.

The DuckDB dialect already rewrote the Spice UDFs it can (`cosine_distance` →
`array_cosine_distance`, `rand` → `random()`) and the whole regex family, but it had no place at
all for a *`DataFusion` built-in* DuckDB spells differently. This adds that place and puts
`btrim` in it.

## Changes

- `dialect::duckdb::btrim_to_trim` renders `btrim` as DuckDB's `trim`.
  - **The two-argument form is a plain rename.** Both engines strip any character of the given
    set from both ends.
  - **The one-argument form is not**, and this is the whole subtlety. `btrim(str)` strips ASCII
    `U+0020` and nothing else — `general_trim` calls `trim_ascii_char(s, b' ')` — while DuckDB's
    one-argument `trim(str)` strips every Unicode `Zs` separator. A bare rename would have turned
    a remote error into a *silently different answer*, which is the worse failure, so the
    one-argument call is rendered `trim(str, ' ')`. That puts DuckDB on its character-set path,
    where it strips exactly the characters given.
  - An arity `btrim`'s own signature cannot produce returns a plan error rather than `Ok(None)`,
    which would hand `btrim` straight back to DuckDB.
- `dialect::duckdb_builtin_scalar_overrides()` is a second override table, for `DataFusion`
  built-ins. It is deliberately **not** folded into `duckdb_native_function_names()`: that list is
  the federation deny-list's carve-out, and a built-in federates unless it is *denied*, so a
  carve-out entry would do nothing — what a built-in needs is the handler. This is the same split
  the BigQuery dialect already makes with `BUILTIN_SCALAR_OVERRIDES`, and
  `no_builtin_override_is_in_the_deny_list_carve_out` now enforces it for both tables instead of
  only BigQuery's.

## Test plan

### Reproduced on `trunk` (`f8d83e39f0`)

A local CSV behind a `duckdb` accelerator plus an unaccelerated twin over the same file, so local
evaluation is visible side by side:

```
$ SELECT trim('123') FROM t_duckdb LIMIT 1
Execution error: Failed to execute query.
Catalog Error: Scalar Function with name btrim does not exist!
Did you mean "trim"?

LINE 1: WITH fetch_schema AS ( SELECT btrim('123') FROM "t_duckdb" LIMIT 1) SELECT * FROM fetch_s...
                                      ^
$ SELECT id, trim(name) FROM t_duckdb ORDER BY id
Execution error: … btrim("t_duckdb"."name") …
$ SELECT id, btrim(name,'x') FROM t_duckdb ORDER BY id
Execution error: … btrim("t_duckdb"."name", 'x') …

$ SELECT id, trim(name) FROM t_local ORDER BY id            # the unaccelerated twin
[{"id":1,"btrim(t_local.name)":"padded"},{"id":2,"btrim(t_local.name)":"xxhelloxx"},{"id":3,"btrim(t_local.name)":null}]
```

An aggregate shape fails identically, including with `optimizer_duckdb_aggregate_pushdown:
enabled`:

```
$ SELECT max(trim(name)) FROM t_duckdb_aggpush
Execution error: … base_sql=SELECT max(btrim("t_duckdb_aggpush"."name")) …
$ SELECT count(*) FROM t_duckdb_aggpush GROUP BY trim(name)
Execution error: … GROUP BY btrim("t_duckdb_aggpush"."name") …
```

### On this branch

```
$ SELECT trim('123') FROM t_duckdb LIMIT 1
[{"btrim(Utf8(\"123\"))":"123"}]
$ SELECT max(trim(name)) FROM t_duckdb_aggpush
[{"max(btrim(t_duckdb_aggpush.name))":"xxhelloxx"}]
$ SELECT trim(name), count(*) FROM t_duckdb_aggpush GROUP BY trim(name)     # returns rows

$ EXPLAIN SELECT trim(name) FROM t_duckdb
physical_plan : … VirtualExecutionPlan name=duckdb … base_sql=SELECT trim("t_duckdb"."name", ' ') FROM "t_duckdb"
```

### The one-argument form, measured byte-for-byte

Same eight rows, accelerated and unaccelerated, `trim(name)` hex-encoded. A bare `trim(str)`
rename passes every ASCII case and silently diverges on Unicode separators:

| id | input | bare `trim(str)` — accel / local | `trim(str, ' ')` — accel / local |
|---|---|---|---|
| 4 | `U+00A0 x U+00A0` | `78` / `c2a078c2a0` ✗ | `c2a078c2a0` / `c2a078c2a0` ✓ |
| 5 | `U+2003 x U+2003` | `78` / `e2808378e28083` ✗ | `e2808378e28083` / same ✓ |
| 6 | `U+3000 x U+3000` | `78` / `e3808078e38080` ✗ | `e3808078e38080` / same ✓ |
| 7 | `U+00A0 ␠x␠ U+00A0` | `78` / `c2a0207820c2a0` ✗ | `c2a0207820c2a0` / same ✓ |
| 8 | `\tx\n` | agrees (tab/LF are not `Zs`) | agrees ✓ |

### Nothing else changed behaviour

A 39-expression battery — every expression run against both the accelerated and the unaccelerated
dataset and the two results compared — went from 11 agreeing / 28 diverging on `trunk` to 16 / 23,
and diffing the label sets shows the only rows that moved are the five `btrim` shapes:

```
< DIFF   btrim('  hi  ')        > SAME   btrim('  hi  ')       [{"v":"hi"}]
< DIFF   btrim('xxhixx', 'x')   > SAME   btrim('xxhixx', 'x')  [{"v":"hi"}]
< DIFF   trim('  hi  ')         > SAME   trim('  hi  ')        [{"v":"hi"}]
< DIFF   btrim(name)            > SAME   btrim(name)           [{"v":"padded"}]
< DIFF   btrim(name, 'x')       > SAME   btrim(name, 'x')      [{"v":"  padded  "}]
```

### Tests added, and neutered to prove they bite

- `accelerator-duckdb`: `duckdb_trim_rewrite_agrees_with_datafusion_btrim` evaluates the *same*
  `btrim` expression twice — through a real in-memory DuckDB using the dialect's unparsed SQL, and
  through `DataFusion` — and asserts they agree, over 18 cases: spaces both sides, a character
  set, both together, an empty trim set, a string that trims away entirely, multi-byte
  characters, tab/newline, and the `Zs` separators above.
- `runtime-datafusion`: `btrim_unparses_to_duckdb_trim` (both arities, pinning
  `trim("t"."name", ' ')`), `duckdb_dialect_installs_the_btrim_override` (whole-expression
  unparse, so a handler written but never installed fails),
  `btrim_with_an_impossible_arity_is_an_error_not_a_passthrough`, and the extended
  `no_builtin_override_is_in_the_deny_list_carve_out`.
- `runtime` integration: `duckdb_accelerator_answers_btrim_and_agrees_with_local` asserts the
  pushed-down `base_sql` calls `trim` and not `btrim`, then compares accelerated rows to
  unaccelerated rows; `duckdb_accelerated_btrim_leaves_unicode_separators_alone` loads
  `Zs`-padded rows and asserts `character_length(trim(name))` is 3 on both datasets (by length,
  so it does not depend on how separators render).

Two neuters, both caught:

| neuter | caught by |
|---|---|
| drop `.chain(duckdb_builtin_scalar_overrides())` — handler written, never installed | `DuckDB has no 'btrim'; the dialect must emit 'trim', got btrim('  padded  ')`, and `duckdb_dialect_installs_the_btrim_override` |
| rename to `trim` but forward only `args[..1]` — valid SQL, wrong answer | the value comparison: `left: Some("xyhelloyx")`, `right: Some("hello")` |

### Gate

- `make lint`
- `make test`
- `cargo test -p runtime --test integration --features postgres,mysql,delta_lake,duckdb,sqlite,turso duckdb_` — 29 passed, both new tests among them. The 10 failures in that filter are environmental on this host and unrelated to the diff: two iceberg tests want `AWS_ICEBERG_ACCOUNT_ID`, and the other eight call `start_postgres_docker_container` / the MySQL equivalent for their *source* and hit `Socket not found: /var/run/docker.sock`.

## Review gate

- Adversarial review: `codex` — job `review-mtk42fgp-gj6gv9` — ran twice, because the first pass changed the approach. Pass 1 (job `review-mtk1rrhv-0jwydu`) returned 2 findings: a `[high]` on the one-argument Unicode-space divergence, which was **right** — the first version of this fix was wrong and the second commit is the correction — and a `[medium]` on the aggregate-pushdown rewriter. Pass 2 on the corrected diff cleared the `[high]` and repeated the `[medium]`. That one is filed as #13819 rather than fixed here: both passes demonstrated only the premise (that `btrim(v)` fails in DuckDB while `trim(v, ' ')` works), and running its own example query with `optimizer_duckdb_aggregate_pushdown: enabled` returns correct rows with `base_sql=… GROUP BY trim("t_duckdb_aggpush"."name", ' ')` and no `DuckDBAggregatePushdownMarkerExec` in the plan — the federation optimizer collapses the aggregate first. The audit it asked for is done and on the issue: `aggregate_pushdown.rs:233` is the only bare `DuckDBDialect::new()` in production code, the rest being `#[cfg(test)]` helpers.
- `/security-review`: no findings, re-run on the corrected diff
- `/simplify`: applied — the DuckDB carve-out drift guard moved into the existing `no_builtin_override_is_in_the_deny_list_carve_out` beside its BigQuery twin, derived from the override table so a future entry is covered, rather than a second test hardcoding `"btrim"`; light checks re-run green

## Scope

This fixes the reported instance. The wider gap — `DataFusion` built-ins DuckDB has no function
for at all — is already tracked and assigned as #10583, and the same run confirms its list:
measured against a live DuckDB accelerator, `arrow_typeof`, `date_bin`, `digest`, `find_in_set`,
`from_unixtime`, `get_field`/`struct`, `initcap`, `iszero`, `nanvl`, `nvl`, `nvl2`, `overlay`,
`regexp_instr`, `signum`, `substr_index`, `to_char`, `to_date`, `to_local_time`, `to_unixtime` and
`to_timestamp(<string>)` all fail the same way. Each needs its own decision — rewrite where a
faithful DuckDB equivalent exists, deny so the call evaluates locally otherwise — and they belong
to that issue.

Two nearby cases are deliberately *not* renamed:

- `struct` → DuckDB's `row`: the only other `DataFusion` built-in whose primary name DuckDB lacks
  while an alias it has exists. `struct(1,2)` is `{c0: 1, c1: 2}` locally and `row(1,2)` does not
  name its fields that way, so the rewrite would change the result's schema.
- `to_hex`: DuckDB *has* `to_hex`, and it answers `FF` where `DataFusion` answers `ff` — the one
  case in the whole sweep that returns a different result instead of an error. Filed as #13818.

Refs #10583
Fixes #13794