### PR TITLE
feat(caching): bound a caching accelerator by size, count and entry lifetime (closes #13525) [release/2.2 backport]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17249,6 +17249,7 @@ dependencies = [
  "arrow_tools",
  "async-trait",
  "aws-sdk-credential-bridge",
+ "byte-unit",
  "bytes",
  "chrono",
  "criterion 0.7.0",

--- a/crates/runtime-acceleration/Cargo.toml
+++ b/crates/runtime-acceleration/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+byte-unit.workspace = true
 app = { path = "../app" }
 arrow.workspace = true
 datafusion-table-providers.workspace = true

--- a/crates/runtime-acceleration/src/acceleration.rs
+++ b/crates/runtime-acceleration/src/acceleration.rs
@@ -392,6 +392,14 @@ pub struct Acceleration {
 
     pub caching_stale_if_error: StaleIfError,
 
+    /// Byte budget for a `refresh_mode: caching` accelerator, from
+    /// `caching_max_size`. `None` leaves the cache bounded only by its TTLs.
+    pub caching_max_size: Option<u64>,
+
+    /// Row budget for a `refresh_mode: caching` accelerator, from
+    /// `caching_max_items`. `None` leaves the cache bounded only by its TTLs.
+    pub caching_max_items: Option<u64>,
+
     pub refresh_cron: Option<Arc<str>>,
 
     pub refresh_sql: Option<String>,
@@ -807,6 +815,8 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
         let caching_stale_while_revalidate_ttl =
             parse_caching_stale_while_revalidate_ttl(&mut params)?;
         let caching_stale_if_error = parse_caching_stale_if_error(&mut params)?;
+        let caching_max_size = parse_caching_max_size(&mut params)?;
+        let caching_max_items = parse_caching_max_items(&mut params)?;
 
         let refresh_check_interval = try_parse_duration(
             "refresh_check_interval",
@@ -831,6 +841,8 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             caching_ttl,
             caching_stale_while_revalidate_ttl,
             caching_stale_if_error,
+            caching_max_size,
+            caching_max_items,
             refresh_cron,
             refresh_sql: acceleration.refresh_sql,
             refresh_data_window: acceleration.refresh_data_window,
@@ -883,6 +895,8 @@ impl Default for Acceleration {
             caching_ttl: None,
             caching_stale_while_revalidate_ttl: None,
             caching_stale_if_error: StaleIfError::default(),
+            caching_max_size: None,
+            caching_max_items: None,
             refresh_cron: None,
             refresh_sql: None,
             refresh_data_window: None,
@@ -938,9 +952,99 @@ fn parse_is_query_federation_disabled(params: &mut Option<Params>) -> Result<boo
     Ok(false)
 }
 
-/// Parse `caching_ttl` duration from params for caching mode.
+/// Parse the caching-mode entry TTL, accepted under either of its two names.
+///
+/// `caching_item_ttl` spells the suffix the runtime's other caches use
+/// (`item_ttl` on the SQL-results, search-results and embeddings caches);
+/// `caching_ttl` is the name this parameter shipped under. Both are read so
+/// neither spelling is silently ignored, and setting both to different values
+/// is an error rather than a coin flip.
 fn parse_caching_ttl(params: &mut Option<Params>) -> Result<Option<Duration>, ParseError> {
-    parse_duration_param(params, "caching_ttl")
+    // Both are removed unconditionally: leaving one behind would let it read
+    // as an unrecognised parameter later.
+    let ttl = parse_duration_param(params, "caching_ttl")?;
+    let item_ttl = parse_duration_param(params, "caching_item_ttl")?;
+
+    match (ttl, item_ttl) {
+        (Some(ttl), Some(item_ttl)) if ttl != item_ttl => {
+            Err(ParseError::InvalidAccelerationConfiguration {
+                detail: format!(
+                    "Conflicting cache TTLs: 'caching_ttl' is {ttl:?} but 'caching_item_ttl' is {item_ttl:?}. They name the same setting — set only one."
+                ),
+            })
+        }
+        (Some(ttl), _) => Ok(Some(ttl)),
+        (None, item_ttl) => Ok(item_ttl),
+    }
+}
+
+/// Parse `caching_max_size`, the byte budget a caching accelerator's stored
+/// rows may occupy, e.g. `512MiB`.
+fn parse_caching_max_size(params: &mut Option<Params>) -> Result<Option<u64>, ParseError> {
+    let Some(params) = params else {
+        return Ok(None);
+    };
+    let Some(value) = params.data.remove("caching_max_size") else {
+        return Ok(None);
+    };
+    match &value {
+        // A plain YAML integer is a byte count, so `caching_max_size: 1048576`
+        // means the same as `'1048576'` rather than being rejected.
+        spicepod::param::ParamValue::Int(n) => {
+            u64::try_from(*n)
+                .map(Some)
+                .map_err(|_| ParseError::InvalidAccelerationConfiguration {
+                    detail: format!(
+                        "Invalid 'caching_max_size' value: {n}. Expected a byte size such as '256MiB' or '1GB'."
+                    ),
+                })
+        }
+        spicepod::param::ParamValue::String(s) => {
+            // Refuse an unparseable budget rather than falling back to
+            // unbounded: this parameter is the bound, and a silent default
+            // would leave an operator believing a limit they set is in force.
+            let bytes = byte_unit::Byte::parse_str(s, true).map_err(|e| {
+                ParseError::InvalidAccelerationConfiguration {
+                    detail: format!(
+                        "Invalid 'caching_max_size' value: '{s}' ({e}). Expected a byte size such as '256MiB' or '1GB'."
+                    ),
+                }
+            })?;
+            Ok(Some(bytes.as_u64()))
+        }
+        _ => Err(ParseError::InvalidAccelerationConfiguration {
+            detail: format!(
+                "Invalid 'caching_max_size' param value: {value:?}. Expected a byte size such as '256MiB' or '1GB'."
+            ),
+        }),
+    }
+}
+
+/// Parse `caching_max_items`, the number of rows a caching accelerator may
+/// keep.
+fn parse_caching_max_items(params: &mut Option<Params>) -> Result<Option<u64>, ParseError> {
+    let Some(params) = params else {
+        return Ok(None);
+    };
+    let Some(value) = params.data.remove("caching_max_items") else {
+        return Ok(None);
+    };
+    let detail = || {
+        format!(
+            "Invalid 'caching_max_items' param value: {value:?}. Expected a whole number of rows, such as '10000'."
+        )
+    };
+    match &value {
+        spicepod::param::ParamValue::String(s) => s
+            .trim()
+            .parse::<u64>()
+            .map(Some)
+            .map_err(|_| ParseError::InvalidAccelerationConfiguration { detail: detail() }),
+        spicepod::param::ParamValue::Int(n) => u64::try_from(*n)
+            .map(Some)
+            .map_err(|_| ParseError::InvalidAccelerationConfiguration { detail: detail() }),
+        _ => Err(ParseError::InvalidAccelerationConfiguration { detail: detail() }),
+    }
 }
 
 /// Parse `caching_stale_while_revalidate_ttl` duration from params for caching mode.
@@ -1009,6 +1113,7 @@ fn parse_duration_param(
 mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema};
+    use spicepod::param::ParamValue;
     use std::sync::Arc;
 
     #[test]
@@ -1070,6 +1175,122 @@ mod tests {
         // Test missing parameter (default)
         let result = parse_caching_stale_if_error(&mut None).expect("to parse");
         assert_eq!(result, StaleIfError::Disabled);
+    }
+
+    #[test]
+    fn caching_max_size_accepts_byte_sizes_and_refuses_anything_else() {
+        for (input, expected) in [
+            ("1024", 1024_u64),
+            ("256MiB", 256 * 1024 * 1024),
+            ("1GB", 1_000_000_000),
+        ] {
+            let params = Params::from_string_map(HashMap::from([(
+                "caching_max_size".to_string(),
+                input.to_string(),
+            )]));
+            let parsed = parse_caching_max_size(&mut Some(params))
+                .unwrap_or_else(|e| panic!("'{input}' should parse: {e}"));
+            assert_eq!(parsed, Some(expected), "for '{input}'");
+        }
+
+        // An unparseable budget must fail the dataset rather than silently
+        // leaving the cache unbounded — the parameter *is* the bound.
+        let params = Params::from_string_map(HashMap::from([(
+            "caching_max_size".to_string(),
+            "lots".to_string(),
+        )]));
+        let err = parse_caching_max_size(&mut Some(params)).expect_err("should error");
+        assert!(
+            err.to_string().contains("caching_max_size"),
+            "error must name the parameter: {err}"
+        );
+
+        // A YAML integer is a byte count, not a type error.
+        let mut params = Params::from_string_map(HashMap::new());
+        params
+            .data
+            .insert("caching_max_size".to_string(), ParamValue::Int(1_048_576));
+        assert_eq!(
+            parse_caching_max_size(&mut Some(params)).expect("to parse"),
+            Some(1_048_576)
+        );
+
+        assert_eq!(parse_caching_max_size(&mut None).expect("to parse"), None);
+    }
+
+    #[test]
+    fn caching_max_items_accepts_a_row_count_and_refuses_anything_else() {
+        let params = Params::from_string_map(HashMap::from([(
+            "caching_max_items".to_string(),
+            "10000".to_string(),
+        )]));
+        assert_eq!(
+            parse_caching_max_items(&mut Some(params)).expect("to parse"),
+            Some(10_000)
+        );
+
+        for invalid in ["-1", "1.5", "many", ""] {
+            let params = Params::from_string_map(HashMap::from([(
+                "caching_max_items".to_string(),
+                invalid.to_string(),
+            )]));
+            let err = parse_caching_max_items(&mut Some(params))
+                .err()
+                .unwrap_or_else(|| panic!("'{invalid}' must be refused, not silently ignored"));
+            assert!(
+                err.to_string().contains("caching_max_items"),
+                "error must name the parameter: {err}"
+            );
+        }
+
+        assert_eq!(parse_caching_max_items(&mut None).expect("to parse"), None);
+    }
+
+    #[test]
+    fn caching_item_ttl_is_accepted_as_the_entry_ttl() {
+        // `item_ttl` is the suffix the runtime's other caches use, so both
+        // spellings must reach the same setting rather than one being ignored.
+        let params = Params::from_string_map(HashMap::from([(
+            "caching_item_ttl".to_string(),
+            "45s".to_string(),
+        )]));
+        assert_eq!(
+            parse_caching_ttl(&mut Some(params)).expect("to parse"),
+            Some(Duration::from_secs(45))
+        );
+
+        let params = Params::from_string_map(HashMap::from([(
+            "caching_ttl".to_string(),
+            "45s".to_string(),
+        )]));
+        assert_eq!(
+            parse_caching_ttl(&mut Some(params)).expect("to parse"),
+            Some(Duration::from_secs(45))
+        );
+    }
+
+    #[test]
+    fn conflicting_ttl_spellings_are_an_error_not_a_coin_flip() {
+        let params = Params::from_string_map(HashMap::from([
+            ("caching_ttl".to_string(), "30s".to_string()),
+            ("caching_item_ttl".to_string(), "10m".to_string()),
+        ]));
+        let err = parse_caching_ttl(&mut Some(params)).expect_err("should error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("caching_ttl") && msg.contains("caching_item_ttl"),
+            "error must name both spellings: {msg}"
+        );
+
+        // Agreeing values are fine.
+        let params = Params::from_string_map(HashMap::from([
+            ("caching_ttl".to_string(), "30s".to_string()),
+            ("caching_item_ttl".to_string(), "30s".to_string()),
+        ]));
+        assert_eq!(
+            parse_caching_ttl(&mut Some(params)).expect("to parse"),
+            Some(Duration::from_secs(30))
+        );
     }
 
     #[test]

--- a/crates/runtime-acceleration/src/acceleration.rs
+++ b/crates/runtime-acceleration/src/acceleration.rs
@@ -393,11 +393,15 @@ pub struct Acceleration {
     pub caching_stale_if_error: StaleIfError,
 
     /// Byte budget for a `refresh_mode: caching` accelerator, from
-    /// `caching_max_size`. `None` leaves the cache bounded only by its TTLs.
+    /// `caching_max_size`. `None` is no byte budget: what remains is expiry by
+    /// `caching_ttl` — and with `caching_stale_if_error: enabled` not even that,
+    /// since expired entries are deliberately kept as fallback for a failing
+    /// origin, leaving nothing to bound the acceleration.
     pub caching_max_size: Option<u64>,
 
     /// Row budget for a `refresh_mode: caching` accelerator, from
-    /// `caching_max_items`. `None` leaves the cache bounded only by its TTLs.
+    /// `caching_max_items`. `None` is no row budget; see [`Self::caching_max_size`]
+    /// for what is left bounding the acceleration.
     pub caching_max_items: Option<u64>,
 
     pub refresh_cron: Option<Arc<str>>,

--- a/crates/runtime-acceleration/src/acceleration.rs
+++ b/crates/runtime-acceleration/src/acceleration.rs
@@ -397,6 +397,14 @@ pub struct Acceleration {
     /// `caching_ttl` — and with `caching_stale_if_error: enabled` not even that,
     /// since expired entries are deliberately kept as fallback for a failing
     /// origin, leaving nothing to bound the acceleration.
+    ///
+    /// The budget measures the payload each entry holds — its text and
+    /// fixed-width columns — not bytes on disk, which the engine's own indexes
+    /// and compression decide. Two things it does not charge for: a response's
+    /// header map, whose size no expression here can measure, and any other
+    /// column of a type that cannot be weighed, which is warned about by name at
+    /// load. An origin sending unusually large headers therefore holds bytes
+    /// outside this ceiling.
     pub caching_max_size: Option<u64>,
 
     /// Row budget for a `refresh_mode: caching` accelerator, from

--- a/crates/runtime-table/src/accelerated/caching.rs
+++ b/crates/runtime-table/src/accelerated/caching.rs
@@ -129,7 +129,10 @@ pub fn stamp_namespace_column(
     fields.push(Field::new(CACHE_NAMESPACE_COLUMN, DataType::Utf8, false));
 
     let mut columns: Vec<ArrayRef> = batch.columns().to_vec();
-    columns.push(Arc::new(StringArray::from(vec![namespace_id; batch.num_rows()])) as ArrayRef);
+    columns.push(Arc::new(StringArray::from_iter_values(std::iter::repeat_n(
+        namespace_id,
+        batch.num_rows(),
+    ))) as ArrayRef);
 
     let new_schema = Arc::new(Schema::new_with_metadata(fields, schema.metadata().clone()));
     RecordBatch::try_new(new_schema, columns).map_err(|e| {
@@ -466,47 +469,42 @@ async fn flush_cache_writes(
 
     let flush_start = std::time::Instant::now();
 
+    let queued = buffer.len();
+
     // One key, one write. Two requests for the same key in a single flush would
     // share one OR'd delete and then each append their batches, leaving the key
     // holding the response twice — and a duplicated source row is a wrong query
-    // result, not a housekeeping problem. Only the newest survives; the older
-    // one is a response this key no longer holds.
+    // result, not a housekeeping problem. Walking newest-first keeps the latest
+    // write for each key; an older one is a response that key no longer holds.
     //
     // The in-flight key set makes this unreachable from the two paths that
     // enqueue today. It is enforced here as well so the flush does not depend
     // on its callers for it.
-    let superseded: Vec<bool> = {
-        let mut seen: HashSet<&str> = HashSet::with_capacity(buffer.len());
-        let mut flags: Vec<bool> = buffer
-            .iter()
-            .rev()
-            .map(|req| !seen.insert(req.cache_key.as_str()))
-            .collect();
-        flags.reverse();
-        flags
-    };
-    if superseded.iter().any(|superseded| *superseded) {
-        let dropped = superseded.iter().filter(|s| **s).count();
+    let mut seen: HashSet<String> = HashSet::with_capacity(queued);
+    let mut requests: Vec<CacheWriteRequest> = buffer
+        .drain(..)
+        .rev()
+        .filter(|req| seen.insert(req.cache_key.clone()))
+        .collect();
+    requests.reverse();
+
+    if requests.len() < queued {
         tracing::debug!(
-            "Dropping {dropped} superseded cache write(s) for dataset={dataset_name}: a later write for the same key is in this flush"
+            "Dropping {superseded} superseded cache write(s) for dataset={dataset_name}: a later write for the same key is in this flush",
+            superseded = queued - requests.len()
         );
-        let mut index = 0;
-        buffer.retain(|_| {
-            let keep = !superseded[index];
-            index += 1;
-            keep
-        });
     }
 
-    let request_count = buffer.len();
-    let total_rows: usize = buffer
+    let request_count = requests.len();
+    let total_rows: usize = requests
         .iter()
         .flat_map(|r| r.batches.iter())
         .map(RecordBatch::num_rows)
         .sum();
 
-    // Collect cache keys to remove after flushing
-    let cache_keys: Vec<String> = buffer.iter().map(|r| r.cache_key.clone()).collect();
+    // Every key claimed for this flush, including the superseded writes, whose
+    // claim is the same string and is released with it.
+    let cache_keys = seen;
 
     tracing::trace!(
         "Flushing {request_count} cache write requests ({total_rows} total rows) for dataset={dataset_name}"
@@ -526,7 +524,7 @@ async fn flush_cache_writes(
     let mut all_batches: Vec<RecordBatch> = Vec::new();
     let mut replace_filters: Vec<Vec<Expr>> = Vec::new();
 
-    for req in buffer.drain(..) {
+    for req in requests {
         let ns_id: &str = &req.namespace_id;
         let batches = match req
             .batches
@@ -1780,39 +1778,36 @@ impl CacheRefreshHelper {
                     return Box::pin(RecordBatchStreamAdapter::new(batch_schema, batch_stream));
                 }
 
-                // Clone batches for propagation to children.
-                // RecordBatch::clone() is cheap - only clones Arc pointers, not the underlying data.
-                let batches_for_propagate = if batches_cacheable {
-                    batches.clone()
-                } else {
-                    Vec::new()
-                };
-                let filters_clone: Vec<Expr> = filters.to_vec();
                 let cache_key =
                     compute_cache_key_from_filters_and_namespace(filters, namespace.storage_id());
 
-                // Claim the key before enqueuing. Without this, two readers
-                // that miss the same key concurrently each append the response
-                // and the key ends up holding it twice — which queries return
-                // as duplicated source rows.
+                // Claiming the key is what stops two readers that miss it
+                // concurrently from each appending the response, leaving the key
+                // holding it twice — which queries return as duplicated source
+                // rows.
                 //
                 // The claim is released by the flush that writes it, so it is
                 // taken only on the path that reaches a flush. Claiming for a
                 // response that is never enqueued would hold the key for the
                 // life of the process and refuse every later write and
                 // revalidation for it.
-                let claimed = batches_cacheable
-                    && in_flight_revalidations
-                        .lock()
-                        .await
-                        .insert(cache_key.clone());
-                if batches_cacheable && !claimed {
+                if !batches_cacheable {
+                    tracing::debug!(
+                        "Fetch returned transient HTTP error responses, skipping cache write for dataset={dataset_name}"
+                    );
+                } else if !in_flight_revalidations
+                    .lock()
+                    .await
+                    .insert(cache_key.clone())
+                {
                     tracing::debug!(
                         "A write for this key is already pending for dataset={dataset_name}; not enqueuing a second copy"
                     );
-                }
-
-                if claimed {
+                } else {
+                    // `RecordBatch::clone` is cheap: it clones Arc pointers,
+                    // not the underlying data.
+                    let batches_for_propagate = batches.clone();
+                    let filters_clone: Vec<Expr> = filters.to_vec();
                     let cache_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
 
                     // Send write request to batched consumer. The flush
@@ -1859,10 +1854,6 @@ impl CacheRefreshHelper {
 
                     tracing::debug!(
                         "Background cache update performed for dataset={dataset_name}, {cache_rows} rows"
-                    );
-                } else if !batches_cacheable {
-                    tracing::debug!(
-                        "Fetch returned transient HTTP error responses, skipping cache write for dataset={dataset_name}"
                     );
                 }
 

--- a/crates/runtime-table/src/accelerated/caching.rs
+++ b/crates/runtime-table/src/accelerated/caching.rs
@@ -58,6 +58,24 @@ pub type InFlightRevalidations = Arc<Mutex<HashSet<String>>>;
 
 pub const CACHE_REFRESHED_AT_COLUMN: &str = "_fetched_at";
 
+/// How long a cached entry stays fresh when the dataset sets no `caching_ttl`.
+///
+/// Read by both the scan that decides whether a row may be served and the sweep
+/// that decides whether it may be kept. One constant, because a sweep with a
+/// shorter default than the scan would delete rows the scan still calls fresh.
+pub const DEFAULT_CACHING_TTL: Duration = Duration::from_secs(30);
+
+/// The TTL a caching scan actually applies, filling in [`DEFAULT_CACHING_TTL`]
+/// for a dataset that configured none.
+///
+/// Named rather than inlined so the eviction sweep's fallback can be asserted
+/// against the same value the read path uses: a sweep with the shorter of the
+/// two would delete rows the scan still calls fresh.
+#[must_use]
+pub fn effective_max_age(configured: Option<Duration>) -> Duration {
+    configured.unwrap_or(DEFAULT_CACHING_TTL)
+}
+
 /// Reserved column name added to caching-mode accelerator storage to scope
 /// cached rows by [`runtime_request_context::CacheNamespace`]. The column is
 /// hidden from the user-facing schema and may not be referenced in user
@@ -78,37 +96,43 @@ pub fn is_reserved_caching_column(name: &str) -> bool {
 }
 
 /// Returns a copy of `batch` with [`CACHE_NAMESPACE_COLUMN`] appended,
-/// populated with `namespace_id` for every row. Idempotent: if the column
-/// is already present the batch is returned unchanged.
+/// populated with `namespace_id` for every row. Idempotent: if the column is
+/// already present the batch is returned unchanged, and if `storage_schema`
+/// does not declare the column the batch is returned unchanged too — a
+/// unit-test mock with an unextended schema opts out that way.
 ///
-/// Called immediately before a [`CacheWriteRequest`] is enqueued so that
-/// every persisted row carries its originating namespace tag, which is
-/// what `__spice_cache_namespace = $current_ns` filtering keys off of on
-/// read.
+/// Called immediately before a [`CacheWriteRequest`]'s batches are handed to
+/// the accelerator, so that every persisted row carries the tag the read path
+/// filters on (`__spice_cache_namespace = $current_ns`).
 ///
 /// # Errors
 ///
-/// Returns a `DataFusionError` if the tagged column cannot be appended to the
-/// batch — the namespace array and the batch disagree on row count, or the
-/// resulting schema is rejected.
+/// Returns a `DataFusionError` if the stamped batch is rejected — the tag array
+/// and the batch disagree on row count, or the resulting schema is invalid.
 pub fn stamp_namespace_column(
     batch: RecordBatch,
+    storage_schema: &arrow::datatypes::Schema,
     namespace_id: &str,
 ) -> DataFusionResult<RecordBatch> {
-    use arrow::array::StringArray;
     use arrow::datatypes::{DataType, Field, Schema};
+
     let schema = batch.schema();
-    if schema.column_with_name(CACHE_NAMESPACE_COLUMN).is_some() {
+    if storage_schema
+        .column_with_name(CACHE_NAMESPACE_COLUMN)
+        .is_none()
+        || schema.column_with_name(CACHE_NAMESPACE_COLUMN).is_some()
+    {
         return Ok(batch);
     }
-    let n = batch.num_rows();
+
     let mut fields: Vec<Field> = schema.fields().iter().map(|f| (**f).clone()).collect();
     fields.push(Field::new(CACHE_NAMESPACE_COLUMN, DataType::Utf8, false));
+
+    let mut columns: Vec<ArrayRef> = batch.columns().to_vec();
+    columns.push(Arc::new(StringArray::from(vec![namespace_id; batch.num_rows()])) as ArrayRef);
+
     let new_schema = Arc::new(Schema::new_with_metadata(fields, schema.metadata().clone()));
-    let ns_array: ArrayRef = Arc::new(StringArray::from(vec![namespace_id; n]));
-    let mut cols: Vec<ArrayRef> = batch.columns().to_vec();
-    cols.push(ns_array);
-    RecordBatch::try_new(new_schema, cols).map_err(|e| {
+    RecordBatch::try_new(new_schema, columns).map_err(|e| {
         DataFusionError::Execution(format!("failed to stamp {CACHE_NAMESPACE_COLUMN}: {e}"))
     })
 }
@@ -167,6 +191,10 @@ pub fn extend_schema_with_cache_namespace(
     ))
 }
 
+/// The request columns that together identify one cache entry — the key a
+/// refresh is rebuilt from and the key eviction removes an entry by.
+pub const REQUEST_KEY_COLUMNS: [&str; 3] = ["request_path", "request_query", "request_body"];
+
 /// Maximum number of concurrent refresh requests
 const MAX_CONCURRENT_REFRESHES: usize = 10;
 
@@ -188,8 +216,6 @@ pub struct CacheWriteRequest {
     pub batches: Vec<RecordBatch>,
     /// Filter expressions to identify the cache key (for upsert operations)
     pub filters: Vec<Expr>,
-    /// If true, this is an upsert (expired data exists), otherwise insert (new data)
-    pub is_upsert: bool,
     /// Cache key computed from filters, used to track in-flight writes
     pub cache_key: String,
     /// Stable storage id of the originating namespace (see
@@ -445,58 +471,62 @@ async fn flush_cache_writes(
         "Flushing {request_count} cache write requests ({total_rows} total rows) for dataset={dataset_name}"
     );
 
-    // Separate inserts from upserts. Stamp the namespace column on every
-    // batch and add a `__spice_cache_namespace = $ns_id` predicate to each
-    // upsert filter set so concurrent writers from different namespaces
-    // never overwrite each other's rows for the same logical key. We do
-    // this here (not at the send-site) so unit-test mocks with a non-
-    // extended schema can opt out by simply not adding the column.
-    let needs_namespace_stamp = accelerator
-        .schema()
+    // Separate inserts from upserts. Stamp the caching accelerator's reserved
+    // columns on every batch and add a `__spice_cache_namespace = $ns_id`
+    // predicate to each upsert filter set so concurrent writers from different
+    // namespaces never overwrite each other's rows for the same logical key.
+    // We do this here (not at the send-site) so unit-test mocks with a non-
+    // extended schema can opt out by simply not declaring the columns.
+    let storage_schema = accelerator.schema();
+    let needs_namespace_stamp = storage_schema
         .column_with_name(CACHE_NAMESPACE_COLUMN)
         .is_some();
 
-    let mut insert_batches: Vec<RecordBatch> = Vec::new();
-    let mut upsert_batches: Vec<RecordBatch> = Vec::new();
-    let mut upsert_filters: Vec<Vec<Expr>> = Vec::new();
+    let mut all_batches: Vec<RecordBatch> = Vec::new();
+    let mut replace_filters: Vec<Vec<Expr>> = Vec::new();
 
     for req in buffer.drain(..) {
-        let mut batches = req.batches;
+        let ns_id: &str = &req.namespace_id;
+        let batches = match req
+            .batches
+            .into_iter()
+            .map(|b| stamp_namespace_column(b, &storage_schema, ns_id))
+            .collect::<DataFusionResult<Vec<_>>>()
+        {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to stamp {CACHE_NAMESPACE_COLUMN} for dataset={dataset_name}: {e}; dropping write"
+                );
+                continue;
+            }
+        };
         let mut filters = req.filters;
         if needs_namespace_stamp {
-            let ns_id: &str = &req.namespace_id;
-            batches = match batches
-                .into_iter()
-                .map(|b| stamp_namespace_column(b, ns_id))
-                .collect::<DataFusionResult<Vec<_>>>()
-            {
-                Ok(b) => b,
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to stamp {CACHE_NAMESPACE_COLUMN} for dataset={dataset_name}: {e}; dropping write"
-                    );
-                    continue;
-                }
-            };
-            if req.is_upsert {
-                filters.push(namespace_filter_expr(ns_id));
-            }
+            filters.push(namespace_filter_expr(ns_id));
         }
-        if req.is_upsert {
-            upsert_batches.extend(batches);
-            upsert_filters.push(filters);
-        } else {
-            insert_batches.extend(batches);
+
+        all_batches.extend(batches);
+
+        // Every write replaces its key, whether or not the sender believed the
+        // key was already cached. A write raised as a fresh insert can still
+        // collide: replacing an entry is a delete followed by an append, and a
+        // reader scanning in between sees no rows, reads it as a miss, and
+        // enqueues its own insert for the same key. Appending that blindly
+        // would leave the key with two copies of the response, which queries
+        // then return as duplicated source rows. Deleting the key first makes
+        // the write idempotent, and for a genuinely new key the delete matches
+        // nothing.
+        //
+        // A write with no filters at all cannot be scoped to a replacement, so
+        // appending is all that is available for it.
+        if !filters.is_empty() {
+            replace_filters.push(filters);
         }
     }
 
-    let insert_rows: usize = insert_batches.iter().map(RecordBatch::num_rows).sum();
-    let upsert_rows: usize = upsert_batches.iter().map(RecordBatch::num_rows).sum();
-    let upsert_count = upsert_filters.len();
-
-    // Combine all batches for writing
-    let mut all_batches = insert_batches;
-    all_batches.extend(upsert_batches);
+    let write_rows: usize = all_batches.iter().map(RecordBatch::num_rows).sum();
+    let replace_count = replace_filters.len();
 
     let write_start = std::time::Instant::now();
 
@@ -515,18 +545,16 @@ async fn flush_cache_writes(
     } else if has_constraints {
         // Use native upsert via append - the accelerator's OnConflict::Upsert handles deduplication
         CacheRefreshHelper::append_to_accelerator(accelerator, dataset_name, all_batches).await
-    } else if !upsert_filters.is_empty() {
-        // No constraints - fall back to read-filter-write pattern for upserts
+    } else if replace_filters.is_empty() {
+        CacheRefreshHelper::insert_into_accelerator(accelerator, dataset_name, all_batches).await
+    } else {
         CacheRefreshHelper::batched_upsert_into_accelerator(
             accelerator,
             dataset_name,
-            &upsert_filters,
+            &replace_filters,
             all_batches,
         )
         .await
-    } else {
-        // No upserts needed - use insert path
-        CacheRefreshHelper::insert_into_accelerator(accelerator, dataset_name, all_batches).await
     };
 
     drop(lock_guard);
@@ -535,14 +563,14 @@ async fn flush_cache_writes(
     if let Err(e) = result {
         tracing::warn!("Failed to flush cache updates for dataset {dataset_name}: {e}");
         health.record_failure(&e);
-    } else if insert_rows > 0 || upsert_rows > 0 {
+    } else if write_rows > 0 {
         health.record_success();
 
         // Update last_updated_at for snapshots_creation_policy: on_change support
         super::AcceleratedTable::set_timestamp_to_now(last_updated_at);
 
         tracing::trace!(
-            "Cache write completed for dataset={dataset_name}: inserts={insert_rows} rows, upserts={upsert_count}, {upsert_rows} rows in {write_ms}ms"
+            "Cache write completed for dataset={dataset_name}: {write_rows} rows across {replace_count} keys in {write_ms}ms"
         );
     }
 
@@ -722,6 +750,45 @@ fn as_timestamp_nanosecond_array(array: &ArrayRef) -> DataFusionResult<ArrayRef>
     })
 }
 
+/// One cache entry found stale in the accelerator: the request to replay
+/// against the source, and the namespace its rows belong to.
+struct StaleCacheEntry {
+    filters: Vec<Expr>,
+    namespace: Option<String>,
+}
+
+/// What a revalidation learned about the source.
+///
+/// The distinction matters because a failing origin does not arrive as an
+/// error. Once the HTTP connector has exhausted its own `max_retries`, it
+/// surfaces the failure as a *successful* fetch whose rows carry a 429 or 5xx
+/// status — so a caller that only inspects `Result` sees "the source answered"
+/// and cannot tell that it answered with a failure. That is the dominant
+/// failure mode of the connectors caching mode accepts, and it is precisely
+/// when `caching_stale_if_error` is supposed to act.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevalidationOutcome {
+    /// The source answered, and its rows were queued to replace the entry.
+    Refreshed { rows: usize },
+    /// The source answered and had nothing to cache. The origin is healthy.
+    Empty,
+    /// The source could not be revalidated: it answered with a transient
+    /// failure after its own retries were exhausted. Nothing was written, and
+    /// whatever is cached is the best answer available.
+    OriginUnavailable,
+}
+
+impl RevalidationOutcome {
+    /// Rows queued for write; zero unless the entry was refreshed.
+    #[must_use]
+    pub fn rows(self) -> usize {
+        match self {
+            Self::Refreshed { rows } => rows,
+            Self::Empty | Self::OriginUnavailable => 0,
+        }
+    }
+}
+
 /// Helper functions for cache refresh operations
 pub struct CacheRefreshHelper;
 
@@ -774,27 +841,31 @@ impl CacheRefreshHelper {
         // Collect all stale rows from accelerator
         let stale_batches = datafusion::physical_plan::collect(plan, task_ctx).await?;
 
-        // Extract unique filter sets from stale rows
-        let filter_sets = Self::extract_unique_filter_sets(&stale_batches)?;
+        // Extract unique entries from stale rows
+        let stale_entries = Self::extract_unique_stale_entries(&stale_batches)?;
 
         let total_stale_rows: usize = stale_batches.iter().map(RecordBatch::num_rows).sum();
         tracing::debug!(
             "Found {total_stale_rows} stale rows ({} unique filter sets) to refresh for dataset {dataset_name}",
-            filter_sets.len()
+            stale_entries.len()
         );
 
-        if filter_sets.is_empty() {
+        if stale_entries.is_empty() {
             return Ok(0);
         }
 
         // Create futures for all refresh operations and run them with limited concurrency.
         // Each refresh fetches from the source and then upserts into the accelerator,
         // which preserves data for other cache entries (different request paths/queries).
-        let refresh_futures = filter_sets.into_iter().map(|row_filters| {
+        let refresh_futures = stale_entries.into_iter().map(|entry| {
             let federated = Arc::clone(&federated);
             let accelerator = Arc::clone(&accelerator);
             let dataset_name = dataset_name.to_string();
             let accelerator_write_mutex = Arc::clone(&accelerator_write_mutex);
+            let StaleCacheEntry {
+                filters: row_filters,
+                namespace,
+            } = entry;
 
             async move {
                 tracing::debug!(
@@ -812,12 +883,35 @@ impl CacheRefreshHelper {
 
                 let refreshed_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
 
+                // Source rows arrive with the connector's columns only, so they
+                // must be stamped with the caching accelerator's own before they
+                // can replace what is stored. Skipping this would write rows with
+                // no namespace and no expiry — the latter reading as "no deadline
+                // to hold this to", which the eviction sweep removes on its next
+                // pass, so a refresh would undo itself.
+                let namespace_id = namespace
+                    .as_deref()
+                    .unwrap_or_else(|| CacheNamespace::Public.storage_id());
+                let storage_schema = accelerator.schema();
+                let batches = batches
+                    .into_iter()
+                    .map(|batch| stamp_namespace_column(batch, &storage_schema, namespace_id))
+                    .collect::<DataFusionResult<Vec<_>>>()?;
+
+                // Scope the replacement to the namespace the stale rows came
+                // from, so refreshing one principal's copy does not delete
+                // another's.
+                let mut write_filters = row_filters.clone();
+                if namespace.is_some() {
+                    write_filters.push(namespace_filter_expr(namespace_id));
+                }
+
                 // Acquire the mutex to protect accelerator operations
                 let lock_guard = accelerator_write_mutex.lock().await;
 
                 // Upsert this specific cache entry - removes rows matching the filters
                 // and adds the new data, preserving other cache entries.
-                Self::upsert_into_accelerator(&accelerator, &dataset_name, &row_filters, batches)
+                Self::upsert_into_accelerator(&accelerator, &dataset_name, &write_filters, batches)
                     .await?;
 
                 drop(lock_guard); // Release the mutex
@@ -865,7 +959,7 @@ impl CacheRefreshHelper {
         namespace: CacheNamespace,
         batch_write_tx: CacheWriteSender,
         in_flight_revalidations: InFlightRevalidations,
-    ) -> DataFusionResult<usize> {
+    ) -> DataFusionResult<RevalidationOutcome> {
         let cache_key =
             compute_cache_key_from_filters_and_namespace(filters, namespace.storage_id());
 
@@ -880,19 +974,19 @@ impl CacheRefreshHelper {
         // Skip cache writes if the source response contains transient HTTP errors.
         if !cache::batches_cacheable(&batches) {
             tracing::debug!(
-                "No cacheable data for dataset={dataset_name} (source returned transient HTTP error responses)"
+                "Revalidation for dataset={dataset_name} found the origin failing (transient HTTP error response); keeping what is cached"
             );
             // Remove from in-flight since no data to write
             let mut in_flight = in_flight_revalidations.lock().await;
             in_flight.remove(&cache_key);
-            return Ok(0);
+            return Ok(RevalidationOutcome::OriginUnavailable);
         }
 
         if batches.is_empty() {
             tracing::debug!("No cacheable data for dataset={dataset_name} (source returned empty)");
             let mut in_flight = in_flight_revalidations.lock().await;
             in_flight.remove(&cache_key);
-            return Ok(0);
+            return Ok(RevalidationOutcome::Empty);
         }
 
         // Stamping and namespace-scoped upsert filters are applied by the
@@ -904,7 +998,6 @@ impl CacheRefreshHelper {
         let request = CacheWriteRequest {
             batches,
             filters: filters.to_vec(),
-            is_upsert: true,
             cache_key: cache_key.clone(),
             namespace_id: namespace.storage_id().into(),
         };
@@ -916,7 +1009,9 @@ impl CacheRefreshHelper {
 
         tracing::trace!("Queued refresh for dataset={dataset_name}, {refreshed_rows} rows");
 
-        Ok(refreshed_rows)
+        Ok(RevalidationOutcome::Refreshed {
+            rows: refreshed_rows,
+        })
     }
 
     /// Extract filter expressions from a row containing `request_path`, `request_query`, `request_body`
@@ -927,7 +1022,7 @@ impl CacheRefreshHelper {
         let schema = batch.schema();
         let mut filters = Vec::new();
 
-        let filter_columns = ["request_path", "request_query", "request_body"];
+        let filter_columns = REQUEST_KEY_COLUMNS;
 
         for column_name in filter_columns {
             if let Some((idx, _)) = schema.column_with_name(column_name) {
@@ -959,27 +1054,51 @@ impl CacheRefreshHelper {
         Ok(filters)
     }
 
-    /// Extract unique filter sets from batches, deduplicating rows with identical
-    /// `(request_path, request_query, request_body)` values.
+    /// Extract the unique cache entries represented by `batches`, deduplicating
+    /// rows with identical `(request_path, request_query, request_body)` and
+    /// namespace.
     ///
-    /// This is needed because HTTP connector JSON array responses are stored as multiple rows
-    /// with identical request parameters. Without deduplication, refreshing N rows from the
-    /// same JSON array would trigger N identical HTTP requests.
-    fn extract_unique_filter_sets(batches: &[RecordBatch]) -> DataFusionResult<Vec<Vec<Expr>>> {
+    /// Deduplication is needed because HTTP connector JSON array responses are
+    /// stored as multiple rows with identical request parameters. Without it,
+    /// refreshing N rows from the same JSON array would trigger N identical HTTP
+    /// requests.
+    ///
+    /// The namespace tag is carried beside the filters rather than folded into
+    /// them, because the filters are replayed against the *source* — a connector
+    /// has no `__spice_cache_namespace` column to match on — while the namespace
+    /// is needed to write the refreshed rows back into the same principal's scope
+    /// they came from. Deduplication keys on both, so two principals holding the
+    /// same request each get their own refresh.
+    fn extract_unique_stale_entries(
+        batches: &[RecordBatch],
+    ) -> DataFusionResult<Vec<StaleCacheEntry>> {
         let mut seen_filter_keys = std::collections::HashSet::new();
-        let mut filter_sets: Vec<Vec<Expr>> = Vec::new();
+        let mut entries: Vec<StaleCacheEntry> = Vec::new();
 
         for batch in batches {
+            let namespaces = batch
+                .schema()
+                .column_with_name(CACHE_NAMESPACE_COLUMN)
+                .and_then(|(idx, _)| batch.column(idx).as_any().downcast_ref::<StringArray>());
+
             for row_idx in 0..batch.num_rows() {
-                let row_filters = Self::extract_filters_from_row(batch, row_idx)?;
-                let cache_key = compute_cache_key_from_filters(&row_filters);
+                let filters = Self::extract_filters_from_row(batch, row_idx)?;
+                let namespace = namespaces
+                    .filter(|array| array.is_valid(row_idx))
+                    .map(|array| array.value(row_idx).to_string());
+                let cache_key = match &namespace {
+                    Some(namespace) => {
+                        compute_cache_key_from_filters_and_namespace(&filters, namespace)
+                    }
+                    None => compute_cache_key_from_filters(&filters),
+                };
                 if seen_filter_keys.insert(cache_key) {
-                    filter_sets.push(row_filters);
+                    entries.push(StaleCacheEntry { filters, namespace });
                 }
             }
         }
 
-        Ok(filter_sets)
+        Ok(entries)
     }
 
     /// Overwrite the data in the accelerator with the provided batches
@@ -1085,128 +1204,113 @@ impl CacheRefreshHelper {
             return Ok(());
         }
 
-        let ctx = SessionContext::new();
-        let state = ctx.state();
-        let new_rows: usize = new_batches.iter().map(RecordBatch::num_rows).sum();
-
-        tracing::debug!(
-            "insert_into_accelerator - reading existing data from accelerator for dataset={}",
-            dataset_name
-        );
-
-        // Scan all existing data from the accelerator
-        let plan = accelerator.scan(&state, None, &[], None).await?;
-        let task_ctx = Arc::new(TaskContext::default());
-        let existing_batches = datafusion::physical_plan::collect(plan, task_ctx).await?;
-
-        let existing_rows: usize = existing_batches.iter().map(RecordBatch::num_rows).sum();
-        tracing::debug!(
-            "insert_into_accelerator - found {} existing rows, adding {} new rows for dataset={}",
-            existing_rows,
-            new_rows,
-            dataset_name
-        );
-
-        // Combine existing data with new data
-        let mut combined_batches = existing_batches;
-        combined_batches.extend(new_batches);
-
-        // Overwrite the accelerator with the combined data
-        Self::overwrite_accelerator(Arc::clone(accelerator), dataset_name, combined_batches).await
+        // Nothing is being replaced, so there is nothing to read first: append
+        // the new rows and leave the rest of the table alone. Reading the whole
+        // table back only to write it out again made the cost of caching one
+        // response grow with everything already cached.
+        Self::append_to_accelerator(accelerator, dataset_name, new_batches).await
     }
 
-    /// Upsert data into the accelerator by removing rows matching the filters and inserting new data.
-    /// This is used when cached data exists but is expired.
+    /// Upsert data into the accelerator by removing rows matching the filters
+    /// and inserting new data. Used when cached data exists but is expired.
     ///
-    /// The process:
-    /// 1. Scan all data from the accelerator
-    /// 2. Filter out rows that match the provided filters (these are the expired rows to replace)
-    /// 3. Combine remaining rows with new data
-    /// 4. Overwrite the accelerator with the combined data
+    /// One cache entry is just the single-entry case of
+    /// [`Self::batched_upsert_into_accelerator`], so it defers to it rather
+    /// than keeping a second copy of the same delete-and-append and
+    /// read-filter-write logic.
     async fn upsert_into_accelerator(
         accelerator: &Arc<dyn TableProvider>,
         dataset_name: &str,
         filters: &[Expr],
         new_batches: Vec<RecordBatch>,
     ) -> DataFusionResult<()> {
-        if new_batches.is_empty() {
-            tracing::debug!(
-                "upsert_into_accelerator called with empty batches for dataset={dataset_name}"
-            );
-            return Ok(());
+        Self::batched_upsert_into_accelerator(
+            accelerator,
+            dataset_name,
+            &[filters.to_vec()],
+            new_batches,
+        )
+        .await
+    }
+
+    /// Replaces the rows matching `filter_sets` with `new_batches` by issuing a
+    /// `DELETE` against the accelerator and appending, instead of reading the
+    /// whole table back, filtering it in memory and overwriting it.
+    ///
+    /// `DuckDB` and Cayenne — and `SQLite`, Turso and the in-memory accelerator —
+    /// implement `TableProvider::delete_from`, so the engine removes the
+    /// superseded rows itself and the cost of replacing one cache entry is
+    /// proportional to that entry rather than to everything cached.
+    ///
+    /// Returns `Ok(false)`, having changed nothing, when the accelerator does
+    /// not implement deletes; the caller falls back to the read-filter-write
+    /// path. A provider without `delete_from` reports that while *planning*, so
+    /// this cannot leave a half-applied replacement behind.
+    ///
+    /// The delete and the append are two statements, not one transaction, so a
+    /// concurrent reader can see the entry briefly absent. That reads as a
+    /// cache miss and refetches — it costs a request, and never serves a
+    /// partial entry, because the append that follows carries every row.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `DataFusionError` if the delete fails for any reason other
+    /// than being unimplemented, or if the append fails.
+    async fn delete_and_append(
+        accelerator: &Arc<dyn TableProvider>,
+        dataset_name: &str,
+        filter_sets: &[Vec<Expr>],
+        new_batches: Vec<RecordBatch>,
+    ) -> DataFusionResult<bool> {
+        // Rows to remove: those matching ANY filter set, i.e. OR of AND-of-set.
+        // An empty set would delete everything, so it disqualifies the whole
+        // delete rather than being skipped.
+        if filter_sets.iter().any(Vec::is_empty) {
+            return Ok(false);
         }
+        // Balanced rather than left-nested: this ORs one predicate per entry, and
+        // a flush can carry many, which `simplify_expr` then walks recursively.
+        let per_entry: Vec<Expr> = filter_sets
+            .iter()
+            .filter_map(|filters| combine_exprs_balanced(filters.clone(), Expr::and))
+            .collect();
+        let Some(delete_expr) = combine_exprs_balanced(per_entry, Expr::or) else {
+            return Ok(false);
+        };
 
         let ctx = SessionContext::new();
         let state = ctx.state();
 
-        tracing::debug!(
-            "upsert_into_accelerator - reading existing data from accelerator for dataset={}",
-            dataset_name
-        );
-
-        // Scan all data from the accelerator (no filters to get everything)
-        let plan = accelerator.scan(&state, None, &[], None).await?;
-        let task_ctx = Arc::new(TaskContext::default());
-        let existing_batches = datafusion::physical_plan::collect(plan, task_ctx).await?;
-
-        let existing_rows: usize = existing_batches.iter().map(RecordBatch::num_rows).sum();
-        tracing::debug!(
-            "upsert_into_accelerator - found {} existing rows in accelerator for dataset={}",
-            existing_rows,
-            dataset_name
-        );
-
-        // If there's no existing data, just insert the new data
-        if existing_batches.is_empty() || existing_rows == 0 {
-            tracing::debug!(
-                "upsert_into_accelerator - no existing data, performing simple insert for dataset={}",
-                dataset_name
-            );
-            return Self::insert_into_accelerator(accelerator, dataset_name, new_batches).await;
-        }
-
-        // Build a filter to exclude rows that match the provided filters
-        // We need to keep rows that DON'T match the filters
-        let exclusion_filter = Self::build_combined_exclusion_filter(&[filters.to_vec()]);
-
-        tracing::debug!(
-            "upsert_into_accelerator - filtering out matching rows with {} filters for dataset={}",
-            filters.len(),
-            dataset_name
-        );
-
-        // Filter existing data to keep only non-matching rows
-        let df = ctx.read_batches(existing_batches)?;
-        let filtered_df = if let Some(filter) = exclusion_filter {
-            df.filter(filter)?
-        } else {
-            // No filters means replace everything
-            tracing::debug!(
-                "upsert_into_accelerator - no filters provided, will replace all data for dataset={}",
-                dataset_name
-            );
-            // Return early with just the new batches
-            return Self::overwrite_accelerator(Arc::clone(accelerator), dataset_name, new_batches)
-                .await;
+        let plan = match accelerator.delete_from(&state, vec![delete_expr]).await {
+            Ok(plan) => plan,
+            Err(DataFusionError::NotImplemented(_)) => {
+                tracing::debug!(
+                    "Accelerator for dataset={dataset_name} does not support deletes; falling back to read-filter-write for cache replacement"
+                );
+                return Ok(false);
+            }
+            Err(e) => return Err(e),
         };
 
-        let kept_batches = filtered_df.collect().await?;
-        let kept_rows: usize = kept_batches.iter().map(RecordBatch::num_rows).sum();
-        let new_rows: usize = new_batches.iter().map(RecordBatch::num_rows).sum();
+        let deleted = datafusion::physical_plan::collect(plan, Arc::new(TaskContext::default()))
+            .await?
+            .first()
+            .map_or(0, |batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<arrow::array::UInt64Array>()
+                    .filter(|a| !a.is_empty())
+                    .map_or(0, |a| a.value(0))
+            });
 
         tracing::debug!(
-            "upsert_into_accelerator - keeping {} rows, adding {} new rows for dataset={}",
-            kept_rows,
-            new_rows,
-            dataset_name
+            "delete_and_append - removed {deleted} superseded rows across {} cache entries for dataset={dataset_name}",
+            filter_sets.len()
         );
 
-        // Combine kept rows with new rows
-        let mut combined_batches = kept_batches;
-        combined_batches.extend(new_batches);
-
-        // Overwrite the accelerator with the combined data
-        Self::overwrite_accelerator(Arc::clone(accelerator), dataset_name, combined_batches).await
+        Self::append_to_accelerator(accelerator, dataset_name, new_batches).await?;
+        Ok(true)
     }
 
     /// Append data to the accelerator using native upsert.
@@ -1281,7 +1385,7 @@ impl CacheRefreshHelper {
     }
 
     /// Batched upsert: replace multiple cache entries in a single read-filter-write operation.
-    async fn batched_upsert_into_accelerator(
+    pub(crate) async fn batched_upsert_into_accelerator(
         accelerator: &Arc<dyn TableProvider>,
         dataset_name: &str,
         filter_sets: &[Vec<Expr>],
@@ -1291,6 +1395,14 @@ impl CacheRefreshHelper {
             tracing::debug!(
                 "batched_upsert_into_accelerator called with empty batches for dataset={dataset_name}"
             );
+            return Ok(());
+        }
+
+        // Prefer letting the engine remove the superseded rows itself.
+        if !filter_sets.is_empty()
+            && Self::delete_and_append(accelerator, dataset_name, filter_sets, new_batches.clone())
+                .await?
+        {
             return Ok(());
         }
 
@@ -1409,35 +1521,29 @@ impl CacheRefreshHelper {
         );
 
         for (idx, child) in children.iter().enumerate() {
-            let stamped: Vec<RecordBatch> = if child
-                .schema()
-                .column_with_name(CACHE_NAMESPACE_COLUMN)
-                .is_some()
-            {
-                let mut out = Vec::with_capacity(batches.len());
-                let mut stamp_err = None;
-                for b in batches {
-                    match stamp_namespace_column(b.clone(), namespace_id) {
-                        Ok(b) => out.push(b),
-                        Err(e) => {
-                            stamp_err = Some(e);
-                            break;
-                        }
+            let child_schema = child.schema();
+            let mut out = Vec::with_capacity(batches.len());
+            let mut stamp_err = None;
+            for b in batches {
+                match stamp_namespace_column(b.clone(), &child_schema, namespace_id) {
+                    Ok(b) => out.push(b),
+                    Err(e) => {
+                        stamp_err = Some(e);
+                        break;
                     }
                 }
-                if let Some(e) = stamp_err {
-                    tracing::warn!(
-                        "Failed to stamp namespace on synchronized child {} for dataset {}: {}",
-                        idx,
-                        dataset_name,
-                        e
-                    );
-                    continue;
-                }
-                out
-            } else {
-                batches.to_vec()
-            };
+            }
+            if let Some(e) = stamp_err {
+                tracing::warn!(
+                    "Failed to stamp {} on synchronized child {} for dataset {}: {}",
+                    CACHE_NAMESPACE_COLUMN,
+                    idx,
+                    dataset_name,
+                    e
+                );
+                continue;
+            }
+            let stamped: Vec<RecordBatch> = out;
 
             let result = if is_expired {
                 Self::upsert_into_accelerator(child, dataset_name, filters, stamped).await
@@ -1601,8 +1707,28 @@ impl CacheRefreshHelper {
                 tracing::trace!("Fetched batch schema:\n{}", SchemaDisplay(&batch_schema));
 
                 // Skip cache writes if the source response contains transient HTTP
-                // errors. User still receives all fetched data.
+                // errors.
                 let batches_cacheable = cache::batches_cacheable(&batches);
+
+                // A failing origin does not arrive as an error. Once the HTTP
+                // connector has exhausted its own retries it reports the
+                // failure as a successful fetch whose rows carry a 429 or 5xx
+                // status, so serving stale data only from the `Err` arm below
+                // would miss the dominant failure mode — an operator who asked
+                // for `caching_stale_if_error` would get the origin's error
+                // body instead of the cached response they asked to fall back
+                // to.
+                if !batches_cacheable
+                    && stale_if_error
+                    && let Some(stale) = expired_batches.filter(|b| !b.is_empty())
+                {
+                    tracing::warn!(
+                        "Origin for dataset '{dataset_name}' answered with a transient failure, so the expired cached response is being served instead because `caching_stale_if_error` is enabled."
+                    );
+                    let batch_schema = stale[0].schema();
+                    let batch_stream = futures::stream::iter(stale.into_iter().map(Ok));
+                    return Box::pin(RecordBatchStreamAdapter::new(batch_schema, batch_stream));
+                }
 
                 // Clone batches for propagation to children.
                 // RecordBatch::clone() is cheap - only clones Arc pointers, not the underlying data.
@@ -1632,7 +1758,6 @@ impl CacheRefreshHelper {
                         let write_request = CacheWriteRequest {
                             batches: batches.clone(),
                             filters: filters.to_vec(),
-                            is_upsert: is_expired,
                             cache_key,
                             namespace_id: namespace.storage_id().into(),
                         };
@@ -1642,7 +1767,7 @@ impl CacheRefreshHelper {
                             );
                         } else {
                             tracing::trace!(
-                                "Enqueued cache write for dataset={dataset_name}, {cache_rows} rows, is_upsert={is_expired}",
+                                "Enqueued cache write for dataset={dataset_name}, {cache_rows} rows",
                             );
                         }
 
@@ -1819,8 +1944,18 @@ impl CacheRefreshHelper {
                             .await;
 
                             match result {
-                                Ok(rows) => {
-                                    tracing::debug!("Background refresh task completed for dataset={dataset_name_clone}, refreshed {rows} rows");
+                                Ok(RevalidationOutcome::OriginUnavailable) => {
+                                    // Not an error to the caller: the entry is
+                                    // still inside its stale-while-revalidate
+                                    // window and keeps being served. Said out
+                                    // loud because "refreshed 0 rows" would
+                                    // read as an origin with nothing to give.
+                                    tracing::warn!(
+                                        "Background revalidation for dataset '{dataset_name_clone}' could not reach a healthy origin, so the cached response is being served past its `caching_ttl` until the origin recovers or the entry falls out of its `caching_stale_while_revalidate_ttl` window."
+                                    );
+                                }
+                                Ok(outcome) => {
+                                    tracing::debug!("Background refresh task completed for dataset={dataset_name_clone}, refreshed {rows} rows", rows = outcome.rows());
                                 }
                                 Err(e) => {
                                     tracing::error!(
@@ -1908,8 +2043,7 @@ impl CachingAccelerationScanExec {
         synchronized_children: SynchronizedChildren,
         batch_write_tx: CacheWriteSender,
     ) -> Self {
-        // Default max_age (TTL) to 30 seconds if not specified
-        let max_age = max_age.or(Some(Duration::from_secs(30)));
+        let max_age = Some(effective_max_age(max_age));
 
         let plan_properties = Arc::new(
             input
@@ -2246,14 +2380,15 @@ mod cache_namespace_column_tests {
     #[test]
     fn stamp_namespace_column_appends_constant_string_array() {
         use arrow::array::{Int32Array, StringArray};
-        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let payload = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let storage = extend_schema_with_cache_namespace("ds", &payload).expect("extend");
         let batch = arrow::array::RecordBatch::try_new(
-            Arc::clone(&schema),
+            Arc::new(payload),
             vec![Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef],
         )
         .expect("batch");
 
-        let stamped = stamp_namespace_column(batch, "apikey:abc").expect("ok");
+        let stamped = stamp_namespace_column(batch, &storage, "apikey:abc").expect("ok");
         assert_eq!(stamped.num_columns(), 2);
         assert_eq!(stamped.schema().field(1).name(), CACHE_NAMESPACE_COLUMN);
         let ns_col = stamped
@@ -2265,6 +2400,22 @@ mod cache_namespace_column_tests {
         for i in 0..ns_col.len() {
             assert_eq!(ns_col.value(i), "apikey:abc");
         }
+    }
+
+    #[test]
+    fn stamp_namespace_column_skips_storage_that_does_not_declare_it() {
+        use arrow::array::StringArray;
+        // A mock accelerator with an unextended schema must be written exactly
+        // as it is, or the insert would fail on arity.
+        let payload = Schema::new(vec![Field::new("content", DataType::Utf8, false)]);
+        let batch = arrow::array::RecordBatch::try_new(
+            Arc::new(payload.clone()),
+            vec![Arc::new(StringArray::from(vec!["x"])) as ArrayRef],
+        )
+        .expect("batch");
+
+        let stamped = stamp_namespace_column(batch, &payload, "public").expect("ok");
+        assert_eq!(stamped.num_columns(), 1);
     }
 
     #[test]
@@ -2283,7 +2434,7 @@ mod cache_namespace_column_tests {
         )
         .expect("batch");
 
-        let stamped = stamp_namespace_column(batch, "public").expect("ok");
+        let stamped = stamp_namespace_column(batch, &schema, "public").expect("ok");
         // Existing column wins; we must not silently rewrite a row's tag
         // because doing so could mask a bug in upstream stamping.
         let ns_col = stamped
@@ -3276,7 +3427,7 @@ mod tests {
         assert_eq!(batch.num_rows(), 6, "Should have 6 rows total");
 
         // Extract unique filter sets
-        let filter_sets = CacheRefreshHelper::extract_unique_filter_sets(&[batch])
+        let filter_sets = CacheRefreshHelper::extract_unique_stale_entries(&[batch])
             .expect("Should extract filter sets");
 
         // Should only have 2 unique filter sets (5 duplicates + 1 unique)
@@ -3589,7 +3740,6 @@ mod tests {
             tx.send(CacheWriteRequest {
                 batches: vec![batch],
                 filters: vec![],
-                is_upsert: false,
                 cache_key: format!("key_{i}"),
                 namespace_id: "public".into(),
             })
@@ -3715,6 +3865,149 @@ mod tests {
             cached_data.is_empty(),
             "Transient error responses (5xx/429) should NOT be in accelerator"
         );
+    }
+
+    /// A stale cached response, in the shape `MockHttpTableProvider` produces.
+    fn stale_cached_batch(schema: &SchemaRef, content: &str) -> RecordBatch {
+        use arrow::array::{StringArray, TimestampNanosecondArray, UInt16Array};
+        RecordBatch::try_new(
+            Arc::clone(schema),
+            vec![
+                Arc::new(StringArray::from(vec!["/api"])) as ArrayRef,
+                Arc::new(StringArray::from(vec![None::<&str>])) as ArrayRef,
+                Arc::new(StringArray::from(vec![content])) as ArrayRef,
+                Arc::new(UInt16Array::from(vec![200_u16])) as ArrayRef,
+                Arc::new(TimestampNanosecondArray::from(vec![Some(1_i64)])) as ArrayRef,
+            ],
+        )
+        .expect("batch")
+    }
+
+    async fn drain(mut stream: SendableRecordBatchStream) -> Vec<RecordBatch> {
+        use futures::StreamExt;
+        let mut out = Vec::new();
+        while let Some(result) = stream.next().await {
+            out.push(result.expect("stream should not error"));
+        }
+        out
+    }
+
+    /// A failing origin reaches us as a *successful* fetch carrying a 5xx row,
+    /// so `stale_if_error` has to act on the response's status, not just on a
+    /// transport error. Without this an operator who asked to fall back to the
+    /// cache gets the origin's error body instead.
+    #[tokio::test]
+    async fn stale_if_error_serves_the_cached_response_when_the_origin_answers_5xx() {
+        let http_source = Arc::new(MockHttpTableProvider::with_status(503, "upstream down"));
+        let schema = http_source.schema();
+        let accelerator = Arc::new(MockAcceleratorTableProvider::new(
+            Arc::clone(&schema),
+            vec![],
+        ));
+        let in_flight: InFlightRevalidations =
+            Arc::new(Mutex::new(std::collections::HashSet::new()));
+        let (batch_write_tx, _handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
+
+        let stale = stale_cached_batch(&schema, "last good response");
+
+        let stream = CacheRefreshHelper::handle_cache_miss(
+            Arc::clone(&http_source) as Arc<dyn TableProvider>,
+            "test_dataset",
+            &[col("content").eq(lit("test"))],
+            None,
+            Arc::clone(&schema),
+            true,              // is_expired
+            true,              // stale_if_error enabled
+            Some(vec![stale]), // the expired entry to fall back to
+            &tokio::runtime::Handle::current(),
+            Arc::new(vec![].into()),
+            batch_write_tx,
+            CacheNamespace::Public,
+        )
+        .await;
+
+        let served = drain(stream).await;
+        assert_eq!(served.len(), 1);
+        let content = served[0]
+            .column_by_name("content")
+            .and_then(|c| c.as_any().downcast_ref::<arrow::array::StringArray>())
+            .expect("content column");
+        assert_eq!(
+            content.value(0),
+            "last good response",
+            "the cached response must be served, not the origin's 5xx body"
+        );
+    }
+
+    /// The same origin failure with `stale_if_error` disabled must still hand
+    /// the caller what the origin said — the fallback is opt-in.
+    #[tokio::test]
+    async fn a_failing_origin_is_returned_to_the_caller_when_stale_if_error_is_off() {
+        let http_source = Arc::new(MockHttpTableProvider::with_status(503, "upstream down"));
+        let schema = http_source.schema();
+        let accelerator = Arc::new(MockAcceleratorTableProvider::new(
+            Arc::clone(&schema),
+            vec![],
+        ));
+        let in_flight: InFlightRevalidations =
+            Arc::new(Mutex::new(std::collections::HashSet::new()));
+        let (batch_write_tx, _handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
+
+        let stale = stale_cached_batch(&schema, "last good response");
+
+        let stream = CacheRefreshHelper::handle_cache_miss(
+            Arc::clone(&http_source) as Arc<dyn TableProvider>,
+            "test_dataset",
+            &[col("content").eq(lit("test"))],
+            None,
+            Arc::clone(&schema),
+            true,
+            false, // stale_if_error disabled
+            Some(vec![stale]),
+            &tokio::runtime::Handle::current(),
+            Arc::new(vec![].into()),
+            batch_write_tx,
+            CacheNamespace::Public,
+        )
+        .await;
+
+        let served = drain(stream).await;
+        assert_eq!(served.len(), 1);
+        let content = served[0]
+            .column_by_name("content")
+            .and_then(|c| c.as_any().downcast_ref::<arrow::array::StringArray>())
+            .expect("content column");
+        assert_eq!(content.value(0), "upstream down");
+    }
+
+    #[tokio::test]
+    async fn a_revalidation_reports_a_failing_origin_rather_than_zero_rows() {
+        let http_source = Arc::new(MockHttpTableProvider::with_status(429, "slow down"));
+        let in_flight: InFlightRevalidations =
+            Arc::new(Mutex::new(std::collections::HashSet::new()));
+        let accelerator = Arc::new(MockAcceleratorTableProvider::new(
+            http_source.schema(),
+            vec![],
+        ));
+        let (batch_write_tx, _handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
+
+        let outcome = CacheRefreshHelper::refresh_entry(
+            Arc::clone(&http_source) as Arc<dyn TableProvider>,
+            "test_dataset",
+            &[col("content").eq(lit("test"))],
+            CacheNamespace::Public,
+            batch_write_tx,
+            Arc::clone(&in_flight),
+        )
+        .await
+        .expect("revalidation should not error");
+
+        assert_eq!(
+            outcome,
+            RevalidationOutcome::OriginUnavailable,
+            "a 429 is a failing origin, not an origin with nothing to give"
+        );
+        assert_eq!(outcome.rows(), 0);
     }
 
     /// Test that 404 responses are cached.
@@ -4041,5 +4334,387 @@ mod tests {
             .expect("status column");
         assert_eq!(status.value(0), 200);
         assert_eq!(status.value(1), 404);
+    }
+}
+
+/// The caching write path must replace a cache entry by telling the engine to
+/// delete the superseded rows, not by reading the whole acceleration back,
+/// filtering it in memory and overwriting it. These tests watch the calls the
+/// accelerator actually receives, because "the right rows ended up stored" is
+/// true of both strategies and would not distinguish them.
+#[cfg(test)]
+mod write_path_tests {
+    use super::*;
+    use arrow::array::StringArray;
+    use arrow::datatypes::{Field, Schema};
+    use async_trait::async_trait;
+    use datafusion::catalog::{Session, TableProvider};
+    use datafusion::common::Constraints;
+    use datafusion::datasource::TableType;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Wraps a real accelerator and records which operations it was asked for.
+    /// `can_delete` models an engine without `delete_from` — the caller must
+    /// fall back rather than fail.
+    #[derive(Debug)]
+    struct CountingAccelerator {
+        inner: Arc<dyn TableProvider>,
+        scans: AtomicUsize,
+        deletes: AtomicUsize,
+        overwrites: AtomicUsize,
+        appends: AtomicUsize,
+        can_delete: bool,
+    }
+
+    impl CountingAccelerator {
+        fn new(inner: Arc<dyn TableProvider>, can_delete: bool) -> Self {
+            Self {
+                inner,
+                scans: AtomicUsize::new(0),
+                deletes: AtomicUsize::new(0),
+                overwrites: AtomicUsize::new(0),
+                appends: AtomicUsize::new(0),
+                can_delete,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TableProvider for CountingAccelerator {
+        fn schema(&self) -> SchemaRef {
+            self.inner.schema()
+        }
+
+        fn constraints(&self) -> Option<&Constraints> {
+            self.inner.constraints()
+        }
+
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+
+        async fn scan(
+            &self,
+            state: &dyn Session,
+            projection: Option<&Vec<usize>>,
+            filters: &[Expr],
+            limit: Option<usize>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            self.scans.fetch_add(1, Ordering::Relaxed);
+            self.inner.scan(state, projection, filters, limit).await
+        }
+
+        async fn insert_into(
+            &self,
+            state: &dyn Session,
+            input: Arc<dyn ExecutionPlan>,
+            op: InsertOp,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            match op {
+                InsertOp::Overwrite => self.overwrites.fetch_add(1, Ordering::Relaxed),
+                _ => self.appends.fetch_add(1, Ordering::Relaxed),
+            };
+            self.inner.insert_into(state, input, op).await
+        }
+
+        async fn delete_from(
+            &self,
+            state: &dyn Session,
+            filters: Vec<Expr>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            if !self.can_delete {
+                return Err(DataFusionError::NotImplemented(
+                    "Delete not implemented for this table".to_string(),
+                ));
+            }
+            self.deletes.fetch_add(1, Ordering::Relaxed);
+            self.inner.delete_from(state, filters).await
+        }
+    }
+
+    fn cache_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("request_path", DataType::Utf8, false),
+            Field::new("content", DataType::Utf8, false),
+        ]))
+    }
+
+    fn entry(path: &str, content: &str) -> RecordBatch {
+        RecordBatch::try_new(
+            cache_schema(),
+            vec![
+                Arc::new(StringArray::from(vec![path])) as ArrayRef,
+                Arc::new(StringArray::from(vec![content])) as ArrayRef,
+            ],
+        )
+        .expect("batch")
+    }
+
+    fn accelerator_with(
+        rows: Vec<RecordBatch>,
+        can_delete: bool,
+    ) -> (Arc<CountingAccelerator>, Arc<dyn TableProvider>) {
+        let inner = data_components::arrow::write::MemTable::try_new(cache_schema(), vec![rows])
+            .expect("mem table");
+        let counting = Arc::new(CountingAccelerator::new(
+            Arc::new(inner) as Arc<dyn TableProvider>,
+            can_delete,
+        ));
+        let as_provider = Arc::clone(&counting) as Arc<dyn TableProvider>;
+        (counting, as_provider)
+    }
+
+    async fn stored(accelerator: &Arc<dyn TableProvider>) -> Vec<(String, String)> {
+        let ctx = SessionContext::new();
+        let batches = ctx
+            .read_table(Arc::clone(accelerator))
+            .expect("read")
+            .collect()
+            .await
+            .expect("collect");
+        let mut out = Vec::new();
+        for batch in &batches {
+            let paths = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("utf8");
+            let contents = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("utf8");
+            for r in 0..batch.num_rows() {
+                out.push((paths.value(r).to_string(), contents.value(r).to_string()));
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// Runs the real batched writer over `accelerator` until the sender drops.
+    fn spawn_test_writer(
+        accelerator: &Arc<dyn TableProvider>,
+    ) -> (CacheWriteSender, tokio::task::JoinHandle<()>) {
+        let (tx, rx) = create_cache_write_channel();
+        let handle = spawn_batched_cache_write_task(
+            rx,
+            Arc::clone(accelerator),
+            TableReference::bare("test_dataset"),
+            Arc::new(Mutex::new(())),
+            Arc::new(Mutex::new(std::collections::HashSet::new())),
+            Arc::new(AtomicI64::new(0)),
+            RuntimeStatus::new(),
+        );
+        (tx, handle)
+    }
+
+    #[tokio::test]
+    async fn a_write_raised_as_a_fresh_insert_still_replaces_its_key() {
+        // Replacing an entry is a delete followed by an append, so a reader
+        // scanning in between sees no rows for the key and reads it as a miss.
+        // The insert it then enqueues must not append a second copy beside the
+        // replacement — queries would return the response twice.
+        let (counting, accelerator) = accelerator_with(
+            vec![entry("/a", "already-cached")],
+            /* can_delete */ true,
+        );
+
+        let (tx, handle) = spawn_test_writer(&accelerator);
+        tx.send(CacheWriteRequest {
+            batches: vec![entry("/a", "raced-insert")],
+            filters: vec![col("request_path").eq(lit("/a"))],
+            // The sender believed this key was absent, because when it looked
+            // it was: the replacement's delete had landed and its append had
+            // not.
+            cache_key: "key".to_string(),
+            namespace_id: "public".into(),
+        })
+        .await
+        .expect("send");
+        drop(tx);
+        handle.await.expect("writer");
+
+        assert_eq!(
+            stored(&accelerator).await,
+            vec![("/a".to_string(), "raced-insert".to_string())],
+            "the key must hold one response, not two"
+        );
+        assert_eq!(
+            counting.deletes.load(Ordering::Relaxed),
+            1,
+            "an insert must still clear its key first"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_write_for_a_key_nothing_holds_yet_is_still_written() {
+        // The guard above must not cost a genuinely new entry its write.
+        let (_counting, accelerator) = accelerator_with(vec![], /* can_delete */ true);
+
+        let (tx, handle) = spawn_test_writer(&accelerator);
+        tx.send(CacheWriteRequest {
+            batches: vec![entry("/new", "first")],
+            filters: vec![col("request_path").eq(lit("/new"))],
+            cache_key: "key".to_string(),
+            namespace_id: "public".into(),
+        })
+        .await
+        .expect("send");
+        drop(tx);
+        handle.await.expect("writer");
+
+        assert_eq!(
+            stored(&accelerator).await,
+            vec![("/new".to_string(), "first".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn replacing_an_entry_deletes_and_appends_without_reading_the_table() {
+        let (counting, accelerator) = accelerator_with(
+            vec![entry("/a", "old-a"), entry("/b", "b")],
+            /* can_delete */ true,
+        );
+
+        CacheRefreshHelper::batched_upsert_into_accelerator(
+            &accelerator,
+            "test_dataset",
+            &[vec![col("request_path").eq(lit("/a"))]],
+            vec![entry("/a", "new-a")],
+        )
+        .await
+        .expect("upsert");
+
+        assert_eq!(
+            counting.deletes.load(Ordering::Relaxed),
+            1,
+            "the superseded rows must be removed by the engine"
+        );
+        assert_eq!(
+            counting.appends.load(Ordering::Relaxed),
+            1,
+            "the replacement rows must be appended"
+        );
+        assert_eq!(
+            counting.overwrites.load(Ordering::Relaxed),
+            0,
+            "replacing one entry must not rewrite the whole acceleration"
+        );
+        assert_eq!(
+            counting.scans.load(Ordering::Relaxed),
+            0,
+            "replacing one entry must not read every cached row back first"
+        );
+
+        assert_eq!(
+            stored(&accelerator).await,
+            vec![
+                ("/a".to_string(), "new-a".to_string()),
+                ("/b".to_string(), "b".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn an_engine_without_deletes_still_replaces_the_entry_correctly() {
+        // Negative control for the test above: an accelerator that cannot
+        // delete must fall back to read-filter-write and reach the same stored
+        // state, so the assertions above are measuring the strategy and not
+        // just the outcome.
+        let (counting, accelerator) = accelerator_with(
+            vec![entry("/a", "old-a"), entry("/b", "b")],
+            /* can_delete */ false,
+        );
+
+        CacheRefreshHelper::batched_upsert_into_accelerator(
+            &accelerator,
+            "test_dataset",
+            &[vec![col("request_path").eq(lit("/a"))]],
+            vec![entry("/a", "new-a")],
+        )
+        .await
+        .expect("upsert");
+
+        assert_eq!(counting.deletes.load(Ordering::Relaxed), 0);
+        assert!(
+            counting.scans.load(Ordering::Relaxed) > 0,
+            "the fallback path reads the table back"
+        );
+        assert_eq!(
+            counting.overwrites.load(Ordering::Relaxed),
+            1,
+            "the fallback path rewrites the whole acceleration"
+        );
+
+        assert_eq!(
+            stored(&accelerator).await,
+            vec![
+                ("/a".to_string(), "new-a".to_string()),
+                ("/b".to_string(), "b".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn caching_a_new_entry_appends_rather_than_rewriting_the_table() {
+        let (counting, accelerator) = accelerator_with(vec![entry("/a", "a")], true);
+
+        CacheRefreshHelper::insert_into_accelerator(
+            &accelerator,
+            "test_dataset",
+            vec![entry("/b", "b")],
+        )
+        .await
+        .expect("insert");
+
+        assert_eq!(counting.appends.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            counting.overwrites.load(Ordering::Relaxed),
+            0,
+            "caching one response must not rewrite everything already cached"
+        );
+        assert_eq!(
+            counting.scans.load(Ordering::Relaxed),
+            0,
+            "caching one response must not read everything already cached"
+        );
+
+        assert_eq!(
+            stored(&accelerator).await,
+            vec![
+                ("/a".to_string(), "a".to_string()),
+                ("/b".to_string(), "b".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_filter_set_never_becomes_an_unconstrained_delete() {
+        // An empty filter set reduces to no predicate, which as a DELETE would
+        // remove the entire cache. It must disqualify the delete path instead.
+        let (counting, accelerator) = accelerator_with(
+            vec![entry("/a", "a"), entry("/b", "b")],
+            /* can_delete */ true,
+        );
+
+        let replaced = CacheRefreshHelper::delete_and_append(
+            &accelerator,
+            "test_dataset",
+            &[vec![]],
+            vec![entry("/c", "c")],
+        )
+        .await
+        .expect("must not error");
+
+        assert!(!replaced, "an unconstrained delete must be refused");
+        assert_eq!(counting.deletes.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            stored(&accelerator).await,
+            vec![
+                ("/a".to_string(), "a".to_string()),
+                ("/b".to_string(), "b".to_string()),
+            ]
+        );
     }
 }

--- a/crates/runtime-table/src/accelerated/caching.rs
+++ b/crates/runtime-table/src/accelerated/caching.rs
@@ -466,6 +466,38 @@ async fn flush_cache_writes(
 
     let flush_start = std::time::Instant::now();
 
+    // One key, one write. Two requests for the same key in a single flush would
+    // share one OR'd delete and then each append their batches, leaving the key
+    // holding the response twice — and a duplicated source row is a wrong query
+    // result, not a housekeeping problem. Only the newest survives; the older
+    // one is a response this key no longer holds.
+    //
+    // The in-flight key set makes this unreachable from the two paths that
+    // enqueue today. It is enforced here as well so the flush does not depend
+    // on its callers for it.
+    let superseded: Vec<bool> = {
+        let mut seen: HashSet<&str> = HashSet::with_capacity(buffer.len());
+        let mut flags: Vec<bool> = buffer
+            .iter()
+            .rev()
+            .map(|req| !seen.insert(req.cache_key.as_str()))
+            .collect();
+        flags.reverse();
+        flags
+    };
+    if superseded.iter().any(|superseded| *superseded) {
+        let dropped = superseded.iter().filter(|s| **s).count();
+        tracing::debug!(
+            "Dropping {dropped} superseded cache write(s) for dataset={dataset_name}: a later write for the same key is in this flush"
+        );
+        let mut index = 0;
+        buffer.retain(|_| {
+            let keep = !superseded[index];
+            index += 1;
+            keep
+        });
+    }
+
     let request_count = buffer.len();
     let total_rows: usize = buffer
         .iter()
@@ -880,6 +912,19 @@ impl CacheRefreshHelper {
 
                 if batches.is_empty() {
                     return Ok::<usize, datafusion::error::DataFusionError>(0);
+                }
+
+                // A failing origin arrives as a successful fetch whose rows
+                // carry a 429 or 5xx status, and this path overwrites the entry
+                // it refreshes. Writing that would replace the last good
+                // response with the origin's error body and serve it as a
+                // cache hit until it expires — so keep what is cached, which is
+                // also what `caching_stale_if_error` exists to do.
+                if !cache::batches_cacheable(&batches) {
+                    tracing::debug!(
+                        "Background refresh for dataset '{dataset_name}' found the origin failing (transient HTTP error response); keeping what is cached"
+                    );
+                    return Ok(0);
                 }
 
                 let refreshed_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
@@ -1749,70 +1794,73 @@ impl CacheRefreshHelper {
                 // Claim the key before enqueuing. Without this, two readers
                 // that miss the same key concurrently each append the response
                 // and the key ends up holding it twice — which queries return
-                // as duplicated source rows. The flush releases the claim once
-                // the write has landed.
-                let claimed = {
-                    let mut in_flight = in_flight_revalidations.lock().await;
-                    in_flight.insert(cache_key.clone())
-                };
-                if !claimed {
+                // as duplicated source rows.
+                //
+                // The claim is released by the flush that writes it, so it is
+                // taken only on the path that reaches a flush. Claiming for a
+                // response that is never enqueued would hold the key for the
+                // life of the process and refuse every later write and
+                // revalidation for it.
+                let claimed = batches_cacheable
+                    && in_flight_revalidations
+                        .lock()
+                        .await
+                        .insert(cache_key.clone());
+                if batches_cacheable && !claimed {
                     tracing::debug!(
                         "A write for this key is already pending for dataset={dataset_name}; not enqueuing a second copy"
                     );
                 }
 
-                if batches_cacheable && claimed {
-                    if batches.is_empty() {
-                        tracing::debug!(
-                            "Fetch returned no rows, skipping cache write for dataset={dataset_name}"
+                if claimed {
+                    let cache_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+
+                    // Send write request to batched consumer. The flush
+                    // task is the one that stamps `__spice_cache_namespace`
+                    // and adds the namespace filter to upsert keys, so it
+                    // can do the right thing based on the accelerator's
+                    // actual storage schema (extended in real deployments,
+                    // unextended in unit-test mocks).
+                    let write_request = CacheWriteRequest {
+                        batches: batches.clone(),
+                        filters: filters.to_vec(),
+                        cache_key: cache_key.clone(),
+                        namespace_id: namespace.storage_id().into(),
+                        replaces_existing: is_expired,
+                    };
+                    if let Err(e) = batch_write_tx.send(write_request).await {
+                        tracing::warn!(
+                            "Failed to enqueue cache write for dataset {dataset_name}: {e} (channel closed)"
                         );
+                        // No flush will run for this key, so release the
+                        // claim here instead of holding it for good.
+                        in_flight_revalidations.lock().await.remove(&cache_key);
                     } else {
-                        let cache_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
-
-                        // Send write request to batched consumer. The flush
-                        // task is the one that stamps `__spice_cache_namespace`
-                        // and adds the namespace filter to upsert keys, so it
-                        // can do the right thing based on the accelerator's
-                        // actual storage schema (extended in real deployments,
-                        // unextended in unit-test mocks).
-                        let write_request = CacheWriteRequest {
-                            batches: batches.clone(),
-                            filters: filters.to_vec(),
-                            cache_key,
-                            namespace_id: namespace.storage_id().into(),
-                            replaces_existing: is_expired,
-                        };
-                        if let Err(e) = batch_write_tx.send(write_request).await {
-                            tracing::warn!(
-                                "Failed to enqueue cache write for dataset {dataset_name}: {e} (channel closed)"
-                            );
-                        } else {
-                            tracing::trace!(
-                                "Enqueued cache write for dataset={dataset_name}, {cache_rows} rows",
-                            );
-                        }
-
-                        // Propagate cacheable data to children.
-                        let synchronized_children_clone = Arc::clone(&synchronized_children);
-                        let dataset_name_clone = dataset_name.to_string();
-                        let namespace_id_clone: Arc<str> = namespace.storage_id().into();
-                        io_runtime.spawn(async move {
-                            Self::propagate_to_synchronized_children(
-                                &synchronized_children_clone,
-                                &dataset_name_clone,
-                                &filters_clone,
-                                &batches_for_propagate,
-                                is_expired,
-                                &namespace_id_clone,
-                            )
-                            .await;
-                        });
-
-                        tracing::debug!(
-                            "Background cache update performed for dataset={dataset_name}, {cache_rows} rows"
+                        tracing::trace!(
+                            "Enqueued cache write for dataset={dataset_name}, {cache_rows} rows",
                         );
                     }
-                } else {
+
+                    // Propagate cacheable data to children.
+                    let synchronized_children_clone = Arc::clone(&synchronized_children);
+                    let dataset_name_clone = dataset_name.to_string();
+                    let namespace_id_clone: Arc<str> = namespace.storage_id().into();
+                    io_runtime.spawn(async move {
+                        Self::propagate_to_synchronized_children(
+                            &synchronized_children_clone,
+                            &dataset_name_clone,
+                            &filters_clone,
+                            &batches_for_propagate,
+                            is_expired,
+                            &namespace_id_clone,
+                        )
+                        .await;
+                    });
+
+                    tracing::debug!(
+                        "Background cache update performed for dataset={dataset_name}, {cache_rows} rows"
+                    );
+                } else if !batches_cacheable {
                     tracing::debug!(
                         "Fetch returned transient HTTP error responses, skipping cache write for dataset={dataset_name}"
                     );
@@ -4098,6 +4146,131 @@ mod tests {
         );
     }
 
+    /// The claim a miss takes is released by the flush that writes it, so a
+    /// response that is never enqueued must never claim.
+    #[tokio::test]
+    async fn a_failing_origin_does_not_leave_the_key_claimed() {
+        use futures::StreamExt;
+
+        // A held claim refuses every later write *and* revalidation for that
+        // key, for the life of the process — so one 5xx would make the key
+        // permanently uncacheable, which is the opposite of what an operator
+        // asking for a cache expects from a transient origin failure.
+        let http_source = Arc::new(MockHttpTableProvider::with_status(503, "upstream down"));
+        let schema = http_source.schema();
+        let accelerator = Arc::new(MockAcceleratorTableProvider::new(
+            Arc::clone(&schema),
+            vec![],
+        ));
+        let in_flight: InFlightRevalidations =
+            Arc::new(Mutex::new(std::collections::HashSet::new()));
+        let (batch_write_tx, handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
+
+        let mut stream = CacheRefreshHelper::handle_cache_miss(
+            Arc::clone(&http_source) as Arc<dyn TableProvider>,
+            "test_dataset",
+            &[col("content").eq(lit("test"))],
+            None,
+            Arc::clone(&schema),
+            false,
+            false,
+            None,
+            &tokio::runtime::Handle::current(),
+            Arc::new(vec![].into()),
+            batch_write_tx,
+            CacheNamespace::Public,
+            Arc::clone(&in_flight),
+        )
+        .await;
+
+        while let Some(batch) = stream.next().await {
+            batch.expect("stream");
+        }
+        drop(stream);
+        tokio::time::sleep(Duration::from_millis(CACHE_WRITE_FLUSH_INTERVAL_MS + 200)).await;
+        handle.abort();
+
+        assert!(
+            in_flight.lock().await.is_empty(),
+            "a key whose response was never enqueued must not stay claimed"
+        );
+    }
+
+    /// The periodic refresh replaces the entry it refreshes, so it must not
+    /// write a failing origin's error body over the last good response.
+    #[tokio::test]
+    async fn a_failing_origin_does_not_overwrite_a_stale_entry_with_its_error_body() {
+        // A 429 or 5xx arrives as a *successful* fetch whose rows carry that
+        // status. Writing it would serve the origin's error body as a cache hit
+        // until it expired, and would defeat `caching_stale_if_error` outright.
+        let origin = Arc::new(MockHttpTableProvider::with_status(503, "upstream down"));
+        let schema = origin.schema();
+
+        #[expect(clippy::cast_possible_truncation)]
+        let fetched_long_ago = (SystemTime::now() - Duration::from_secs(3600))
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos() as i64;
+
+        let stale = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["/a"])) as ArrayRef,
+                Arc::new(StringArray::from(vec![""])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["good-body"])) as ArrayRef,
+                Arc::new(arrow::array::UInt16Array::from(vec![200_u16])) as ArrayRef,
+                Arc::new(TimestampNanosecondArray::from(vec![Some(fetched_long_ago)])) as ArrayRef,
+            ],
+        )
+        .expect("stale row");
+
+        let accelerator = Arc::new(
+            data_components::arrow::write::MemTable::try_new(
+                Arc::clone(&schema),
+                vec![vec![stale]],
+            )
+            .expect("mem table"),
+        ) as Arc<dyn TableProvider>;
+
+        let refreshed = CacheRefreshHelper::refresh_all_stale_rows(
+            Arc::clone(&origin) as Arc<dyn TableProvider>,
+            Arc::clone(&accelerator),
+            "test_dataset",
+            Duration::from_secs(1),
+            Arc::new(Mutex::new(())),
+        )
+        .await
+        .expect("refresh");
+
+        assert_eq!(refreshed, 0, "a failing origin refreshes nothing");
+
+        let ctx = SessionContext::new();
+        let batches = ctx
+            .read_table(Arc::clone(&accelerator))
+            .expect("read")
+            .collect()
+            .await
+            .expect("collect");
+        let bodies: Vec<String> = batches
+            .iter()
+            .flat_map(|batch| {
+                let content = batch
+                    .column(2)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("utf8");
+                (0..batch.num_rows())
+                    .map(|r| content.value(r).to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert_eq!(
+            bodies,
+            vec!["good-body".to_string()],
+            "the cached response must survive a failing origin"
+        );
+    }
+
     /// Test that 404 responses are cached.
     ///
     /// Simulates cache miss flow:
@@ -4628,6 +4801,35 @@ mod write_path_tests {
         assert_eq!(
             stored(&accelerator).await,
             vec![("/new".to_string(), "first".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn two_writes_for_one_key_in_a_flush_store_the_newest_only() {
+        // Both are raised as fresh inserts, so neither deletes. Appending both
+        // would leave the key holding the response twice, which queries return
+        // as duplicated source rows.
+        let (_counting, accelerator) = accelerator_with(vec![], /* can_delete */ true);
+
+        let (tx, handle) = spawn_test_writer(&accelerator);
+        for content in ["older", "newer"] {
+            tx.send(CacheWriteRequest {
+                batches: vec![entry("/a", content)],
+                filters: vec![col("request_path").eq(lit("/a"))],
+                cache_key: "same-key".to_string(),
+                namespace_id: "public".into(),
+                replaces_existing: false,
+            })
+            .await
+            .expect("send");
+        }
+        drop(tx);
+        handle.await.expect("writer");
+
+        assert_eq!(
+            stored(&accelerator).await,
+            vec![("/a".to_string(), "newer".to_string())],
+            "the key must hold one response, and it must be the newest"
         );
     }
 

--- a/crates/runtime-table/src/accelerated/caching.rs
+++ b/crates/runtime-table/src/accelerated/caching.rs
@@ -50,11 +50,76 @@ use runtime_request_context::CacheNamespace;
 use runtime_status::{ComponentStatus, RuntimeStatus};
 use util::expr::combine_exprs_balanced;
 
-/// Type alias for tracking in-flight revalidation requests.
-/// The key is a cache key derived from the filter expressions (`request_path`, `request_query`, `request_body`).
-/// When a revalidation is in progress for a cache key, other requests for the same key will skip
-/// triggering a new revalidation to avoid duplicate upstream requests during the SWR window.
-pub type InFlightRevalidations = Arc<Mutex<HashSet<String>>>;
+/// The cache keys a write is currently pending for, one entry per claim.
+///
+/// The key is derived from the filter expressions (`request_path`,
+/// `request_query`, `request_body`) and the namespace. Claims are taken and
+/// released through [`CacheKeyClaim`] rather than by touching this directly.
+///
+/// A synchronous lock: every critical section is one `HashSet` operation, never
+/// held across an `.await`, and [`CacheKeyClaim`]'s `Drop` must be able to
+/// release without one.
+pub type InFlightRevalidations = Arc<parking_lot::Mutex<HashSet<String>>>;
+
+/// A cache key claimed for writing, released when this is dropped.
+///
+/// One key, one writer. Two writers for the same key each append their
+/// response, leaving the key holding it twice — which queries return as
+/// duplicated source rows.
+///
+/// The claim deliberately spans the whole window in which a writer's view of
+/// the key can go stale, so it is taken *before* the origin is asked rather
+/// than after. Replacing an entry is a delete followed by an append, and a
+/// reader scanning in between sees no rows and reads a miss. By the time that
+/// reader's own fetch returns, the replacement may have landed and released;
+/// claiming only then would let it append beside a response it never saw.
+///
+/// Dropping releases the claim, so a fetch that never returns or a query
+/// cancelled while waiting for write-channel capacity cannot leave a key
+/// claimed for the life of the process — which would refuse every later write
+/// *and* revalidation for it, making one transient failure permanent.
+pub struct CacheKeyClaim {
+    key: String,
+    in_flight: InFlightRevalidations,
+    /// Set once a queued write owns the claim; that write releases it after it
+    /// has landed, so dropping this must not.
+    queued: bool,
+}
+
+impl CacheKeyClaim {
+    /// Claims `key`, or `None` when a write for it is already pending.
+    pub fn acquire(in_flight: &InFlightRevalidations, key: String) -> Option<Self> {
+        if !in_flight.lock().insert(key.clone()) {
+            return None;
+        }
+        Some(Self {
+            key,
+            in_flight: Arc::clone(in_flight),
+            queued: false,
+        })
+    }
+
+    #[must_use]
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Hands the claim to a write that has been queued, which releases it once
+    /// the write has landed. Call only after the send has succeeded: a claim
+    /// given to a request that never reaches the flush is never released.
+    fn into_queued(mut self) {
+        self.queued = true;
+    }
+}
+
+impl Drop for CacheKeyClaim {
+    fn drop(&mut self) {
+        if self.queued {
+            return;
+        }
+        self.in_flight.lock().remove(&self.key);
+    }
+}
 
 pub const CACHE_REFRESHED_AT_COLUMN: &str = "_fetched_at";
 
@@ -592,7 +657,9 @@ async fn flush_cache_writes(
 
     let write_ms = write_start.elapsed().as_millis();
     if let Err(e) = result {
-        tracing::warn!("Failed to flush cache updates for dataset {dataset_name}: {e}");
+        tracing::warn!(
+            "Failed to write cached responses for dataset '{dataset_name}', so those entries are not cached and the next query for them will be answered from the origin. Cause: {e}"
+        );
         health.record_failure(&e);
     } else if write_rows > 0 {
         health.record_success();
@@ -607,7 +674,7 @@ async fn flush_cache_writes(
 
     // Remove cache keys from in-flight tracking now that writes are persisted
     {
-        let mut in_flight = in_flight_revalidations.lock().await;
+        let mut in_flight = in_flight_revalidations.lock();
         for key in &cache_keys {
             in_flight.remove(key);
         }
@@ -841,6 +908,7 @@ impl CacheRefreshHelper {
         dataset_name: &str,
         ttl: Duration,
         accelerator_write_mutex: Arc<Mutex<()>>,
+        in_flight_revalidations: InFlightRevalidations,
     ) -> DataFusionResult<usize> {
         let ctx = SessionContext::new();
         let state = ctx.state();
@@ -893,12 +961,32 @@ impl CacheRefreshHelper {
             let accelerator = Arc::clone(&accelerator);
             let dataset_name = dataset_name.to_string();
             let accelerator_write_mutex = Arc::clone(&accelerator_write_mutex);
+            let in_flight_revalidations = Arc::clone(&in_flight_revalidations);
             let StaleCacheEntry {
                 filters: row_filters,
                 namespace,
             } = entry;
 
             async move {
+                // This path replaces the entry it refreshes, so it opens the
+                // same delete-then-append gap every other writer does and must
+                // hold the key for it. Without the claim a reader scanning in
+                // that gap reads a miss and appends its own copy beside this
+                // one. Held until the write below has landed; dropped with this
+                // future on any early return.
+                let namespace_id = namespace
+                    .as_deref()
+                    .unwrap_or_else(|| CacheNamespace::Public.storage_id());
+                let Some(_claim) = CacheKeyClaim::acquire(
+                    &in_flight_revalidations,
+                    compute_cache_key_from_filters_and_namespace(&row_filters, namespace_id),
+                ) else {
+                    tracing::debug!(
+                        "Skipping stale refresh for dataset {dataset_name}: a write for this entry is already pending"
+                    );
+                    return Ok::<usize, datafusion::error::DataFusionError>(0);
+                };
+
                 tracing::debug!(
                     "Refreshing stale data for dataset {} with {} filters",
                     dataset_name,
@@ -933,9 +1021,6 @@ impl CacheRefreshHelper {
                 // no namespace and no expiry — the latter reading as "no deadline
                 // to hold this to", which the eviction sweep removes on its next
                 // pass, so a refresh would undo itself.
-                let namespace_id = namespace
-                    .as_deref()
-                    .unwrap_or_else(|| CacheNamespace::Public.storage_id());
                 let storage_schema = accelerator.schema();
                 let batches = batches
                     .into_iter()
@@ -1002,11 +1087,8 @@ impl CacheRefreshHelper {
         filters: &[Expr],
         namespace: CacheNamespace,
         batch_write_tx: CacheWriteSender,
-        in_flight_revalidations: InFlightRevalidations,
+        claim: CacheKeyClaim,
     ) -> DataFusionResult<RevalidationOutcome> {
-        let cache_key =
-            compute_cache_key_from_filters_and_namespace(filters, namespace.storage_id());
-
         tracing::trace!(
             "Refreshing single cache entry for dataset {dataset_name} with {} filters",
             filters.len()
@@ -1015,21 +1097,17 @@ impl CacheRefreshHelper {
         // Fetch fresh data for this specific entry
         let batches = Self::fetch_from_source(&federated, dataset_name, filters, None).await?;
 
-        // Skip cache writes if the source response contains transient HTTP errors.
+        // Skip cache writes if the source response contains transient HTTP
+        // errors. Returning here drops `claim`, releasing the key.
         if !cache::batches_cacheable(&batches) {
             tracing::debug!(
                 "Revalidation for dataset={dataset_name} found the origin failing (transient HTTP error response); keeping what is cached"
             );
-            // Remove from in-flight since no data to write
-            let mut in_flight = in_flight_revalidations.lock().await;
-            in_flight.remove(&cache_key);
             return Ok(RevalidationOutcome::OriginUnavailable);
         }
 
         if batches.is_empty() {
             tracing::debug!("No cacheable data for dataset={dataset_name} (source returned empty)");
-            let mut in_flight = in_flight_revalidations.lock().await;
-            in_flight.remove(&cache_key);
             return Ok(RevalidationOutcome::Empty);
         }
 
@@ -1042,15 +1120,18 @@ impl CacheRefreshHelper {
         let request = CacheWriteRequest {
             batches,
             filters: filters.to_vec(),
-            cache_key: cache_key.clone(),
+            cache_key: claim.key().to_string(),
             namespace_id: namespace.storage_id().into(),
             replaces_existing: true,
         };
 
+        // The claim passes to the queued write only once the send has
+        // succeeded; on the error path it drops and releases here.
         batch_write_tx
             .send(request)
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        claim.into_queued();
 
         tracing::trace!("Queued refresh for dataset={dataset_name}, {refreshed_rows} rows");
 
@@ -1295,7 +1376,23 @@ impl CacheRefreshHelper {
     /// The delete and the append are two statements, not one transaction, so a
     /// concurrent reader can see the entry briefly absent. That reads as a
     /// cache miss and refetches — it costs a request, and never serves a
-    /// partial entry, because the append that follows carries every row.
+    /// partial entry, because the append that follows carries every row. Such a
+    /// reader cannot write what it fetched: the key is claimed for the whole
+    /// replacement, including this gap (see [`CacheKeyClaim`]).
+    ///
+    /// **Deleting first is deliberate, and it is the order that fails safely.**
+    /// Without a transaction one of the two statements can land alone. If the
+    /// append fails after the delete, the entry is gone and the next read
+    /// re-fetches it — a cache miss, which is always a correct answer. Appending
+    /// first would instead leave the key holding both responses if the delete
+    /// failed, and a duplicated source row is a *wrong* answer that queries go
+    /// on returning until something else removes it. A cache may lose an entry;
+    /// it may not invent rows.
+    ///
+    /// What the deletion costs is the `caching_stale_if_error` fallback for that
+    /// entry: there is no longer an expired copy to serve if the origin is down
+    /// when the next read arrives. The failure is logged and recorded against
+    /// the dataset's health rather than passed over.
     ///
     /// # Errors
     ///
@@ -1722,8 +1819,11 @@ impl CacheRefreshHelper {
     /// * `io_runtime` - Tokio runtime handle for spawning background write tasks.
     /// * `synchronized_children` - Child accelerators that should also receive the cached data.
     /// * `batch_write_tx` - Channel sender for batched writes to the caching consumer.
-    /// * `in_flight_revalidations` - Keys with a write already pending, so two
-    ///   readers missing the same key do not each append the response.
+    /// * `in_flight_revalidations` - The keys a write is already pending for. A
+    ///   claim on this key is taken *before* the source is asked and held until
+    ///   the write lands, so a reader whose observation of the cache is made
+    ///   stale by a concurrent replacement cannot append beside it. See
+    ///   [`CacheKeyClaim`].
     #[expect(clippy::too_many_arguments)]
     async fn handle_cache_miss(
         federated: Arc<dyn TableProvider>,
@@ -1740,6 +1840,13 @@ impl CacheRefreshHelper {
         namespace: CacheNamespace,
         in_flight_revalidations: InFlightRevalidations,
     ) -> SendableRecordBatchStream {
+        // Claimed before the origin is asked, not after: see [`CacheKeyClaim`]
+        // for why the window this covers has to include the fetch.
+        let claim = CacheKeyClaim::acquire(
+            &in_flight_revalidations,
+            compute_cache_key_from_filters_and_namespace(filters, namespace.storage_id()),
+        );
+
         match Self::fetch_from_source(&federated, dataset_name, filters, limit).await {
             Ok(batches) if !batches.is_empty() => {
                 let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
@@ -1778,32 +1885,13 @@ impl CacheRefreshHelper {
                     return Box::pin(RecordBatchStreamAdapter::new(batch_schema, batch_stream));
                 }
 
-                let cache_key =
-                    compute_cache_key_from_filters_and_namespace(filters, namespace.storage_id());
-
-                // Claiming the key is what stops two readers that miss it
-                // concurrently from each appending the response, leaving the key
-                // holding it twice — which queries return as duplicated source
-                // rows.
-                //
-                // The claim is released by the flush that writes it, so it is
-                // taken only on the path that reaches a flush. Claiming for a
-                // response that is never enqueued would hold the key for the
-                // life of the process and refuse every later write and
-                // revalidation for it.
+                // Each arm that does not enqueue drops the claim, releasing
+                // the key for the next writer.
                 if !batches_cacheable {
                     tracing::debug!(
                         "Fetch returned transient HTTP error responses, skipping cache write for dataset={dataset_name}"
                     );
-                } else if !in_flight_revalidations
-                    .lock()
-                    .await
-                    .insert(cache_key.clone())
-                {
-                    tracing::debug!(
-                        "A write for this key is already pending for dataset={dataset_name}; not enqueuing a second copy"
-                    );
-                } else {
+                } else if let Some(claim) = claim {
                     // `RecordBatch::clone` is cheap: it clones Arc pointers,
                     // not the underlying data.
                     let batches_for_propagate = batches.clone();
@@ -1819,18 +1907,20 @@ impl CacheRefreshHelper {
                     let write_request = CacheWriteRequest {
                         batches: batches.clone(),
                         filters: filters.to_vec(),
-                        cache_key: cache_key.clone(),
+                        cache_key: claim.key().to_string(),
                         namespace_id: namespace.storage_id().into(),
                         replaces_existing: is_expired,
                     };
+                    // The claim passes to the queued write only once the send
+                    // has succeeded. A failed send — or a cancellation while
+                    // waiting for capacity — drops it instead, so no flush is
+                    // owed a release that will never come.
                     if let Err(e) = batch_write_tx.send(write_request).await {
                         tracing::warn!(
                             "Failed to enqueue cache write for dataset {dataset_name}: {e} (channel closed)"
                         );
-                        // No flush will run for this key, so release the
-                        // claim here instead of holding it for good.
-                        in_flight_revalidations.lock().await.remove(&cache_key);
                     } else {
+                        claim.into_queued();
                         tracing::trace!(
                             "Enqueued cache write for dataset={dataset_name}, {cache_rows} rows",
                         );
@@ -1854,6 +1944,10 @@ impl CacheRefreshHelper {
 
                     tracing::debug!(
                         "Background cache update performed for dataset={dataset_name}, {cache_rows} rows"
+                    );
+                } else {
+                    tracing::debug!(
+                        "A write for this key is already pending for dataset={dataset_name}; not enqueuing a second copy"
                     );
                 }
 
@@ -1911,7 +2005,7 @@ impl CacheRefreshHelper {
     /// - `Stale`: Return cached data immediately, trigger background refresh (if not already in-flight)
     /// - `Expired`: This should not be called for expired data (handled as cache miss)
     #[expect(clippy::too_many_arguments)]
-    async fn handle_cache_hit(
+    fn handle_cache_hit(
         cached_batches: Vec<RecordBatch>,
         federated: &Arc<dyn TableProvider>,
         dataset_name: &str,
@@ -1947,28 +2041,17 @@ impl CacheRefreshHelper {
                     );
                 }
                 CacheFreshness::Stale => {
-                    // Compute cache key to check for in-flight revalidation
-                    let cache_key = compute_cache_key_from_filters_and_namespace(
-                        filters,
-                        namespace.storage_id(),
+                    // One revalidation per key: the claim is held for the
+                    // whole refresh and released by the write that lands it.
+                    let claim = CacheKeyClaim::acquire(
+                        in_flight_revalidations,
+                        compute_cache_key_from_filters_and_namespace(
+                            filters,
+                            namespace.storage_id(),
+                        ),
                     );
 
-                    // Try to acquire the revalidation slot for this cache key
-                    // Use async lock since we're in an async context
-                    let should_revalidate = {
-                        let mut in_flight = in_flight_revalidations.lock().await;
-                        if in_flight.contains(&cache_key) {
-                            tracing::debug!(
-                                "Skipping background refresh for dataset={dataset_name}, cache_key={cache_key} - revalidation already in progress"
-                            );
-                            false
-                        } else {
-                            in_flight.insert(cache_key.clone());
-                            true
-                        }
-                    };
-
-                    if should_revalidate {
+                    if let Some(claim) = claim {
                         tracing::debug!(
                             "Data is stale for dataset={dataset_name}, triggering background refresh"
                         );
@@ -1983,11 +2066,9 @@ impl CacheRefreshHelper {
 
                         let federated_clone = Arc::clone(federated);
                         let dataset_name_clone = dataset_name.to_string();
-                        let in_flight_clone = Arc::clone(in_flight_revalidations);
                         let filters_for_refresh: Vec<Expr> = filters.to_vec();
-                        let batch_write_tx_clone = batch_write_tx.clone();
-                        let cache_key_clone = cache_key.clone();
-                        let namespace_clone = namespace.clone();
+                        let batch_write_tx_clone = batch_write_tx;
+                        let namespace_clone = namespace;
 
                         io_runtime.spawn(async move {
                             tracing::debug!(
@@ -1999,7 +2080,7 @@ impl CacheRefreshHelper {
                                 &filters_for_refresh,
                                 namespace_clone,
                                 batch_write_tx_clone,
-                                Arc::clone(&in_flight_clone),
+                                claim,
                             )
                             .await;
 
@@ -2018,13 +2099,11 @@ impl CacheRefreshHelper {
                                     tracing::debug!("Background refresh task completed for dataset={dataset_name_clone}, refreshed {rows} rows", rows = outcome.rows());
                                 }
                                 Err(e) => {
+                                    // The claim was dropped with the failed
+                                    // refresh, so the key is already released.
                                     tracing::error!(
                                         "Background refresh task failed for dataset={dataset_name_clone}: {e}"
                                     );
-                                    // Remove from in-flight only on failure
-                                    // On success, cache_key is removed by flush_cache_writes after write completes
-                                    let mut in_flight = in_flight_clone.lock().await;
-                                    in_flight.remove(&cache_key_clone);
                                 }
                             }
                         });
@@ -2339,7 +2418,6 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     batch_write_tx.clone(),
                     namespace,
                 )
-                .await
             } else {
                 // Cache miss - no data in accelerator - retrieve from source and store in accelerator
                 tracing::debug!(
@@ -3668,7 +3746,7 @@ mod tests {
         let max_age = Some(Duration::from_mins(1)); // 60 second TTL
         let stale_while_revalidate = Some(Duration::from_mins(5)); // 5 minute SWR window
         let in_flight_revalidations: InFlightRevalidations =
-            Arc::new(Mutex::new(std::collections::HashSet::new()));
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
 
         let (batch_write_tx, _consumer_handle) =
             spawn_test_cache_write_consumer(&accelerator, &in_flight_revalidations);
@@ -3691,8 +3769,7 @@ mod tests {
             &in_flight_revalidations,
             batch_write_tx,
             CacheNamespace::Public,
-        )
-        .await;
+        );
 
         // Wait for flush interval `CACHE_WRITE_FLUSH_INTERVAL_MS` + buffer 100ms
         tokio::time::sleep(Duration::from_millis(CACHE_WRITE_FLUSH_INTERVAL_MS + 100)).await;
@@ -3735,7 +3812,7 @@ mod tests {
         );
 
         // Verify in-flight tracking was cleaned up
-        let in_flight = in_flight_revalidations.lock().await;
+        let in_flight = in_flight_revalidations.lock();
         assert!(
             in_flight.is_empty(),
             "In-flight revalidation set should be empty after refresh completes"
@@ -3788,7 +3865,7 @@ mod tests {
             vec![],
         ));
         let in_flight: InFlightRevalidations =
-            Arc::new(Mutex::new(std::collections::HashSet::new()));
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
 
         let (tx, _handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
 
@@ -3842,7 +3919,7 @@ mod tests {
             vec![],
         ));
         let in_flight: InFlightRevalidations =
-            Arc::new(Mutex::new(std::collections::HashSet::new()));
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
 
         let (batch_write_tx, _handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
 
@@ -3970,7 +4047,7 @@ mod tests {
             vec![],
         ));
         let in_flight: InFlightRevalidations =
-            Arc::new(Mutex::new(std::collections::HashSet::new()));
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
         let (batch_write_tx, _handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
 
         let stale = stale_cached_batch(&schema, "last good response");
@@ -4016,7 +4093,7 @@ mod tests {
             vec![],
         ));
         let in_flight: InFlightRevalidations =
-            Arc::new(Mutex::new(std::collections::HashSet::new()));
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
         let (batch_write_tx, _handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
 
         let stale = stale_cached_batch(&schema, "last good response");
@@ -4051,7 +4128,7 @@ mod tests {
     async fn a_revalidation_reports_a_failing_origin_rather_than_zero_rows() {
         let http_source = Arc::new(MockHttpTableProvider::with_status(429, "slow down"));
         let in_flight: InFlightRevalidations =
-            Arc::new(Mutex::new(std::collections::HashSet::new()));
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
         let accelerator = Arc::new(MockAcceleratorTableProvider::new(
             http_source.schema(),
             vec![],
@@ -4064,7 +4141,7 @@ mod tests {
             &[col("content").eq(lit("test"))],
             CacheNamespace::Public,
             batch_write_tx,
-            Arc::clone(&in_flight),
+            CacheKeyClaim::acquire(&in_flight, "key".to_string()).expect("claim"),
         )
         .await
         .expect("revalidation should not error");
@@ -4091,7 +4168,7 @@ mod tests {
             vec![],
         ));
         let in_flight: InFlightRevalidations =
-            Arc::new(Mutex::new(std::collections::HashSet::new()));
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
         let (batch_write_tx, handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
 
         // Stand in for the first reader: its write for this key is already
@@ -4101,7 +4178,7 @@ mod tests {
             &filters,
             CacheNamespace::Public.storage_id(),
         );
-        in_flight.lock().await.insert(key);
+        in_flight.lock().insert(key);
 
         let mut stream = CacheRefreshHelper::handle_cache_miss(
             Arc::clone(&http_source) as Arc<dyn TableProvider>,
@@ -4137,6 +4214,125 @@ mod tests {
         );
     }
 
+    /// A claim that is never handed to a write releases its key when dropped.
+    #[tokio::test]
+    async fn a_dropped_claim_releases_its_key() {
+        // This is what makes a cancelled query safe. The miss path holds the
+        // claim across the fetch and across the enqueue, so a client that
+        // disconnects, or a send that blocks on a full write channel, drops the
+        // future somewhere in the middle. Without release-on-drop that key
+        // stays claimed for the life of the process and every later write and
+        // revalidation for it is refused.
+        let in_flight: InFlightRevalidations =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
+
+        {
+            let claim = CacheKeyClaim::acquire(&in_flight, "k".to_string()).expect("claim");
+            assert_eq!(claim.key(), "k");
+            assert!(
+                CacheKeyClaim::acquire(&in_flight, "k".to_string()).is_none(),
+                "a claimed key must refuse a second claim"
+            );
+        }
+
+        assert!(
+            in_flight.lock().is_empty(),
+            "dropping a claim must release its key"
+        );
+        assert!(
+            CacheKeyClaim::acquire(&in_flight, "k".to_string()).is_some(),
+            "the key is claimable again"
+        );
+    }
+
+    /// A claim handed to a queued write is released by that write, not by the
+    /// scope that raised it.
+    #[tokio::test]
+    async fn a_queued_claim_outlives_the_scope_that_raised_it() {
+        let in_flight: InFlightRevalidations =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
+
+        {
+            let claim = CacheKeyClaim::acquire(&in_flight, "k".to_string()).expect("claim");
+            claim.into_queued();
+        }
+
+        assert!(
+            in_flight.lock().contains("k"),
+            "the flush that writes this key is the one that releases it"
+        );
+    }
+
+    /// The periodic refresh replaces the entries it refreshes, so it opens the
+    /// same delete-then-append gap as every other writer and must hold the key.
+    #[tokio::test]
+    async fn the_periodic_refresh_skips_an_entry_whose_key_is_already_claimed() {
+        // Without the claim, a reader scanning that gap sees no rows, reads a
+        // miss, and appends its own copy beside this one — leaving the key
+        // holding the response twice.
+        let origin = Arc::new(MockHttpTableProvider::with_status(200, "fresh-body"));
+        let schema = origin.schema();
+
+        #[expect(clippy::cast_possible_truncation)]
+        let fetched_long_ago = (SystemTime::now() - Duration::from_hours(1))
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos() as i64;
+
+        let stale = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["/a"])) as ArrayRef,
+                Arc::new(StringArray::from(vec![""])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["good-body"])) as ArrayRef,
+                Arc::new(arrow::array::UInt16Array::from(vec![200_u16])) as ArrayRef,
+                Arc::new(TimestampNanosecondArray::from(vec![Some(fetched_long_ago)])) as ArrayRef,
+            ],
+        )
+        .expect("stale row");
+
+        // Claim the key exactly as the refresh will compute it.
+        let entries =
+            CacheRefreshHelper::extract_unique_stale_entries(std::slice::from_ref(&stale))
+                .expect("stale entries");
+        let entry = entries.first().expect("one stale entry");
+        let namespace_id = entry
+            .namespace
+            .as_deref()
+            .unwrap_or_else(|| CacheNamespace::Public.storage_id());
+        let in_flight: InFlightRevalidations =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
+        let _held = CacheKeyClaim::acquire(
+            &in_flight,
+            compute_cache_key_from_filters_and_namespace(&entry.filters, namespace_id),
+        )
+        .expect("claim");
+
+        let accelerator = Arc::new(
+            data_components::arrow::write::MemTable::try_new(
+                Arc::clone(&schema),
+                vec![vec![stale]],
+            )
+            .expect("mem table"),
+        ) as Arc<dyn TableProvider>;
+
+        let refreshed = CacheRefreshHelper::refresh_all_stale_rows(
+            Arc::clone(&origin) as Arc<dyn TableProvider>,
+            Arc::clone(&accelerator),
+            "test_dataset",
+            Duration::from_secs(1),
+            Arc::new(Mutex::new(())),
+            Arc::clone(&in_flight),
+        )
+        .await
+        .expect("refresh");
+
+        assert_eq!(
+            refreshed, 0,
+            "an entry another writer already holds must be left to them"
+        );
+    }
+
     /// The claim a miss takes is released by the flush that writes it, so a
     /// response that is never enqueued must never claim.
     #[tokio::test]
@@ -4154,7 +4350,7 @@ mod tests {
             vec![],
         ));
         let in_flight: InFlightRevalidations =
-            Arc::new(Mutex::new(std::collections::HashSet::new()));
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
         let (batch_write_tx, handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
 
         let mut stream = CacheRefreshHelper::handle_cache_miss(
@@ -4182,7 +4378,7 @@ mod tests {
         handle.abort();
 
         assert!(
-            in_flight.lock().await.is_empty(),
+            in_flight.lock().is_empty(),
             "a key whose response was never enqueued must not stay claimed"
         );
     }
@@ -4198,7 +4394,7 @@ mod tests {
         let schema = origin.schema();
 
         #[expect(clippy::cast_possible_truncation)]
-        let fetched_long_ago = (SystemTime::now() - Duration::from_secs(3600))
+        let fetched_long_ago = (SystemTime::now() - Duration::from_hours(1))
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("clock")
             .as_nanos() as i64;
@@ -4229,6 +4425,7 @@ mod tests {
             "test_dataset",
             Duration::from_secs(1),
             Arc::new(Mutex::new(())),
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new())),
         )
         .await
         .expect("refresh");
@@ -4282,7 +4479,7 @@ mod tests {
             vec![],
         ));
         let in_flight: InFlightRevalidations =
-            Arc::new(Mutex::new(std::collections::HashSet::new()));
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
 
         let (batch_write_tx, _handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
 
@@ -4755,7 +4952,7 @@ mod write_path_tests {
             Arc::clone(accelerator),
             TableReference::bare("test_dataset"),
             Arc::new(Mutex::new(())),
-            Arc::new(Mutex::new(std::collections::HashSet::new())),
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new())),
             Arc::new(AtomicI64::new(0)),
             RuntimeStatus::new(),
         );

--- a/crates/runtime-table/src/accelerated/caching.rs
+++ b/crates/runtime-table/src/accelerated/caching.rs
@@ -218,6 +218,15 @@ pub struct CacheWriteRequest {
     pub filters: Vec<Expr>,
     /// Cache key computed from filters, used to track in-flight writes
     pub cache_key: String,
+    /// Whether rows for this key are already stored, so the write must remove
+    /// them before appending.
+    ///
+    /// A key nothing holds yet is appended with no delete. That matters more
+    /// than it looks: on Cayenne a `delete_from` first checkpoints the inline
+    /// memtable to a file, so deleting on every write — including the
+    /// overwhelming majority that cannot collide with anything — collapsed
+    /// measured ingest from thousands of entries per second to about ten.
+    pub replaces_existing: bool,
     /// Stable storage id of the originating namespace (see
     /// [`runtime_request_context::CacheNamespace::storage_id`]). Stamped into
     /// `__spice_cache_namespace` on every row at flush time and added to the
@@ -508,19 +517,11 @@ async fn flush_cache_writes(
 
         all_batches.extend(batches);
 
-        // Every write replaces its key, whether or not the sender believed the
-        // key was already cached. A write raised as a fresh insert can still
-        // collide: replacing an entry is a delete followed by an append, and a
-        // reader scanning in between sees no rows, reads it as a miss, and
-        // enqueues its own insert for the same key. Appending that blindly
-        // would leave the key with two copies of the response, which queries
-        // then return as duplicated source rows. Deleting the key first makes
-        // the write idempotent, and for a genuinely new key the delete matches
-        // nothing.
-        //
-        // A write with no filters at all cannot be scoped to a replacement, so
-        // appending is all that is available for it.
-        if !filters.is_empty() {
+        // Only a write that replaces stored rows deletes first: a delete for a
+        // key nothing holds matches nothing and is not free. Two writes racing
+        // to insert the same fresh key are prevented where the miss is
+        // enqueued, by the in-flight key set, rather than by deleting here.
+        if req.replaces_existing && !filters.is_empty() {
             replace_filters.push(filters);
         }
     }
@@ -1000,6 +1001,7 @@ impl CacheRefreshHelper {
             filters: filters.to_vec(),
             cache_key: cache_key.clone(),
             namespace_id: namespace.storage_id().into(),
+            replaces_existing: true,
         };
 
         batch_write_tx
@@ -1677,6 +1679,8 @@ impl CacheRefreshHelper {
     /// * `io_runtime` - Tokio runtime handle for spawning background write tasks.
     /// * `synchronized_children` - Child accelerators that should also receive the cached data.
     /// * `batch_write_tx` - Channel sender for batched writes to the caching consumer.
+    /// * `in_flight_revalidations` - Keys with a write already pending, so two
+    ///   readers missing the same key do not each append the response.
     #[expect(clippy::too_many_arguments)]
     async fn handle_cache_miss(
         federated: Arc<dyn TableProvider>,
@@ -1691,6 +1695,7 @@ impl CacheRefreshHelper {
         synchronized_children: SynchronizedChildren,
         batch_write_tx: CacheWriteSender,
         namespace: CacheNamespace,
+        in_flight_revalidations: InFlightRevalidations,
     ) -> SendableRecordBatchStream {
         match Self::fetch_from_source(&federated, dataset_name, filters, limit).await {
             Ok(batches) if !batches.is_empty() => {
@@ -1741,7 +1746,22 @@ impl CacheRefreshHelper {
                 let cache_key =
                     compute_cache_key_from_filters_and_namespace(filters, namespace.storage_id());
 
-                if batches_cacheable {
+                // Claim the key before enqueuing. Without this, two readers
+                // that miss the same key concurrently each append the response
+                // and the key ends up holding it twice — which queries return
+                // as duplicated source rows. The flush releases the claim once
+                // the write has landed.
+                let claimed = {
+                    let mut in_flight = in_flight_revalidations.lock().await;
+                    in_flight.insert(cache_key.clone())
+                };
+                if !claimed {
+                    tracing::debug!(
+                        "A write for this key is already pending for dataset={dataset_name}; not enqueuing a second copy"
+                    );
+                }
+
+                if batches_cacheable && claimed {
                     if batches.is_empty() {
                         tracing::debug!(
                             "Fetch returned no rows, skipping cache write for dataset={dataset_name}"
@@ -1760,6 +1780,7 @@ impl CacheRefreshHelper {
                             filters: filters.to_vec(),
                             cache_key,
                             namespace_id: namespace.storage_id().into(),
+                            replaces_existing: is_expired,
                         };
                         if let Err(e) = batch_write_tx.send(write_request).await {
                             tracing::warn!(
@@ -2259,6 +2280,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                             Arc::clone(&synchronized_children),
                             batch_write_tx.clone(),
                             namespace,
+                            Arc::clone(&in_flight_revalidations),
                         )
                         .await;
                     }
@@ -2297,6 +2319,7 @@ impl ExecutionPlan for CachingAccelerationScanExec {
                     synchronized_children,
                     batch_write_tx,
                     namespace,
+                    Arc::clone(&in_flight_revalidations),
                 )
                 .await
             }
@@ -3742,6 +3765,7 @@ mod tests {
                 filters: vec![],
                 cache_key: format!("key_{i}"),
                 namespace_id: "public".into(),
+                replaces_existing: false,
             })
             .await
             .expect("to send write request");
@@ -3797,6 +3821,7 @@ mod tests {
             Arc::new(vec![].into()),
             batch_write_tx.clone(),
             CacheNamespace::Public,
+            Arc::clone(&in_flight),
         )
         .await;
 
@@ -3835,6 +3860,7 @@ mod tests {
             Arc::new(vec![].into()),
             batch_write_tx,
             CacheNamespace::Public,
+            Arc::clone(&in_flight),
         )
         .await;
 
@@ -3923,6 +3949,7 @@ mod tests {
             Arc::new(vec![].into()),
             batch_write_tx,
             CacheNamespace::Public,
+            Arc::clone(&in_flight),
         )
         .await;
 
@@ -3968,6 +3995,7 @@ mod tests {
             Arc::new(vec![].into()),
             batch_write_tx,
             CacheNamespace::Public,
+            Arc::clone(&in_flight),
         )
         .await;
 
@@ -4010,6 +4038,66 @@ mod tests {
         assert_eq!(outcome.rows(), 0);
     }
 
+    /// The duplicate a fresh insert could cause is prevented where the miss is
+    /// enqueued, not by deleting on every write: two readers that miss the same
+    /// key concurrently must not each append the response.
+    #[tokio::test]
+    async fn a_second_reader_missing_the_same_key_does_not_enqueue_a_second_copy() {
+        use futures::StreamExt;
+
+        let http_source = Arc::new(MockHttpTableProvider::with_status(200, "body"));
+        let schema = http_source.schema();
+        let accelerator = Arc::new(MockAcceleratorTableProvider::new(
+            Arc::clone(&schema),
+            vec![],
+        ));
+        let in_flight: InFlightRevalidations =
+            Arc::new(Mutex::new(std::collections::HashSet::new()));
+        let (batch_write_tx, handle) = spawn_test_cache_write_consumer(&accelerator, &in_flight);
+
+        // Stand in for the first reader: its write for this key is already
+        // pending, so the claim is held.
+        let filters = vec![col("content").eq(lit("test"))];
+        let key = compute_cache_key_from_filters_and_namespace(
+            &filters,
+            CacheNamespace::Public.storage_id(),
+        );
+        in_flight.lock().await.insert(key);
+
+        let mut stream = CacheRefreshHelper::handle_cache_miss(
+            Arc::clone(&http_source) as Arc<dyn TableProvider>,
+            "test_dataset",
+            &filters,
+            None,
+            Arc::clone(&schema),
+            false,
+            false,
+            None,
+            &tokio::runtime::Handle::current(),
+            Arc::new(vec![].into()),
+            batch_write_tx,
+            CacheNamespace::Public,
+            Arc::clone(&in_flight),
+        )
+        .await;
+
+        // The caller is still served the response it fetched.
+        let mut served = 0;
+        while let Some(batch) = stream.next().await {
+            served += batch.expect("stream").num_rows();
+        }
+        assert!(served > 0, "the reader still gets its data");
+
+        drop(stream);
+        tokio::time::sleep(Duration::from_millis(CACHE_WRITE_FLUSH_INTERVAL_MS + 200)).await;
+        handle.abort();
+
+        assert!(
+            accelerator.get_data().is_empty(),
+            "the second reader must not write a second copy of the response"
+        );
+    }
+
     /// Test that 404 responses are cached.
     ///
     /// Simulates cache miss flow:
@@ -4048,6 +4136,7 @@ mod tests {
             Arc::new(vec![].into()), // synchronized_children
             batch_write_tx,
             CacheNamespace::Public,
+            Arc::clone(&in_flight),
         )
         .await;
 
@@ -4510,47 +4599,12 @@ mod write_path_tests {
     }
 
     #[tokio::test]
-    async fn a_write_raised_as_a_fresh_insert_still_replaces_its_key() {
-        // Replacing an entry is a delete followed by an append, so a reader
-        // scanning in between sees no rows for the key and reads it as a miss.
-        // The insert it then enqueues must not append a second copy beside the
-        // replacement — queries would return the response twice.
-        let (counting, accelerator) = accelerator_with(
-            vec![entry("/a", "already-cached")],
-            /* can_delete */ true,
-        );
-
-        let (tx, handle) = spawn_test_writer(&accelerator);
-        tx.send(CacheWriteRequest {
-            batches: vec![entry("/a", "raced-insert")],
-            filters: vec![col("request_path").eq(lit("/a"))],
-            // The sender believed this key was absent, because when it looked
-            // it was: the replacement's delete had landed and its append had
-            // not.
-            cache_key: "key".to_string(),
-            namespace_id: "public".into(),
-        })
-        .await
-        .expect("send");
-        drop(tx);
-        handle.await.expect("writer");
-
-        assert_eq!(
-            stored(&accelerator).await,
-            vec![("/a".to_string(), "raced-insert".to_string())],
-            "the key must hold one response, not two"
-        );
-        assert_eq!(
-            counting.deletes.load(Ordering::Relaxed),
-            1,
-            "an insert must still clear its key first"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_write_for_a_key_nothing_holds_yet_is_still_written() {
-        // The guard above must not cost a genuinely new entry its write.
-        let (_counting, accelerator) = accelerator_with(vec![], /* can_delete */ true);
+    async fn a_fresh_insert_appends_without_deleting() {
+        // A key nothing holds yet cannot collide, so the delete would match
+        // nothing — and on Cayenne a delete first checkpoints the inline
+        // memtable to a file, which collapsed measured ingest from thousands of
+        // entries per second to about ten when every write did one.
+        let (counting, accelerator) = accelerator_with(vec![], /* can_delete */ true);
 
         let (tx, handle) = spawn_test_writer(&accelerator);
         tx.send(CacheWriteRequest {
@@ -4558,6 +4612,7 @@ mod write_path_tests {
             filters: vec![col("request_path").eq(lit("/new"))],
             cache_key: "key".to_string(),
             namespace_id: "public".into(),
+            replaces_existing: false,
         })
         .await
         .expect("send");
@@ -4565,8 +4620,43 @@ mod write_path_tests {
         handle.await.expect("writer");
 
         assert_eq!(
+            counting.deletes.load(Ordering::Relaxed),
+            0,
+            "a fresh key must not pay for a delete"
+        );
+        assert_eq!(counting.appends.load(Ordering::Relaxed), 1);
+        assert_eq!(
             stored(&accelerator).await,
             vec![("/new".to_string(), "first".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn replacing_an_entry_deletes_first() {
+        let (counting, accelerator) =
+            accelerator_with(vec![entry("/a", "old-a"), entry("/b", "b")], true);
+
+        let (tx, handle) = spawn_test_writer(&accelerator);
+        tx.send(CacheWriteRequest {
+            batches: vec![entry("/a", "new-a")],
+            filters: vec![col("request_path").eq(lit("/a"))],
+            cache_key: "key".to_string(),
+            namespace_id: "public".into(),
+            replaces_existing: true,
+        })
+        .await
+        .expect("send");
+        drop(tx);
+        handle.await.expect("writer");
+
+        assert_eq!(counting.deletes.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            stored(&accelerator).await,
+            vec![
+                ("/a".to_string(), "new-a".to_string()),
+                ("/b".to_string(), "b".to_string()),
+            ],
+            "the key holds the new response only"
         );
     }
 

--- a/crates/runtime-table/src/accelerated/caching_eviction.rs
+++ b/crates/runtime-table/src/accelerated/caching_eviction.rs
@@ -164,7 +164,17 @@ impl CacheEvictionPredicate {
     /// Warns once, at startup, about configurations this can only partly
     /// enforce — so an operator learns it from the log rather than from
     /// unexplained growth.
-    pub fn warn_about_unenforceable(&self, accelerator: &Arc<dyn TableProvider>) {
+    ///
+    /// * `accelerator` - the storage the cache is held in, whose schema decides
+    ///   which entries can be identified and which payloads can be measured.
+    /// * `has_user_retention` - whether the dataset also sets `retention_period`
+    ///   or `retention_sql`. Those evict entries as well, so a cache with no
+    ///   budget of its own is not necessarily unbounded.
+    pub fn warn_about_unenforceable(
+        &self,
+        accelerator: &Arc<dyn TableProvider>,
+        has_user_retention: bool,
+    ) {
         let dataset_name = &self.dataset_name;
         let schema = accelerator.schema();
 
@@ -191,7 +201,7 @@ impl CacheEvictionPredicate {
             );
         }
 
-        if !self.limits.is_enforced() {
+        if !self.limits.is_enforced() && !has_user_retention {
             tracing::warn!(
                 "Dataset '{dataset_name}' sets `caching_stale_if_error: enabled` with no `caching_max_size` or `caching_max_items`, so no cached entry is ever evicted and the acceleration will grow without bound — expired entries are deliberately kept as fallback for a failing origin. Set a budget to bound it. For details, visit: https://spiceai.org/docs/components/data-accelerators/data-refresh#refresh-modes"
             );
@@ -1271,7 +1281,7 @@ mod tests {
         }
     }
 
-    /// One row for , fetched just now — what a refresh writes back.
+    /// One row for `path`, fetched just now — what a refresh writes back.
     fn refreshed_row(path: &str) -> RecordBatch {
         use arrow::array::{StringArray, TimestampNanosecondArray};
         RecordBatch::try_new(

--- a/crates/runtime-table/src/accelerated/caching_eviction.rs
+++ b/crates/runtime-table/src/accelerated/caching_eviction.rs
@@ -44,6 +44,7 @@ limitations under the License.
 //! Expiry runs first because it is free capacity: evicting a live entry while
 //! an expired one still occupies the budget would be a straight loss.
 
+use std::ops::Not;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -58,7 +59,11 @@ use datafusion::scalar::ScalarValue;
 use datafusion::sql::TableReference;
 use tokio::runtime::Handle;
 
-use super::RetentionPredicate;
+use datafusion::logical_expr::Operator;
+use util::timestamp_filter::TimestampFilterConvert;
+
+use super::{Retention, RetentionPredicate};
+use super::retention::create_timestamp_filter_converter;
 use super::caching::{
     CACHE_NAMESPACE_COLUMN, CACHE_REFRESHED_AT_COLUMN, REQUEST_KEY_COLUMNS, effective_max_age,
 };
@@ -73,13 +78,73 @@ use util::expr::combine_exprs_balanced;
 /// eviction saves. Overflow is not dropped — it is evicted by the next sweep,
 /// and the shortfall is logged rather than passed over in silence.
 ///
-/// This bounds *predicate width*, which is a hard limit rather than a taste:
-/// DataFusion walks an expression tree recursively, and a 50,000-wide `OR`
-/// overflowed the stack and aborted the process outright. It is deliberately not
-/// the mechanism that keeps a large cache within its budget — see
-/// [`bulk_cutoff`], which evicts any number of entries in one small predicate
-/// whenever it is provably safe to do so. This cap only bounds the fallback.
+/// The predicates are combined with [`combine_exprs_balanced`], so the tree is
+/// logarithmic in depth rather than linear — width, not nesting, is what this
+/// bounds. Raising it to 50,000 aborted a measured run with a stack overflow in
+/// a query worker; that was not root-caused to a specific frame, so the cap is
+/// kept as the conservative bound rather than on a mechanism this comment could
+/// name. Width is not free regardless: every term is translated and evaluated by
+/// the accelerator's own delete planner.
+///
+/// It is deliberately not the mechanism that keeps a large cache within its
+/// budget — see [`bulk_cutoff`], which evicts any number of entries in one small
+/// predicate whenever it is provably safe to do so. This cap only bounds the
+/// fallback.
 const MAX_ENTRIES_PER_SWEEP: usize = 512;
+
+/// The `Map` of response headers the HTTP connector stores beside every body.
+///
+/// Named here because [`unmeasurable_payload_columns`] has to recognise it to
+/// stay quiet about it; see that function for why.
+const RESPONSE_HEADERS_COLUMN: &str = "response_headers";
+
+/// The retention policy that bounds a caching accelerator.
+///
+/// Assembled here rather than in the accelerated-table builder because every
+/// rule in it is cache policy: which cadence wins, why the dataset's own
+/// `retention_check_enabled` does not gate it, and which configurations can
+/// only be partly enforced.
+///
+/// `dataset_retention` is the dataset's own `retention_period` /
+/// `retention_sql`, if it set any. Its filters are carried through and applied
+/// per entry rather than per row; see [`CacheEvictionPredicate`].
+pub fn retention(
+    limits: CacheLimits,
+    dataset_retention: Option<Retention>,
+    accelerator: &Arc<dyn TableProvider>,
+    dataset_name: &TableReference,
+    io_runtime: &Handle,
+) -> Retention {
+    let predicate = Arc::new(CacheEvictionPredicate::new(
+        dataset_name.clone(),
+        limits,
+        io_runtime.clone(),
+    ));
+
+    let sweep = sweep_interval(limits.ttl);
+    // Not built through `RetentionBuilder`, whose `enabled` flag governs the
+    // dataset's own retention rules: switching those off must not also switch
+    // off `caching_ttl`, `caching_max_size` and `caching_max_items`.
+    let (filters, check_interval) = match dataset_retention {
+        // Sweep at whichever cadence is tighter. The user's
+        // `retention_check_interval` must not slow the cache bounds down, and
+        // the cache's cadence must not make their retention rule run less often
+        // than they asked.
+        Some(retention) => (retention.filters, retention.check_interval.min(sweep)),
+        None => (Vec::new(), sweep),
+    };
+
+    // After the user's filters are known: a `retention_period` or
+    // `retention_sql` rule evicts entries too, so whether anything bounds the
+    // cache is not decidable from the cache's own limits.
+    predicate.warn_about_unenforceable(accelerator, !filters.is_empty());
+
+    Retention {
+        filters,
+        check_interval,
+        computed: Some(predicate),
+    }
+}
 
 /// The bounds a caching accelerator is held to, beyond its TTLs.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -225,23 +290,36 @@ impl RetentionPredicate for CacheEvictionPredicate {
 
         let schema = accelerator.schema();
         let key_columns = entry_key_columns(&schema);
-        let has_fetched_at = schema.column_with_name(CACHE_REFRESHED_AT_COLUMN).is_some();
+
+        // Every comparison against `_fetched_at` goes through the converter the
+        // retention loop's own time filter uses, so the predicate is built for
+        // the type the accelerator actually stores the column as. Cayenne keeps
+        // it in microseconds, and a `DuckDB` cast carrying a timezone has to be
+        // rendered as `AT TIME ZONE` (#12528) — neither is something a literal
+        // written here could know.
+        let refreshed_at =
+            create_timestamp_filter_converter(accelerator, CACHE_REFRESHED_AT_COLUMN, None, None, None);
+
+        // With `stale_if_error` an expired entry is deliberately kept as
+        // fallback for a failing origin, so there is no deadline to apply.
+        let cutoff = self
+            .limits
+            .stale_if_error
+            .not()
+            .then(|| expiry_cutoff(&self.limits))
+            .flatten()
+            .filter(|_| refreshed_at.is_some());
 
         if key_columns.is_empty() {
             // Nothing identifies an entry, so nothing can be evicted as one.
             // Expiry can still run row by row, safely: with no key there is no
             // entry to leave half of. The dataset's own retention predicate is
             // row-level already and passes through unchanged.
-            let expired = if self.limits.stale_if_error || !has_fetched_at {
-                None
-            } else {
-                expiry_cutoff(&self.limits).map(row_level_expiry_expr)
-            };
-            return Ok(match (configured, expired) {
-                (Some(a), Some(b)) => Some(a.or(b)),
-                (Some(only), None) | (None, Some(only)) => Some(only),
-                (None, None) => None,
-            });
+            let expired = cutoff.and_then(|cutoff| row_level_expiry_expr(&refreshed_at, cutoff));
+            return Ok(combine_exprs_balanced(
+                [configured, expired].into_iter().flatten().collect(),
+                Expr::or,
+            ));
         }
 
         let entries = rank_entries(
@@ -261,9 +339,6 @@ impl RetentionPredicate for CacheEvictionPredicate {
         //    past their window. Both are judged per entry: a row-level delete
         //    could take part of a multi-row response and leave the rest to be
         //    served as if it were whole.
-        let cutoff = (!self.limits.stale_if_error && has_fetched_at)
-            .then(|| expiry_cutoff(&self.limits))
-            .flatten();
         for entry in &entries {
             let retained_out = entry.matches_configured;
             let expired = cutoff.is_some_and(|cutoff| entry.expired_at(cutoff));
@@ -305,11 +380,10 @@ impl RetentionPredicate for CacheEvictionPredicate {
         // One range predicate when the doomed and surviving entries do not
         // overlap in fetch time: exact, and not bounded by how many entries it
         // covers.
-        if let Some(cutoff) = bulk_cutoff(&doomed, &survivors) {
-            return Ok(Some(
-                col(CACHE_REFRESHED_AT_COLUMN)
-                    .lt_eq(lit(ScalarValue::TimestampNanosecond(Some(cutoff), None))),
-            ));
+        if let Some(bulk) = bulk_cutoff(&doomed, &survivors)
+            && let Some(expr) = row_level_expiry_expr(&refreshed_at, bulk)
+        {
+            return Ok(Some(expr));
         }
 
         // Otherwise name each entry, bounded to the rows it held when ranked.
@@ -325,7 +399,7 @@ impl RetentionPredicate for CacheEvictionPredicate {
         }
         let predicates: Vec<Expr> = naming
             .iter()
-            .filter_map(|entry| entry_predicate(&entry.key, entry.newest))
+            .filter_map(|entry| entry_predicate(&entry.key, entry.newest, &refreshed_at))
             .collect();
         Ok(combine_exprs_balanced(predicates, Expr::or))
     }
@@ -339,8 +413,9 @@ impl RetentionPredicate for CacheEvictionPredicate {
 /// window is unservable on its own terms. A row with no fetch time goes too:
 /// there is no deadline to hold it to, and the read path already treats a null
 /// timestamp as expired.
-fn row_level_expiry_expr(cutoff: i64) -> Expr {
-    col(CACHE_REFRESHED_AT_COLUMN).lt_eq(lit(ScalarValue::TimestampNanosecond(Some(cutoff), None)))
+fn row_level_expiry_expr(refreshed_at: &Option<TimestampFilterConvert>, cutoff: i64) -> Option<Expr> {
+    let converter = refreshed_at.as_ref()?;
+    Some(converter.convert(u128::try_from(cutoff).ok()?, Operator::LtEq))
 }
 
 /// The instant before which an entry can no longer be served: `caching_ttl`
@@ -389,48 +464,59 @@ impl Budget {
 /// The caching accelerator's reserved columns are excluded, so the budget
 /// counts what was cached rather than the bookkeeping around it.
 fn payload_bytes_expr(schema: &arrow::datatypes::Schema) -> Option<Expr> {
+    payload_columns(schema)
+        .filter_map(|field| measured_bytes(&field))
+        .reduce(|acc, next| acc + next)
+}
+
+/// What one column contributes to an entry's measured size, or `None` if it
+/// cannot be weighed.
+///
+/// The single source for that rule: [`payload_bytes_expr`] sums what it returns
+/// and [`unmeasurable_payload_columns`] reports what it refuses, so the warning
+/// an operator reads cannot come to disagree with what the budget counts.
+fn measured_bytes(field: &arrow::datatypes::Field) -> Option<Expr> {
+    match field.data_type() {
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+            // `octet_length` is Int32 and NULL-propagating; widen it so a large
+            // cache cannot overflow the running sum, and give NULL a weight of
+            // zero rather than poisoning the row's total.
+            Some(coalesce(vec![
+                cast(octet_length(col(field.name())), DataType::Int64),
+                lit(0_i64),
+            ]))
+        }
+        other => other
+            .primitive_width()
+            .and_then(|width| i64::try_from(width).ok())
+            .map(lit),
+    }
+}
+
+/// The columns a budget is charged for: everything the cache stores except the
+/// accelerator's own bookkeeping.
+fn payload_columns(
+    schema: &arrow::datatypes::Schema,
+) -> impl Iterator<Item = arrow::datatypes::FieldRef> + '_ {
     schema
         .fields()
         .iter()
         .filter(|field| !super::caching::is_reserved_caching_column(field.name()))
-        .filter_map(|field| match field.data_type() {
-            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
-                // `octet_length` is Int32 and NULL-propagating; widen it so a
-                // large cache cannot overflow the running sum, and give NULL a
-                // weight of zero rather than poisoning the row's total.
-                Some(coalesce(vec![
-                    cast(octet_length(col(field.name())), DataType::Int64),
-                    lit(0_i64),
-                ]))
-            }
-            other => other
-                .primitive_width()
-                .and_then(|width| i64::try_from(width).ok())
-                .map(lit),
-        })
-        .reduce(|acc, next| acc + next)
+        .map(std::clone::Clone::clone)
 }
 
 /// Payload columns [`payload_bytes_expr`] cannot weigh, so `caching_max_size`
 /// under-counts by whatever they hold.
 ///
-/// `response_headers` is excluded deliberately: it is a `Map` on every HTTP
-/// response, it is small beside the body it accompanies, and reporting it would
-/// put a warning in the log of every ordinary caching dataset that sets a
+/// [`RESPONSE_HEADERS_COLUMN`] is excluded deliberately: it is a `Map` on every
+/// HTTP response, it is small beside the body it accompanies, and reporting it
+/// would put a warning in the log of every ordinary caching dataset that sets a
 /// budget — which is how a warning stops being read. Anything else nested is
 /// worth saying out loud, because it could be the payload itself.
 fn unmeasurable_payload_columns(schema: &arrow::datatypes::Schema) -> Vec<String> {
-    schema
-        .fields()
-        .iter()
-        .filter(|field| !super::caching::is_reserved_caching_column(field.name()))
-        .filter(|field| field.name() != "response_headers")
-        .filter(|field| {
-            !matches!(
-                field.data_type(),
-                DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
-            ) && field.data_type().primitive_width().is_none()
-        })
+    payload_columns(schema)
+        .filter(|field| field.name() != RESPONSE_HEADERS_COLUMN)
+        .filter(|field| measured_bytes(field).is_none())
         .map(|field| field.name().clone())
         .collect()
 }
@@ -498,10 +584,11 @@ fn nameable<'a>(doomed: &'a [&'a EntryCost]) -> (&'a [&'a EntryCost], usize) {
 ///
 /// Returns `None` if either side lacks a fetch time, or if the two overlap.
 fn bulk_cutoff(doomed: &[&EntryCost], survivors: &[&EntryCost]) -> Option<i64> {
-    let newest_doomed = doomed.iter().map(|e| e.newest).max().flatten()?;
-    if doomed.iter().any(|e| e.newest.is_none()) {
-        return None;
-    }
+    // `try_fold` on both sides: one pass each, and a missing fetch time on
+    // either stops it rather than being folded away.
+    let newest_doomed = doomed
+        .iter()
+        .try_fold(i64::MIN, |acc, e| e.newest.map(|n| acc.max(n)))?;
     let oldest_survivor = survivors
         .iter()
         .try_fold(i64::MAX, |acc, e| e.oldest.map(|o| acc.min(o)))?;
@@ -556,7 +643,6 @@ async fn rank_entries(
     // over the payload means reading every cached response body off disk, and
     // for a dataset with a TTL and no byte budget the figure is discarded.
     let size_expr = max_size_bytes.and_then(|_| payload_bytes_expr(schema));
-    let has_size = size_expr.is_some();
     let has_fetched_at = schema.column_with_name(CACHE_REFRESHED_AT_COLUMN).is_some();
 
     let mut aggregates = vec![count(lit(1)).alias("rows")];
@@ -569,7 +655,6 @@ async fn rank_entries(
         aggregates.push(min(col(CACHE_REFRESHED_AT_COLUMN)).alias("oldest"));
         aggregates.push(max(col(CACHE_REFRESHED_AT_COLUMN)).alias("newest"));
     }
-    let has_configured = configured.is_some();
     if let Some(configured) = configured {
         aggregates.push(bool_or(configured).alias("configured"));
     }
@@ -600,25 +685,16 @@ async fn rank_entries(
                 .iter()
                 .map(|name| (name.clone(), read_utf8(batch, name, row)))
                 .collect();
+            // Every reader resolves its column by name and answers `None` for
+            // one the aggregate did not produce, so an absent aggregate needs
+            // no flag of its own here.
             entries.push(EntryCost {
                 key,
                 rows: read_u64_at(batch, "rows", row).unwrap_or(0),
-                bytes: if has_size {
-                    read_u64_at(batch, "bytes", row).unwrap_or(0)
-                } else {
-                    0
-                },
-                oldest: if has_fetched_at {
-                    read_timestamp_nanos(batch, "oldest", row)
-                } else {
-                    None
-                },
-                newest: if has_fetched_at {
-                    read_timestamp_nanos(batch, "newest", row)
-                } else {
-                    None
-                },
-                matches_configured: has_configured && read_bool(batch, "configured", row),
+                bytes: read_u64_at(batch, "bytes", row).unwrap_or(0),
+                oldest: read_timestamp_nanos(batch, "oldest", row),
+                newest: read_timestamp_nanos(batch, "newest", row),
+                matches_configured: read_bool(batch, "configured", row),
             });
         }
     }
@@ -652,7 +728,11 @@ async fn rank_entries(
 /// and gets the bare identity predicate. Only an entry mixing timestamped and
 /// untimestamped rows keeps the untimestamped ones, which one fetch cannot
 /// produce.
-fn entry_predicate(key: &[(String, Option<String>)], ranked_newest: Option<i64>) -> Option<Expr> {
+fn entry_predicate(
+    key: &[(String, Option<String>)],
+    ranked_newest: Option<i64>,
+    refreshed_at: &Option<TimestampFilterConvert>,
+) -> Option<Expr> {
     let identity = key
         .iter()
         .map(|(name, value)| value.as_ref().map(|v| col(name).eq(lit(v.as_str()))))
@@ -660,16 +740,12 @@ fn entry_predicate(key: &[(String, Option<String>)], ranked_newest: Option<i64>)
         .into_iter()
         .reduce(Expr::and)?;
 
-    let Some(ranked_newest) = ranked_newest else {
+    let Some(bound) = ranked_newest.and_then(|newest| row_level_expiry_expr(refreshed_at, newest))
+    else {
         return Some(identity);
     };
 
-    Some(identity.and(
-        col(CACHE_REFRESHED_AT_COLUMN).lt_eq(lit(ScalarValue::TimestampNanosecond(
-            Some(ranked_newest),
-            None,
-        ))),
-    ))
+    Some(identity.and(bound))
 }
 
 /// The subset of [`REQUEST_KEY_COLUMNS`] this accelerator stores, plus the cache
@@ -936,12 +1012,17 @@ mod tests {
             .map(|name| (name, Some(String::new())))
             .collect();
 
+        let converter = refreshed_at_converter();
         let mut rendered = vec![
-            entry_predicate(&key, None).expect("identity").to_string(),
-            entry_predicate(&key, Some(1_700_000_000))
+            entry_predicate(&key, None, &converter)
+                .expect("identity")
+                .to_string(),
+            entry_predicate(&key, Some(1_700_000_000), &converter)
                 .expect("ranked")
                 .to_string(),
-            row_level_expiry_expr(1_700_000_000).to_string(),
+            row_level_expiry_expr(&converter, 1_700_000_000)
+                .expect("expiry")
+                .to_string(),
         ];
         if let Some(size) = payload_bytes_expr(&schema) {
             rendered.push(size.to_string());
@@ -966,7 +1047,7 @@ mod tests {
             ("request_path".to_string(), Some("/users".to_string())),
             ("request_query".to_string(), None),
         ];
-        assert!(entry_predicate(&with_null, None).is_none());
+        assert!(entry_predicate(&with_null, None, &refreshed_at_converter()).is_none());
 
         // The shape the HTTP connector actually stores: absent query and body
         // are empty strings, so they match by equality.
@@ -974,7 +1055,9 @@ mod tests {
             ("request_path".to_string(), Some("/users".to_string())),
             ("request_query".to_string(), Some(String::new())),
         ];
-        let rendered = entry_predicate(&empty, Some(10)).unwrap().to_string();
+        let rendered = entry_predicate(&empty, Some(10), &refreshed_at_converter())
+            .unwrap()
+            .to_string();
         assert!(
             !rendered.contains("IS NULL"),
             "no predicate this builds may contain IS NULL: {rendered}"
@@ -985,7 +1068,7 @@ mod tests {
     fn entry_predicate_of_an_empty_key_is_none() {
         // Guards the delete path: an unconstrained predicate would delete the
         // whole cache.
-        assert!(entry_predicate(&[], None).is_none());
+        assert!(entry_predicate(&[], None, &refreshed_at_converter()).is_none());
     }
 
     #[test]
@@ -1169,6 +1252,19 @@ mod tests {
     /// Builds an in-memory accelerator holding `rows`. `MemTable` implements
     /// `delete_from`, so the sweep exercises the same delete path a `DuckDB` or
     /// Cayenne accelerator takes.
+    /// The `_fetched_at` converter [`CacheEvictionPredicate::delete_expr`]
+    /// builds, for tests that call the predicate builders directly.
+    fn refreshed_at_converter() -> Option<TimestampFilterConvert> {
+        let accelerator = Arc::new(
+            data_components::arrow::write::MemTable::try_new(
+                Arc::new(http_cache_schema()),
+                vec![],
+            )
+            .expect("mem table"),
+        ) as Arc<dyn TableProvider>;
+        create_timestamp_filter_converter(&accelerator, CACHE_REFRESHED_AT_COLUMN, None, None, None)
+    }
+
     fn cache_table(rows: &[Row]) -> (Arc<dyn TableProvider>, Arc<FederatedTable>) {
         use arrow::array::{StringArray, TimestampNanosecondArray};
         use data_components::arrow::write::MemTable;
@@ -1347,7 +1443,7 @@ mod tests {
         let expr = combine_exprs_balanced(
             doomed
                 .iter()
-                .filter_map(|entry| entry_predicate(&entry.key, entry.newest))
+                .filter_map(|entry| entry_predicate(&entry.key, entry.newest, &refreshed_at_converter()))
                 .collect(),
             Expr::or,
         )

--- a/crates/runtime-table/src/accelerated/caching_eviction.rs
+++ b/crates/runtime-table/src/accelerated/caching_eviction.rs
@@ -70,8 +70,15 @@ use util::expr::combine_exprs_balanced;
 ///
 /// The predicate is an `OR` over per-entry equality tests, so it grows with the
 /// number of entries evicted; past some width the plan costs more than the
-/// eviction saves. Overflow is not dropped — it is simply evicted by the next
-/// sweep, and the shortfall is logged rather than passed over in silence.
+/// eviction saves. Overflow is not dropped — it is evicted by the next sweep,
+/// and the shortfall is logged rather than passed over in silence.
+///
+/// This bounds *predicate width*, which is a hard limit rather than a taste:
+/// DataFusion walks an expression tree recursively, and a 50,000-wide `OR`
+/// overflowed the stack and aborted the process outright. It is deliberately not
+/// the mechanism that keeps a large cache within its budget — see
+/// [`bulk_cutoff`], which evicts any number of entries in one small predicate
+/// whenever it is provably safe to do so. This cap only bounds the fallback.
 const MAX_ENTRIES_PER_SWEEP: usize = 512;
 
 /// The bounds a caching accelerator is held to, beyond its TTLs.
@@ -266,18 +273,16 @@ impl RetentionPredicate for CacheEvictionPredicate {
         .into_iter()
         .flatten()
         {
-            let Selection { keep, deferred } = select_doomed_refs(&survivors, budget);
+            let keep = select_doomed_refs(&survivors, budget);
             if keep == survivors.len() {
                 continue;
             }
-            if deferred > 0 {
-                tracing::info!(
-                    "Cache eviction for dataset '{dataset}' is evicting {evicting} entries to satisfy `{budget_name}`, leaving {deferred} more for the next sweep.",
-                    dataset = self.dataset_name,
-                    evicting = survivors.len() - keep,
-                    budget_name = budget.name(),
-                );
-            }
+            tracing::debug!(
+                "Cache eviction for dataset '{dataset}' is evicting {evicting} entries to satisfy `{budget_name}`.",
+                dataset = self.dataset_name,
+                evicting = survivors.len() - keep,
+                budget_name = budget.name(),
+            );
             // The evicted set is the tail, so the next budget sees exactly what
             // this one leaves behind without any recounting.
             doomed.extend(survivors.drain(keep..));
@@ -287,9 +292,28 @@ impl RetentionPredicate for CacheEvictionPredicate {
             return Ok(None);
         }
 
-        // One predicate naming every entry that goes, bounded to the rows each
-        // held when it was ranked.
-        let predicates: Vec<Expr> = doomed
+        // One range predicate when the doomed and surviving entries do not
+        // overlap in fetch time: exact, and not bounded by how many entries it
+        // covers.
+        if let Some(cutoff) = bulk_cutoff(&doomed, &survivors) {
+            return Ok(Some(
+                col(CACHE_REFRESHED_AT_COLUMN)
+                    .lt_eq(lit(ScalarValue::TimestampNanosecond(Some(cutoff), None))),
+            ));
+        }
+
+        // Otherwise name each entry, bounded to the rows it held when ranked.
+        // Oldest first, since the cap may not reach all of them this sweep.
+        let (naming, deferred) = nameable(&doomed);
+        if deferred > 0 {
+            tracing::info!(
+                "Cache eviction for dataset '{dataset}' cannot separate {total} over-budget entries from the ones it keeps by fetch time, so it is naming {naming} individually and leaving {deferred} for the next sweep.",
+                dataset = self.dataset_name,
+                total = doomed.len(),
+                naming = naming.len(),
+            );
+        }
+        let predicates: Vec<Expr> = naming
             .iter()
             .filter_map(|entry| entry_predicate(&entry.key, entry.newest))
             .collect();
@@ -306,9 +330,7 @@ impl RetentionPredicate for CacheEvictionPredicate {
 /// there is no deadline to hold it to, and the read path already treats a null
 /// timestamp as expired.
 fn row_level_expiry_expr(cutoff: i64) -> Expr {
-    col(CACHE_REFRESHED_AT_COLUMN)
-        .lt_eq(lit(ScalarValue::TimestampNanosecond(Some(cutoff), None)))
-        .or(col(CACHE_REFRESHED_AT_COLUMN).is_null())
+    col(CACHE_REFRESHED_AT_COLUMN).lt_eq(lit(ScalarValue::TimestampNanosecond(Some(cutoff), None)))
 }
 
 /// The instant before which an entry can no longer be served: `caching_ttl`
@@ -438,33 +460,59 @@ impl EntryCost {
     }
 }
 
-/// Where a budget cuts a ranked entry list.
+/// The slice of `doomed` one delete may name, and how many that leaves behind.
 ///
-/// An index rather than a second vector, because the evicted set is always a
-/// contiguous tail: the caller splits the list it already holds instead of
-/// re-deriving the boundary by comparing entries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct Selection {
-    /// How many of the most recent entries stay.
-    keep: usize,
-    /// How many the sweep left for the next tick, having capped the delete.
-    deferred: usize,
+/// Oldest first: `doomed` is ordered newest-first, so the tail is the oldest and
+/// the cap defers the *newest* of the doomed. Trimming the other end would keep
+/// the least valuable entries and re-doom the same ones every sweep.
+fn nameable<'a>(doomed: &'a [&'a EntryCost]) -> (&'a [&'a EntryCost], usize) {
+    let deferred = doomed.len().saturating_sub(MAX_ENTRIES_PER_SWEEP);
+    (&doomed[deferred..], deferred)
+}
+
+/// The `_fetched_at` cutoff that deletes exactly `doomed` and nothing else, when
+/// one exists.
+///
+/// Eviction normally names each entry by key, because a cached response can span
+/// rows with different fetch times and a range delete could cut one in half. But
+/// when every doomed entry's newest row is older than every survivor's oldest
+/// row, no entry straddles the boundary and `_fetched_at <= cutoff` selects the
+/// doomed set exactly — one small predicate instead of an `OR` per entry.
+///
+/// That matters because predicate width is capped by stack depth
+/// ([`MAX_ENTRIES_PER_SWEEP`]), so naming entries individually cannot evict
+/// faster than a few hundred per sweep — which a cache ingesting hundreds per
+/// second outruns forever. A workload that fetches new keys over time separates
+/// cleanly in fetch order, so this is the ordinary case and the per-key fallback
+/// is for the interleaved one.
+///
+/// Returns `None` if either side lacks a fetch time, or if the two overlap.
+fn bulk_cutoff(doomed: &[&EntryCost], survivors: &[&EntryCost]) -> Option<i64> {
+    let newest_doomed = doomed.iter().map(|e| e.newest).max().flatten()?;
+    if doomed.iter().any(|e| e.newest.is_none()) {
+        return None;
+    }
+    let oldest_survivor = survivors
+        .iter()
+        .try_fold(i64::MAX, |acc, e| e.oldest.map(|o| acc.min(o)))?;
+    (newest_doomed < oldest_survivor).then_some(newest_doomed)
 }
 
 /// Chooses which entries to evict from `entries`, which must be ordered
 /// most-recently-fetched first.
 ///
-/// Returns the doomed entries and how many more were left for the next sweep.
+/// Returns how many of the most recent entries stay; the rest are evicted. An
+/// index rather than a second vector, because the evicted set is always a
+/// contiguous tail.
 ///
 /// Eviction takes a contiguous *oldest* suffix rather than whatever happens not
 /// to fit, so the cache always holds the most recent entries it can afford. If
 /// more entries are doomed than one `DELETE` predicate should name, the
 /// **oldest** of them go first — trimming the other end would keep the least
 /// valuable entries and re-doom the same ones every sweep.
-fn select_doomed_refs(entries: &[&EntryCost], budget: Budget) -> Selection {
+fn select_doomed_refs(entries: &[&EntryCost], budget: Budget) -> usize {
     let allowance = budget.allowance();
     let mut spent: u64 = 0;
-    let mut first_doomed = entries.len();
 
     for (index, entry) in entries.iter().enumerate() {
         let cost = match budget {
@@ -472,19 +520,12 @@ fn select_doomed_refs(entries: &[&EntryCost], budget: Budget) -> Selection {
             Budget::Bytes(_) => entry.bytes,
         };
         if spent.saturating_add(cost) > allowance {
-            first_doomed = index;
-            break;
+            return index;
         }
         spent = spent.saturating_add(cost);
     }
 
-    // Take from the end: `entries` is newest-first, so the oldest are last, and
-    // the ones a capped sweep defers are the newest of the doomed.
-    let deferred = (entries.len() - first_doomed).saturating_sub(MAX_ENTRIES_PER_SWEEP);
-    Selection {
-        keep: first_doomed + deferred,
-        deferred,
-    }
+    entries.len()
 }
 
 /// Groups the stored rows into cache entries and orders them
@@ -578,9 +619,11 @@ async fn rank_entries(
 /// Builds `col = value AND ...` identifying exactly one cache entry, bounded to
 /// the rows that entry held when it was ranked.
 ///
-/// A NULL key component is matched with `IS NULL` rather than `= NULL`, which
-/// is never true and would leave the entry undeletable — an entry with no query
-/// string is the common case, not an edge one.
+/// An entry with a NULL key component is skipped rather than matched with
+/// `IS NULL`, because a delete naming many entries is one statement: an engine
+/// that rejects `IS NULL` rejects the whole thing, so emitting it would cost
+/// every entry's eviction to save one. HTTP metadata columns hold empty strings
+/// rather than NULLs, so this is an edge the shipped connectors do not reach.
 ///
 /// `ranked_newest` is what makes it safe to rank without holding the write
 /// lock. A refresh replaces an entry by deleting it and appending rows with a
@@ -591,31 +634,32 @@ async fn rank_entries(
 /// successfully refreshed response into a cache miss, which is precisely what
 /// `stale_if_error` exists to avoid during an origin outage.
 ///
-/// A row with no fetch time is included: it cannot have come from a refresh, and
-/// excluding it would leave part of the entry behind.
+/// Deliberately no `IS NULL` disjunct for a row with no fetch time: an
+/// accelerator's delete translator need not accept `IS NULL`, and the `DuckDB`
+/// one does not — emitting it failed every sweep with "Expression not
+/// supported" and evicted nothing at all. An entry whose rows *all* lack a
+/// fetch time is still removed whole, because it ranks with `newest = None`
+/// and gets the bare identity predicate. Only an entry mixing timestamped and
+/// untimestamped rows keeps the untimestamped ones, which one fetch cannot
+/// produce.
 fn entry_predicate(key: &[(String, Option<String>)], ranked_newest: Option<i64>) -> Option<Expr> {
     let identity = key
         .iter()
-        .map(|(name, value)| match value {
-            Some(value) => col(name).eq(lit(value.as_str())),
-            None => col(name).is_null(),
-        })
+        .map(|(name, value)| value.as_ref().map(|v| col(name).eq(lit(v.as_str()))))
+        .collect::<Option<Vec<_>>>()?
+        .into_iter()
         .reduce(Expr::and)?;
 
     let Some(ranked_newest) = ranked_newest else {
         return Some(identity);
     };
 
-    Some(
-        identity.and(
-            col(CACHE_REFRESHED_AT_COLUMN)
-                .lt_eq(lit(ScalarValue::TimestampNanosecond(
-                    Some(ranked_newest),
-                    None,
-                )))
-                .or(col(CACHE_REFRESHED_AT_COLUMN).is_null()),
-        ),
-    )
+    Some(identity.and(
+        col(CACHE_REFRESHED_AT_COLUMN).lt_eq(lit(ScalarValue::TimestampNanosecond(
+            Some(ranked_newest),
+            None,
+        ))),
+    ))
 }
 
 /// The subset of [`REQUEST_KEY_COLUMNS`] this accelerator stores, plus the cache
@@ -762,16 +806,168 @@ mod tests {
         assert!(entry_key_columns(&schema).is_empty());
     }
 
+    fn cost(oldest: Option<i64>, newest: Option<i64>) -> EntryCost {
+        EntryCost {
+            key: vec![("request_path".to_string(), Some("/x".to_string()))],
+            rows: 1,
+            bytes: 1,
+            oldest,
+            newest,
+            matches_configured: false,
+        }
+    }
+
     #[test]
-    fn entry_predicate_matches_a_null_component_with_is_null() {
-        let key = vec![
+    fn a_clean_separation_in_fetch_time_yields_one_range_predicate() {
+        // The ordinary case: entries fetched over time do not overlap, so the
+        // whole doomed set goes in one predicate rather than one per entry.
+        let doomed = [cost(Some(10), Some(20)), cost(Some(5), Some(15))];
+        let survivors = [cost(Some(30), Some(40)), cost(Some(50), Some(60))];
+        let d: Vec<&EntryCost> = doomed.iter().collect();
+        let s: Vec<&EntryCost> = survivors.iter().collect();
+        assert_eq!(bulk_cutoff(&d, &s), Some(20));
+    }
+
+    #[test]
+    fn an_overlapping_survivor_refuses_the_range_predicate() {
+        // A survivor with a row older than the newest doomed row would be
+        // caught by `_fetched_at <= cutoff`, so the range delete is not exact
+        // and must not be used.
+        let doomed = [cost(Some(10), Some(30))];
+        let survivors = [cost(Some(20), Some(40))];
+        let d: Vec<&EntryCost> = doomed.iter().collect();
+        let s: Vec<&EntryCost> = survivors.iter().collect();
+        assert_eq!(bulk_cutoff(&d, &s), None);
+    }
+
+    #[test]
+    fn a_missing_fetch_time_on_either_side_refuses_the_range_predicate() {
+        // Without a timestamp there is no boundary to reason about, and a row
+        // that cannot be placed must not be swept up by a range.
+        let d1 = [cost(Some(10), None)];
+        let s1 = [cost(Some(30), Some(40))];
+        assert_eq!(
+            bulk_cutoff(
+                &d1.iter().collect::<Vec<_>>(),
+                &s1.iter().collect::<Vec<_>>()
+            ),
+            None
+        );
+
+        let d2 = [cost(Some(10), Some(20))];
+        let s2 = [cost(None, Some(40))];
+        assert_eq!(
+            bulk_cutoff(
+                &d2.iter().collect::<Vec<_>>(),
+                &s2.iter().collect::<Vec<_>>()
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn evicting_everything_still_yields_a_range_predicate() {
+        // No survivors means no boundary to violate.
+        let doomed = [cost(Some(1), Some(2)), cost(Some(3), Some(4))];
+        let d: Vec<&EntryCost> = doomed.iter().collect();
+        assert_eq!(bulk_cutoff(&d, &[]), Some(4));
+    }
+
+    #[tokio::test]
+    async fn a_budget_evicts_far_more_entries_than_one_predicate_could_name() {
+        // The convergence property: naming entries individually is capped at
+        // MAX_ENTRIES_PER_SWEEP, so a cache well over budget could never catch
+        // up. With a clean fetch-time separation one sweep removes all of it.
+        let over = MAX_ENTRIES_PER_SWEEP * 3;
+        let rows: Vec<Row> = (0..over + 10)
+            .map(|i| Row {
+                path: Box::leak(format!("/e{i}").into_boxed_str()),
+                query: None,
+                // Distinct ages, newest last, so nothing overlaps.
+                age: Duration::from_secs((over + 10 - i) as u64),
+                content: "body",
+            })
+            .collect();
+        let (accelerator, federated) = cache_table(&rows);
+
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                max_items: Some(10),
+                ..no_expiry()
+            },
+        )
+        .await;
+
+        assert!(
+            deleted as usize > MAX_ENTRIES_PER_SWEEP,
+            "one sweep must be able to evict past the per-predicate cap, or a \
+             cache over budget never converges: deleted={deleted}"
+        );
+        assert_eq!(remaining(&accelerator).await.len(), 10);
+    }
+
+    /// Every predicate this module hands an accelerator must stay inside what a
+    /// real delete translator accepts.
+    ///
+    /// `MemTable`, which the tests above delete through, evaluates arbitrary
+    /// DataFusion expressions — so it accepted an `IS NULL` term that the DuckDB
+    /// accelerator rejects outright with "Expression not supported". A measured
+    /// run failed *every* sweep on that one term and evicted nothing at all,
+    /// while the suite was green. The test double being more capable than the
+    /// engine is what hid it, so this asserts on the predicate's shape rather
+    /// than on what a permissive double does with it.
+    #[test]
+    fn no_predicate_this_builds_contains_is_null() {
+        let schema = http_cache_schema();
+        let key: Vec<(String, Option<String>)> = entry_key_columns(&schema)
+            .into_iter()
+            .map(|name| (name, Some(String::new())))
+            .collect();
+
+        let mut rendered = vec![
+            entry_predicate(&key, None).expect("identity").to_string(),
+            entry_predicate(&key, Some(1_700_000_000))
+                .expect("ranked")
+                .to_string(),
+            row_level_expiry_expr(1_700_000_000).to_string(),
+        ];
+        if let Some(size) = payload_bytes_expr(&schema) {
+            rendered.push(size.to_string());
+        }
+
+        for expr in rendered {
+            assert!(
+                !expr.to_uppercase().contains("IS NULL"),
+                "an accelerator's delete translator need not accept IS NULL: {expr}"
+            );
+        }
+    }
+
+    #[test]
+    fn entry_predicate_never_emits_is_null() {
+        // A delete naming many entries is one statement, and an accelerator's
+        // delete translator need not accept `IS NULL` — the DuckDB one does not,
+        // and a single such term failed every sweep and evicted nothing at all.
+        // An entry with a NULL key component is therefore skipped rather than
+        // matched, which costs that entry's eviction instead of everyone's.
+        let with_null = vec![
             ("request_path".to_string(), Some("/users".to_string())),
             ("request_query".to_string(), None),
         ];
-        let rendered = entry_predicate(&key, None).unwrap().to_string();
+        assert!(entry_predicate(&with_null, None).is_none());
+
+        // The shape the HTTP connector actually stores: absent query and body
+        // are empty strings, so they match by equality.
+        let empty = vec![
+            ("request_path".to_string(), Some("/users".to_string())),
+            ("request_query".to_string(), Some(String::new())),
+        ];
+        let rendered = entry_predicate(&empty, Some(10)).unwrap().to_string();
         assert!(
-            rendered.contains("IS NULL"),
-            "a NULL key component must be matched with IS NULL, or the entry can never be evicted: {rendered}"
+            !rendered.contains("IS NULL"),
+            "no predicate this builds may contain IS NULL: {rendered}"
         );
     }
 
@@ -857,14 +1053,13 @@ mod tests {
             .collect()
     }
 
-    fn doomed_paths(entries: &[EntryCost], budget: Budget) -> (Vec<String>, usize) {
+    fn doomed_paths(entries: &[EntryCost], budget: Budget) -> Vec<String> {
         let refs: Vec<&EntryCost> = entries.iter().collect();
-        let Selection { keep, deferred } = select_doomed_refs(&refs, budget);
-        let paths = refs[keep..]
+        let keep = select_doomed_refs(&refs, budget);
+        refs[keep..]
             .iter()
             .filter_map(|e| e.key.first().and_then(|(_, v)| v.clone()))
-            .collect();
-        (paths, deferred)
+            .collect()
     }
 
     #[test]
@@ -872,15 +1067,14 @@ mod tests {
         // Entries are newest-first, so /0 is newest. A budget of 2 rows keeps
         // /0 and /1 and dooms the rest — not whichever happen to fit.
         let entries = ranked(&[(1, 10), (1, 10), (1, 10), (1, 10)]);
-        let (doomed, deferred) = doomed_paths(&entries, Budget::Items(2));
+        let doomed = doomed_paths(&entries, Budget::Items(2));
         assert_eq!(doomed, vec!["/2".to_string(), "/3".to_string()]);
-        assert_eq!(deferred, 0);
     }
 
     #[test]
     fn selection_charges_bytes_against_a_byte_budget() {
         let entries = ranked(&[(1, 100), (1, 100), (1, 100)]);
-        let (doomed, _) = doomed_paths(&entries, Budget::Bytes(250));
+        let doomed = doomed_paths(&entries, Budget::Bytes(250));
         assert_eq!(doomed, vec!["/2".to_string()]);
     }
 
@@ -888,14 +1082,8 @@ mod tests {
     fn selection_evicts_nothing_when_everything_fits() {
         let entries = ranked(&[(1, 10), (1, 10)]);
         let refs: Vec<&EntryCost> = entries.iter().collect();
-        assert_eq!(
-            select_doomed_refs(&refs, Budget::Items(10)).keep,
-            refs.len()
-        );
-        assert_eq!(
-            select_doomed_refs(&refs, Budget::Bytes(1024)).keep,
-            refs.len()
-        );
+        assert_eq!(select_doomed_refs(&refs, Budget::Items(10)), refs.len());
+        assert_eq!(select_doomed_refs(&refs, Budget::Bytes(1024)), refs.len());
     }
 
     #[test]
@@ -903,31 +1091,40 @@ mod tests {
         // Otherwise one oversized response would pin the cache over its budget
         // for good.
         let entries = ranked(&[(1, 5_000)]);
-        let (doomed, _) = doomed_paths(&entries, Budget::Bytes(1_000));
+        let doomed = doomed_paths(&entries, Budget::Bytes(1_000));
         assert_eq!(doomed, vec!["/0".to_string()]);
     }
 
     #[test]
-    fn an_overflowing_sweep_evicts_the_oldest_entries_first() {
-        // More entries are doomed than one DELETE should name. The ones that go
-        // must be the *oldest* — taking the other end would keep the least
-        // valuable entries and re-doom the same ones every sweep, so the cache
-        // would never converge on its budget.
+    fn selection_dooms_every_over_budget_entry_not_only_what_one_delete_can_name() {
+        // The cap belongs to how the delete is written, not to what is over
+        // budget. Capping here left over-budget entries among the survivors,
+        // where they overlapped the doomed in fetch time and forced the
+        // per-entry path forever — so a large cache could never converge.
         let count = MAX_ENTRIES_PER_SWEEP + 10;
         let entries = ranked(&vec![(1_u64, 10_u64); count]);
+        let doomed = doomed_paths(&entries, Budget::Items(0));
+        assert_eq!(doomed.len(), count, "every over-budget entry is doomed");
+    }
 
-        let (doomed, deferred) = doomed_paths(&entries, Budget::Items(0));
-        assert_eq!(doomed.len(), MAX_ENTRIES_PER_SWEEP);
+    #[test]
+    fn a_capped_delete_names_the_oldest_entries_first() {
+        // When entries cannot be separated by fetch time the delete names them
+        // individually, and the cap must trim the *newest* of the doomed:
+        // trimming the other end would keep the least valuable entries and
+        // re-doom the same ones every sweep.
+        let count = MAX_ENTRIES_PER_SWEEP + 10;
+        let entries = ranked(&vec![(1_u64, 10_u64); count]);
+        let refs: Vec<&EntryCost> = entries.iter().collect();
+
+        let (naming, deferred) = nameable(&refs);
+        assert_eq!(naming.len(), MAX_ENTRIES_PER_SWEEP);
         assert_eq!(deferred, 10);
+        let path = |e: &EntryCost| e.key[0].1.clone().unwrap_or_default();
+        assert_eq!(path(naming[naming.len() - 1]), format!("/{}", count - 1));
         assert_eq!(
-            doomed.last().map(String::as_str),
-            Some(format!("/{}", count - 1).as_str()),
-            "the oldest entry must be in this sweep"
-        );
-        assert_eq!(
-            doomed.first().map(String::as_str),
-            Some(format!("/{}", count - MAX_ENTRIES_PER_SWEEP).as_str()),
-            "the newest of the doomed entries are the ones deferred"
+            path(naming[0]),
+            format!("/{}", count - MAX_ENTRIES_PER_SWEEP)
         );
     }
 
@@ -974,9 +1171,11 @@ mod tests {
                     rows.iter().map(|r| r.path).collect::<Vec<_>>(),
                 )) as _,
                 Arc::new(StringArray::from(
-                    rows.iter().map(|r| r.query).collect::<Vec<_>>(),
+                    rows.iter()
+                        .map(|r| r.query.unwrap_or(""))
+                        .collect::<Vec<_>>(),
                 )) as _,
-                Arc::new(StringArray::from(vec![None::<&str>; rows.len()])) as _,
+                Arc::new(StringArray::from(vec![""; rows.len()])) as _,
                 Arc::new(StringArray::from(
                     rows.iter().map(|r| r.content).collect::<Vec<_>>(),
                 )) as _,
@@ -1011,7 +1210,9 @@ mod tests {
             for r in 0..batch.num_rows() {
                 out.push((
                     read_utf8(batch, "request_path", r).unwrap_or_default(),
-                    read_utf8(batch, "request_query", r),
+                    // The connector stores an absent query as an empty string;
+                    // report it as absent so assertions read as intent.
+                    read_utf8(batch, "request_query", r).filter(|q| !q.is_empty()),
                 ));
             }
         }
@@ -1077,8 +1278,8 @@ mod tests {
             Arc::new(http_cache_schema()),
             vec![
                 Arc::new(StringArray::from(vec![path])) as _,
-                Arc::new(StringArray::from(vec![None::<&str>])) as _,
-                Arc::new(StringArray::from(vec![None::<&str>])) as _,
+                Arc::new(StringArray::from(vec![""])) as _,
+                Arc::new(StringArray::from(vec![""])) as _,
                 Arc::new(StringArray::from(vec!["refreshed"])) as _,
                 Arc::new(TimestampNanosecondArray::from(vec![Some(nanos_ago(
                     Duration::ZERO,
@@ -1683,8 +1884,8 @@ mod tests {
             Arc::clone(&schema),
             vec![
                 Arc::new(StringArray::from(vec!["/live", "/dead"])) as _,
-                Arc::new(StringArray::from(vec![None::<&str>, None])) as _,
-                Arc::new(StringArray::from(vec![None::<&str>, None])) as _,
+                Arc::new(StringArray::from(vec!["", ""])) as _,
+                Arc::new(StringArray::from(vec!["", ""])) as _,
                 Arc::new(StringArray::from(vec!["a", "b"])) as _,
                 Arc::new(TimestampMicrosecondArray::from(vec![
                     Some(live_us),

--- a/crates/runtime-table/src/accelerated/caching_eviction.rs
+++ b/crates/runtime-table/src/accelerated/caching_eviction.rs
@@ -32,6 +32,25 @@ limitations under the License.
 //! 3. **Byte budget** — `caching_max_size`, measured by summing each row's
 //!    payload bytes.
 //!
+//! ## What a sweep costs
+//!
+//! Deriving rather than storing means each sweep asks the accelerator, and the
+//! question is a `GROUP BY` over every stored row. With a byte budget set it
+//! also sums `octet_length` over the payload columns, which reads every cached
+//! response body; without one that measurement is not requested at all, so a
+//! TTL-only cache pays for the grouping and not for the bodies. The interval
+//! floors at [`MIN_SWEEP_INTERVAL`], so the recurring cost scales with what is
+//! cached, not with what the workload is doing.
+//!
+//! That is the price of the trade below, and it is a real one: a measured run
+//! swept a 2,500,000-entry `DuckDB` acceleration every five minutes for 84
+//! minutes without failing, but the ranking materialises one record per entry
+//! while it runs. Deferring each entry's key strings until the delete actually
+//! names it — at most [`MAX_ENTRIES_PER_SWEEP`] of them, and none at all on the
+//! [`bulk_range`] path — would remove most of that, and is the identified next
+//! step. Keeping a running tally beside the table instead is the alternative
+//! this module exists to avoid; see below.
+//!
 //! Both the deadline and the size are *derived* rather than stored. A row's
 //! deadline is `_fetched_at + caching_ttl`, and `caching_ttl` is dataset
 //! configuration the sweep already has, so a stored copy would only be a
@@ -62,11 +81,11 @@ use tokio::runtime::Handle;
 use datafusion::logical_expr::Operator;
 use util::timestamp_filter::TimestampFilterConvert;
 
-use super::{Retention, RetentionPredicate};
-use super::retention::create_timestamp_filter_converter;
 use super::caching::{
     CACHE_NAMESPACE_COLUMN, CACHE_REFRESHED_AT_COLUMN, REQUEST_KEY_COLUMNS, effective_max_age,
 };
+use super::retention::create_timestamp_filter_converter;
+use super::{Retention, RetentionPredicate};
 use runtime_datafusion::session_config::get_df_default_config;
 use runtime_object_store::registry::default_runtime_env;
 use util::expr::combine_exprs_balanced;
@@ -297,8 +316,13 @@ impl RetentionPredicate for CacheEvictionPredicate {
         // it in microseconds, and a `DuckDB` cast carrying a timezone has to be
         // rendered as `AT TIME ZONE` (#12528) — neither is something a literal
         // written here could know.
-        let refreshed_at =
-            create_timestamp_filter_converter(accelerator, CACHE_REFRESHED_AT_COLUMN, None, None, None);
+        let refreshed_at = create_timestamp_filter_converter(
+            accelerator,
+            CACHE_REFRESHED_AT_COLUMN,
+            None,
+            None,
+            None,
+        );
 
         // With `stale_if_error` an expired entry is deliberately kept as
         // fallback for a failing origin, so there is no deadline to apply.
@@ -315,7 +339,8 @@ impl RetentionPredicate for CacheEvictionPredicate {
             // Expiry can still run row by row, safely: with no key there is no
             // entry to leave half of. The dataset's own retention predicate is
             // row-level already and passes through unchanged.
-            let expired = cutoff.and_then(|cutoff| row_level_expiry_expr(&refreshed_at, cutoff));
+            let expired =
+                cutoff.and_then(|cutoff| row_level_expiry_expr(refreshed_at.as_ref(), cutoff));
             return Ok(combine_exprs_balanced(
                 [configured, expired].into_iter().flatten().collect(),
                 Expr::or,
@@ -380,8 +405,8 @@ impl RetentionPredicate for CacheEvictionPredicate {
         // One range predicate when the doomed and surviving entries do not
         // overlap in fetch time: exact, and not bounded by how many entries it
         // covers.
-        if let Some(bulk) = bulk_cutoff(&doomed, &survivors)
-            && let Some(expr) = row_level_expiry_expr(&refreshed_at, bulk)
+        if let Some((from, to)) = bulk_range(&doomed, &survivors)
+            && let Some(expr) = fetched_at_between(refreshed_at.as_ref(), from, to)
         {
             return Ok(Some(expr));
         }
@@ -399,7 +424,7 @@ impl RetentionPredicate for CacheEvictionPredicate {
         }
         let predicates: Vec<Expr> = naming
             .iter()
-            .filter_map(|entry| entry_predicate(&entry.key, entry.newest, &refreshed_at))
+            .filter_map(|entry| entry_predicate(&entry.key, entry.newest, refreshed_at.as_ref()))
             .collect();
         Ok(combine_exprs_balanced(predicates, Expr::or))
     }
@@ -413,8 +438,11 @@ impl RetentionPredicate for CacheEvictionPredicate {
 /// window is unservable on its own terms. A row with no fetch time goes too:
 /// there is no deadline to hold it to, and the read path already treats a null
 /// timestamp as expired.
-fn row_level_expiry_expr(refreshed_at: &Option<TimestampFilterConvert>, cutoff: i64) -> Option<Expr> {
-    let converter = refreshed_at.as_ref()?;
+fn row_level_expiry_expr(
+    refreshed_at: Option<&TimestampFilterConvert>,
+    cutoff: i64,
+) -> Option<Expr> {
+    let converter = refreshed_at?;
     Some(converter.convert(u128::try_from(cutoff).ok()?, Operator::LtEq))
 }
 
@@ -508,11 +536,18 @@ fn payload_columns(
 /// Payload columns [`payload_bytes_expr`] cannot weigh, so `caching_max_size`
 /// under-counts by whatever they hold.
 ///
-/// [`RESPONSE_HEADERS_COLUMN`] is excluded deliberately: it is a `Map` on every
-/// HTTP response, it is small beside the body it accompanies, and reporting it
-/// would put a warning in the log of every ordinary caching dataset that sets a
-/// budget — which is how a warning stops being read. Anything else nested is
-/// worth saying out loud, because it could be the payload itself.
+/// [`RESPONSE_HEADERS_COLUMN`] is excluded from the *warning* deliberately: it
+/// is a `Map` on every HTTP response, so reporting it would put a line in the
+/// log of every ordinary caching dataset that sets a budget, telling the
+/// operator about a column they did not choose to store and cannot stop the
+/// connector storing — which is how a warning stops being read.
+///
+/// It is genuinely not counted, though, and an origin sending large or numerous
+/// headers therefore holds bytes the budget does not charge for. That shortfall
+/// is stated where an operator setting a budget will look for it, on
+/// `caching_max_size` itself, rather than as a warning they cannot act on.
+/// Anything else nested is worth saying out loud, because it could be the
+/// payload itself.
 fn unmeasurable_payload_columns(schema: &arrow::datatypes::Schema) -> Vec<String> {
     payload_columns(schema)
         .filter(|field| field.name() != RESPONSE_HEADERS_COLUMN)
@@ -566,33 +601,59 @@ fn nameable<'a>(doomed: &'a [&'a EntryCost]) -> (&'a [&'a EntryCost], usize) {
     (&doomed[deferred..], deferred)
 }
 
-/// The `_fetched_at` cutoff that deletes exactly `doomed` and nothing else, when
+/// The `_fetched_at` window that holds exactly `doomed` and no survivor, when
 /// one exists.
 ///
 /// Eviction normally names each entry by key, because a cached response can span
 /// rows with different fetch times and a range delete could cut one in half. But
 /// when every doomed entry's newest row is older than every survivor's oldest
-/// row, no entry straddles the boundary and `_fetched_at <= cutoff` selects the
-/// doomed set exactly — one small predicate instead of an `OR` per entry.
+/// row, no entry straddles the boundary and a range over the doomed entries'
+/// own fetch times selects them exactly — one small predicate instead of an
+/// `OR` per entry.
 ///
-/// That matters because predicate width is capped by stack depth
-/// ([`MAX_ENTRIES_PER_SWEEP`]), so naming entries individually cannot evict
-/// faster than a few hundred per sweep — which a cache ingesting hundreds per
-/// second outruns forever. A workload that fetches new keys over time separates
-/// cleanly in fetch order, so this is the ordinary case and the per-key fallback
-/// is for the interleaved one.
+/// That matters because predicate width is capped ([`MAX_ENTRIES_PER_SWEEP`]),
+/// so naming entries individually cannot evict faster than a few hundred per
+/// sweep — which a cache ingesting hundreds per second outruns forever. A
+/// workload that fetches new keys over time separates cleanly in fetch order,
+/// so this is the ordinary case and the per-key fallback is for the interleaved
+/// one.
+///
+/// The window is closed at **both** ends, which is what makes it safe to build
+/// from a ranking taken without the write lock. An open `_fetched_at <= cutoff`
+/// would also select anything arriving after the ranking with a fetch time
+/// below that cutoff — a row this sweep never measured and never decided about,
+/// and if it belonged to an entry whose other rows are newer, half of that entry
+/// would go and the rest would be served as though it were the whole response.
+/// Bounding below at the oldest row the ranking actually saw means the delete
+/// can only reach rows that were there when the decision was made.
 ///
 /// Returns `None` if either side lacks a fetch time, or if the two overlap.
-fn bulk_cutoff(doomed: &[&EntryCost], survivors: &[&EntryCost]) -> Option<i64> {
+fn bulk_range(doomed: &[&EntryCost], survivors: &[&EntryCost]) -> Option<(i64, i64)> {
     // `try_fold` on both sides: one pass each, and a missing fetch time on
     // either stops it rather than being folded away.
-    let newest_doomed = doomed
+    let (oldest_doomed, newest_doomed) = doomed
         .iter()
-        .try_fold(i64::MIN, |acc, e| e.newest.map(|n| acc.max(n)))?;
+        .try_fold((i64::MAX, i64::MIN), |(oldest, newest), entry| {
+            Some((oldest.min(entry.oldest?), newest.max(entry.newest?)))
+        })?;
     let oldest_survivor = survivors
         .iter()
         .try_fold(i64::MAX, |acc, e| e.oldest.map(|o| acc.min(o)))?;
-    (newest_doomed < oldest_survivor).then_some(newest_doomed)
+    (newest_doomed < oldest_survivor).then_some((oldest_doomed, newest_doomed))
+}
+
+/// `from <= _fetched_at <= to`, built for the column's stored type.
+fn fetched_at_between(
+    refreshed_at: Option<&TimestampFilterConvert>,
+    from: i64,
+    to: i64,
+) -> Option<Expr> {
+    let converter = refreshed_at?;
+    Some(
+        converter
+            .convert(u128::try_from(from).ok()?, Operator::GtEq)
+            .and(converter.convert(u128::try_from(to).ok()?, Operator::LtEq)),
+    )
 }
 
 /// Chooses which entries to evict from `entries`, which must be ordered
@@ -731,7 +792,7 @@ async fn rank_entries(
 fn entry_predicate(
     key: &[(String, Option<String>)],
     ranked_newest: Option<i64>,
-    refreshed_at: &Option<TimestampFilterConvert>,
+    refreshed_at: Option<&TimestampFilterConvert>,
 ) -> Option<Expr> {
     let identity = key
         .iter()
@@ -911,7 +972,51 @@ mod tests {
         let survivors = [cost(Some(30), Some(40)), cost(Some(50), Some(60))];
         let d: Vec<&EntryCost> = doomed.iter().collect();
         let s: Vec<&EntryCost> = survivors.iter().collect();
-        assert_eq!(bulk_cutoff(&d, &s), Some(20));
+        assert_eq!(bulk_range(&d, &s), Some((5, 20)));
+    }
+
+    #[test]
+    fn the_bulk_window_is_closed_below_the_oldest_row_the_ranking_saw() {
+        // The ranking is taken without the write lock, so rows can arrive after
+        // it. An open `_fetched_at <= cutoff` would select one stamped below
+        // that cutoff even though this sweep never measured it — and if its
+        // entry's other rows are newer, half the entry would go and the rest
+        // would be served as though it were the whole response.
+        let doomed = [cost(Some(10), Some(20)), cost(Some(14), Some(18))];
+        let survivors = [cost(Some(30), Some(40))];
+        let d: Vec<&EntryCost> = doomed.iter().collect();
+        let s: Vec<&EntryCost> = survivors.iter().collect();
+
+        let (from, to) = bulk_range(&d, &s).expect("range");
+        assert_eq!(
+            (from, to),
+            (10, 20),
+            "the window spans exactly the rows the ranking saw"
+        );
+
+        let arrived_after_the_ranking = 5;
+        assert!(
+            arrived_after_the_ranking < from,
+            "a row stamped before anything this sweep ranked is outside the window"
+        );
+    }
+
+    #[test]
+    fn the_bulk_predicate_bounds_both_ends() {
+        // Asserted on the predicate's shape rather than on what a permissive
+        // test double does with it: the lower bound is the whole guarantee, and
+        // dropping it would still pass every eviction test in this file.
+        let rendered = fetched_at_between(refreshed_at_converter().as_ref(), 10, 20)
+            .expect("predicate")
+            .to_string();
+        assert!(
+            rendered.contains(">="),
+            "the window must be closed below: {rendered}"
+        );
+        assert!(
+            rendered.contains("<="),
+            "the window must be closed above: {rendered}"
+        );
     }
 
     #[test]
@@ -923,7 +1028,7 @@ mod tests {
         let survivors = [cost(Some(20), Some(40))];
         let d: Vec<&EntryCost> = doomed.iter().collect();
         let s: Vec<&EntryCost> = survivors.iter().collect();
-        assert_eq!(bulk_cutoff(&d, &s), None);
+        assert_eq!(bulk_range(&d, &s), None);
     }
 
     #[test]
@@ -933,7 +1038,7 @@ mod tests {
         let d1 = [cost(Some(10), None)];
         let s1 = [cost(Some(30), Some(40))];
         assert_eq!(
-            bulk_cutoff(
+            bulk_range(
                 &d1.iter().collect::<Vec<_>>(),
                 &s1.iter().collect::<Vec<_>>()
             ),
@@ -943,7 +1048,7 @@ mod tests {
         let d2 = [cost(Some(10), Some(20))];
         let s2 = [cost(None, Some(40))];
         assert_eq!(
-            bulk_cutoff(
+            bulk_range(
                 &d2.iter().collect::<Vec<_>>(),
                 &s2.iter().collect::<Vec<_>>()
             ),
@@ -956,7 +1061,7 @@ mod tests {
         // No survivors means no boundary to violate.
         let doomed = [cost(Some(1), Some(2)), cost(Some(3), Some(4))];
         let d: Vec<&EntryCost> = doomed.iter().collect();
-        assert_eq!(bulk_cutoff(&d, &[]), Some(4));
+        assert_eq!(bulk_range(&d, &[]), Some((1, 4)));
     }
 
     #[tokio::test]
@@ -987,7 +1092,7 @@ mod tests {
         .await;
 
         assert!(
-            deleted as usize > MAX_ENTRIES_PER_SWEEP,
+            u64::try_from(MAX_ENTRIES_PER_SWEEP).is_ok_and(|cap| deleted > cap),
             "one sweep must be able to evict past the per-predicate cap, or a \
              cache over budget never converges: deleted={deleted}"
         );
@@ -998,8 +1103,8 @@ mod tests {
     /// real delete translator accepts.
     ///
     /// `MemTable`, which the tests above delete through, evaluates arbitrary
-    /// DataFusion expressions — so it accepted an `IS NULL` term that the DuckDB
-    /// accelerator rejects outright with "Expression not supported". A measured
+    /// `DataFusion` expressions — so it accepted an `IS NULL` term that the
+    /// `DuckDB` accelerator rejects outright with "Expression not supported". A measured
     /// run failed *every* sweep on that one term and evicted nothing at all,
     /// while the suite was green. The test double being more capable than the
     /// engine is what hid it, so this asserts on the predicate's shape rather
@@ -1014,13 +1119,13 @@ mod tests {
 
         let converter = refreshed_at_converter();
         let mut rendered = vec![
-            entry_predicate(&key, None, &converter)
+            entry_predicate(&key, None, converter.as_ref())
                 .expect("identity")
                 .to_string(),
-            entry_predicate(&key, Some(1_700_000_000), &converter)
+            entry_predicate(&key, Some(1_700_000_000), converter.as_ref())
                 .expect("ranked")
                 .to_string(),
-            row_level_expiry_expr(&converter, 1_700_000_000)
+            row_level_expiry_expr(converter.as_ref(), 1_700_000_000)
                 .expect("expiry")
                 .to_string(),
         ];
@@ -1047,7 +1152,7 @@ mod tests {
             ("request_path".to_string(), Some("/users".to_string())),
             ("request_query".to_string(), None),
         ];
-        assert!(entry_predicate(&with_null, None, &refreshed_at_converter()).is_none());
+        assert!(entry_predicate(&with_null, None, refreshed_at_converter().as_ref()).is_none());
 
         // The shape the HTTP connector actually stores: absent query and body
         // are empty strings, so they match by equality.
@@ -1055,7 +1160,7 @@ mod tests {
             ("request_path".to_string(), Some("/users".to_string())),
             ("request_query".to_string(), Some(String::new())),
         ];
-        let rendered = entry_predicate(&empty, Some(10), &refreshed_at_converter())
+        let rendered = entry_predicate(&empty, Some(10), refreshed_at_converter().as_ref())
             .unwrap()
             .to_string();
         assert!(
@@ -1068,7 +1173,7 @@ mod tests {
     fn entry_predicate_of_an_empty_key_is_none() {
         // Guards the delete path: an unconstrained predicate would delete the
         // whole cache.
-        assert!(entry_predicate(&[], None, &refreshed_at_converter()).is_none());
+        assert!(entry_predicate(&[], None, refreshed_at_converter().as_ref()).is_none());
     }
 
     #[test]
@@ -1256,11 +1361,8 @@ mod tests {
     /// builds, for tests that call the predicate builders directly.
     fn refreshed_at_converter() -> Option<TimestampFilterConvert> {
         let accelerator = Arc::new(
-            data_components::arrow::write::MemTable::try_new(
-                Arc::new(http_cache_schema()),
-                vec![],
-            )
-            .expect("mem table"),
+            data_components::arrow::write::MemTable::try_new(Arc::new(http_cache_schema()), vec![])
+                .expect("mem table"),
         ) as Arc<dyn TableProvider>;
         create_timestamp_filter_converter(&accelerator, CACHE_REFRESHED_AT_COLUMN, None, None, None)
     }
@@ -1443,7 +1545,9 @@ mod tests {
         let expr = combine_exprs_balanced(
             doomed
                 .iter()
-                .filter_map(|entry| entry_predicate(&entry.key, entry.newest, &refreshed_at_converter()))
+                .filter_map(|entry| {
+                    entry_predicate(&entry.key, entry.newest, refreshed_at_converter().as_ref())
+                })
                 .collect(),
             Expr::or,
         )

--- a/crates/runtime-table/src/accelerated/caching_eviction.rs
+++ b/crates/runtime-table/src/accelerated/caching_eviction.rs
@@ -1,0 +1,1718 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Bounding a `refresh_mode: caching` accelerator.
+//!
+//! Everything here is driven by queries against the accelerator itself rather
+//! than by bookkeeping held beside it. The accelerator is the cache, so what it
+//! currently holds is a question only it can answer — an in-memory tally would
+//! have to be rebuilt on restart, kept in step with every write path, and would
+//! disagree with the table the moment a row was evicted by anything else.
+//! Asking costs one aggregate per sweep and cannot drift.
+//!
+//! Three bounds are applied, in order:
+//!
+//! 1. **Expiry** — rows fetched longer ago than `caching_ttl` plus the
+//!    stale-while-revalidate window are deleted. They can no longer be served,
+//!    so keeping them only consumes budget.
+//! 2. **Item count** — `caching_max_items`.
+//! 3. **Byte budget** — `caching_max_size`, measured by summing each row's
+//!    payload bytes.
+//!
+//! Both the deadline and the size are *derived* rather than stored. A row's
+//! deadline is `_fetched_at + caching_ttl`, and `caching_ttl` is dataset
+//! configuration the sweep already has, so a stored copy would only be a
+//! denormalisation that can go stale against the config it came from. A row's
+//! size is `octet_length` over its own payload columns, which the engine
+//! computes during the same aggregate the sweep already runs, and which stays
+//! true if the rows are ever rewritten. Neither needs a storage column, so a
+//! caching accelerator's on-disk schema is unchanged.
+//!
+//! Expiry runs first because it is free capacity: evicting a live entry while
+//! an expired one still occupies the budget would be a straight loss.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use arrow::array::{Array, RecordBatch, StringArray};
+use arrow::datatypes::DataType;
+use datafusion::catalog::TableProvider;
+use datafusion::common::Result as DataFusionResult;
+use datafusion::functions::expr_fn::octet_length;
+use datafusion::functions_aggregate::expr_fn::{bool_or, count, max, min, sum};
+use datafusion::prelude::{Expr, SessionContext, cast, coalesce, col, lit};
+use datafusion::scalar::ScalarValue;
+use datafusion::sql::TableReference;
+use tokio::runtime::Handle;
+
+use super::RetentionPredicate;
+use super::caching::{
+    CACHE_NAMESPACE_COLUMN, CACHE_REFRESHED_AT_COLUMN, REQUEST_KEY_COLUMNS, effective_max_age,
+};
+use runtime_datafusion::session_config::get_df_default_config;
+use runtime_object_store::registry::default_runtime_env;
+use util::expr::combine_exprs_balanced;
+
+/// The most entries one sweep will name in a single `DELETE` predicate.
+///
+/// The predicate is an `OR` over per-entry equality tests, so it grows with the
+/// number of entries evicted; past some width the plan costs more than the
+/// eviction saves. Overflow is not dropped — it is simply evicted by the next
+/// sweep, and the shortfall is logged rather than passed over in silence.
+const MAX_ENTRIES_PER_SWEEP: usize = 512;
+
+/// The bounds a caching accelerator is held to, beyond its TTLs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CacheLimits {
+    /// `caching_max_size`: total bytes the stored rows may occupy.
+    pub max_size_bytes: Option<u64>,
+    /// `caching_max_items`: number of rows that may be stored.
+    pub max_items: Option<u64>,
+    /// `caching_ttl`: how long after it was fetched an entry stays fresh. With
+    /// `stale_while_revalidate` it gives the deadline past which an entry can
+    /// no longer be served and so no longer needs keeping.
+    pub ttl: Option<Duration>,
+    /// `caching_stale_while_revalidate_ttl`: how long past its TTL an entry
+    /// may still be served, and so how long past it the entry must be kept.
+    pub stale_while_revalidate: Option<Duration>,
+    /// `caching_stale_if_error`: whether an expired entry may still be served
+    /// when the origin is failing.
+    ///
+    /// This is why expiry alone cannot bound the cache. An entry kept as
+    /// error-fallback material is one the expiry sweep must not delete, so with
+    /// this enabled the byte and item budgets are the only thing standing
+    /// between the cache and unbounded growth.
+    pub stale_if_error: bool,
+}
+
+impl CacheLimits {
+    /// True when a sweep would do something. With `stale_if_error` disabled the
+    /// expiry sweep alone is worth running; with it enabled, only a configured
+    /// budget can remove anything — so a dataset for which this is false is one
+    /// nothing will ever evict from, the configuration #13525 describes.
+    #[must_use]
+    pub fn is_enforced(&self) -> bool {
+        self.max_size_bytes.is_some() || self.max_items.is_some() || !self.stale_if_error
+    }
+}
+
+/// Shortest interval between eviction sweeps. Sweeping much faster than the
+/// entry TTL finds nothing new to expire while still costing an aggregate over
+/// the whole table.
+const MIN_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Longest interval between eviction sweeps. A budget is only as tight as the
+/// sweep that enforces it — between sweeps the cache may overshoot by whatever
+/// the workload writes — so the interval is capped regardless of how long the
+/// TTL is. Deriving it from `caching_ttl` alone is what let a year-long
+/// stale-while-revalidate window schedule effectively one check ever.
+const MAX_SWEEP_INTERVAL: Duration = Duration::from_mins(5);
+
+/// How often to sweep, given the dataset's entry TTL.
+#[must_use]
+pub fn sweep_interval(caching_ttl: Option<Duration>) -> Duration {
+    caching_ttl
+        .unwrap_or(MIN_SWEEP_INTERVAL)
+        .clamp(MIN_SWEEP_INTERVAL, MAX_SWEEP_INTERVAL)
+}
+
+/// Bounds a `refresh_mode: caching` accelerator as a retention filter, so the
+/// cache is swept by the same loop, lock and index-aware delete every other
+/// dataset uses rather than by a second one beside it.
+///
+/// It resolves the whole decision itself and returns one predicate, because the
+/// three things it must apply are not independent: what expiry removes changes
+/// whether a budget is exceeded at all, and two filters computed against the
+/// same snapshot would each select entries the other was already deleting.
+#[derive(Debug)]
+pub struct CacheEvictionPredicate {
+    dataset_name: TableReference,
+    limits: CacheLimits,
+    io_runtime: Handle,
+}
+
+impl CacheEvictionPredicate {
+    #[must_use]
+    pub fn new(dataset_name: TableReference, limits: CacheLimits, io_runtime: Handle) -> Self {
+        Self {
+            dataset_name,
+            limits,
+            io_runtime,
+        }
+    }
+
+    /// Warns once, at startup, about configurations this can only partly
+    /// enforce — so an operator learns it from the log rather than from
+    /// unexplained growth.
+    pub fn warn_about_unenforceable(&self, accelerator: &Arc<dyn TableProvider>) {
+        let dataset_name = &self.dataset_name;
+        let schema = accelerator.schema();
+
+        if self.limits.max_size_bytes.is_some() {
+            let unmeasurable = unmeasurable_payload_columns(&schema);
+            if !unmeasurable.is_empty() {
+                tracing::warn!(
+                    "Cache dataset '{dataset_name}' stores column(s) {columns} whose size cannot be measured, so `caching_max_size` counts less than the acceleration actually holds and it may grow past the budget. Store the response as text to have it counted. For details, visit: https://spiceai.org/docs/components/data-accelerators/data-refresh#refresh-modes",
+                    columns = unmeasurable
+                        .iter()
+                        .map(|c| format!("'{c}'"))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+            }
+        }
+
+        if (self.limits.max_items.is_some() || self.limits.max_size_bytes.is_some())
+            && entry_key_columns(&schema).is_empty()
+        {
+            tracing::warn!(
+                "Cache dataset '{dataset_name}' stores none of the request columns that identify a cache entry ({keys}), so `caching_max_size` and `caching_max_items` cannot be enforced and the acceleration will keep growing. Remove the limits, or use a connector that records the request each row came from.",
+                keys = REQUEST_KEY_COLUMNS.join(", "),
+            );
+        }
+
+        if !self.limits.is_enforced() {
+            tracing::warn!(
+                "Dataset '{dataset_name}' sets `caching_stale_if_error: enabled` with no `caching_max_size` or `caching_max_items`, so no cached entry is ever evicted and the acceleration will grow without bound — expired entries are deliberately kept as fallback for a failing origin. Set a budget to bound it. For details, visit: https://spiceai.org/docs/components/data-accelerators/data-refresh#refresh-modes"
+            );
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RetentionPredicate for CacheEvictionPredicate {
+    async fn delete_expr(
+        &self,
+        accelerator: &Arc<dyn TableProvider>,
+        configured: Option<Expr>,
+    ) -> DataFusionResult<Option<Expr>> {
+        if !self.limits.is_enforced() && configured.is_none() {
+            // Nothing would ever be selected, so the whole-table aggregate below
+            // would run every tick to return an empty answer. Warned about at
+            // load; see `warn_about_unenforceable`.
+            return Ok(None);
+        }
+
+        let schema = accelerator.schema();
+        let key_columns = entry_key_columns(&schema);
+        let has_fetched_at = schema.column_with_name(CACHE_REFRESHED_AT_COLUMN).is_some();
+
+        if key_columns.is_empty() {
+            // Nothing identifies an entry, so nothing can be evicted as one.
+            // Expiry can still run row by row, safely: with no key there is no
+            // entry to leave half of. The dataset's own retention predicate is
+            // row-level already and passes through unchanged.
+            let expired = if self.limits.stale_if_error || !has_fetched_at {
+                None
+            } else {
+                expiry_cutoff(&self.limits).map(row_level_expiry_expr)
+            };
+            return Ok(match (configured, expired) {
+                (Some(a), Some(b)) => Some(a.or(b)),
+                (Some(only), None) | (None, Some(only)) => Some(only),
+                (None, None) => None,
+            });
+        }
+
+        let entries = rank_entries(
+            accelerator,
+            &self.io_runtime,
+            &key_columns,
+            &schema,
+            configured,
+            self.limits.max_size_bytes,
+        )
+        .await?;
+
+        let mut doomed: Vec<&EntryCost> = Vec::new();
+        let mut survivors: Vec<&EntryCost> = Vec::new();
+
+        // 1. Entries the dataset's own retention predicate matches, and entries
+        //    past their window. Both are judged per entry: a row-level delete
+        //    could take part of a multi-row response and leave the rest to be
+        //    served as if it were whole.
+        let cutoff = (!self.limits.stale_if_error && has_fetched_at)
+            .then(|| expiry_cutoff(&self.limits))
+            .flatten();
+        for entry in &entries {
+            let retained_out = entry.matches_configured;
+            let expired = cutoff.is_some_and(|cutoff| entry.expired_at(cutoff));
+            if retained_out || expired {
+                doomed.push(entry);
+            } else {
+                survivors.push(entry);
+            }
+        }
+
+        // 2. Budgets, over what step 1 leaves behind — so a budget is not
+        //    charged for entries that are going anyway.
+        for budget in [
+            self.limits.max_items.map(Budget::Items),
+            self.limits.max_size_bytes.map(Budget::Bytes),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let Selection { keep, deferred } = select_doomed_refs(&survivors, budget);
+            if keep == survivors.len() {
+                continue;
+            }
+            if deferred > 0 {
+                tracing::info!(
+                    "Cache eviction for dataset '{dataset}' is evicting {evicting} entries to satisfy `{budget_name}`, leaving {deferred} more for the next sweep.",
+                    dataset = self.dataset_name,
+                    evicting = survivors.len() - keep,
+                    budget_name = budget.name(),
+                );
+            }
+            // The evicted set is the tail, so the next budget sees exactly what
+            // this one leaves behind without any recounting.
+            doomed.extend(survivors.drain(keep..));
+        }
+
+        if doomed.is_empty() {
+            return Ok(None);
+        }
+
+        // One predicate naming every entry that goes, bounded to the rows each
+        // held when it was ranked.
+        let predicates: Vec<Expr> = doomed
+            .iter()
+            .filter_map(|entry| entry_predicate(&entry.key, entry.newest))
+            .collect();
+        Ok(combine_exprs_balanced(predicates, Expr::or))
+    }
+}
+
+/// Deletes rows past their window without regard to which entry they belong to.
+///
+/// Everywhere else in this module a range delete is exactly what must not
+/// happen. It is safe *here* only because the caller has established there are
+/// no request columns, so there is no entry to leave half of, and a row past its
+/// window is unservable on its own terms. A row with no fetch time goes too:
+/// there is no deadline to hold it to, and the read path already treats a null
+/// timestamp as expired.
+fn row_level_expiry_expr(cutoff: i64) -> Expr {
+    col(CACHE_REFRESHED_AT_COLUMN)
+        .lt_eq(lit(ScalarValue::TimestampNanosecond(Some(cutoff), None)))
+        .or(col(CACHE_REFRESHED_AT_COLUMN).is_null())
+}
+
+/// The instant before which an entry can no longer be served: `caching_ttl`
+/// plus the stale-while-revalidate grace, ago.
+fn expiry_cutoff(limits: &CacheLimits) -> Option<i64> {
+    let window = effective_max_age(limits.ttl) + limits.stale_while_revalidate.unwrap_or_default();
+    nanos_since_epoch(SystemTime::now().checked_sub(window)?)
+}
+
+/// Which budget a trim is enforcing, and what each entry costs against it.
+#[derive(Debug, Clone, Copy)]
+enum Budget {
+    Items(u64),
+    Bytes(u64),
+}
+
+impl Budget {
+    fn allowance(self) -> u64 {
+        match self {
+            Budget::Items(n) | Budget::Bytes(n) => n,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Budget::Items(_) => "caching_max_items",
+            Budget::Bytes(_) => "caching_max_size",
+        }
+    }
+}
+
+/// An expression giving one row's payload size in bytes, or `None` when the
+/// schema has no columns this can measure.
+///
+/// Text is measured exactly with `octet_length` and fixed-width columns
+/// contribute their width, which between them covers what a caching
+/// accelerator stores: an HTTP response body is text, and a body decomposed
+/// into columns is decomposed into text columns. Columns of neither kind are
+/// not counted — see [`unmeasurable_payload_columns`], which reports them so
+/// the shortfall is stated rather than silent.
+///
+/// The figure is a payload measure rather than an on-disk one, which is what
+/// `caching_max_size` bounds: the engine's own storage adds indexes and
+/// compression that nothing here could predict.
+///
+/// The caching accelerator's reserved columns are excluded, so the budget
+/// counts what was cached rather than the bookkeeping around it.
+fn payload_bytes_expr(schema: &arrow::datatypes::Schema) -> Option<Expr> {
+    schema
+        .fields()
+        .iter()
+        .filter(|field| !super::caching::is_reserved_caching_column(field.name()))
+        .filter_map(|field| match field.data_type() {
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+                // `octet_length` is Int32 and NULL-propagating; widen it so a
+                // large cache cannot overflow the running sum, and give NULL a
+                // weight of zero rather than poisoning the row's total.
+                Some(coalesce(vec![
+                    cast(octet_length(col(field.name())), DataType::Int64),
+                    lit(0_i64),
+                ]))
+            }
+            other => other
+                .primitive_width()
+                .and_then(|width| i64::try_from(width).ok())
+                .map(lit),
+        })
+        .reduce(|acc, next| acc + next)
+}
+
+/// Payload columns [`payload_bytes_expr`] cannot weigh, so `caching_max_size`
+/// under-counts by whatever they hold.
+///
+/// `response_headers` is excluded deliberately: it is a `Map` on every HTTP
+/// response, it is small beside the body it accompanies, and reporting it would
+/// put a warning in the log of every ordinary caching dataset that sets a
+/// budget — which is how a warning stops being read. Anything else nested is
+/// worth saying out loud, because it could be the payload itself.
+fn unmeasurable_payload_columns(schema: &arrow::datatypes::Schema) -> Vec<String> {
+    schema
+        .fields()
+        .iter()
+        .filter(|field| !super::caching::is_reserved_caching_column(field.name()))
+        .filter(|field| field.name() != "response_headers")
+        .filter(|field| {
+            !matches!(
+                field.data_type(),
+                DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+            ) && field.data_type().primitive_width().is_none()
+        })
+        .map(|field| field.name().clone())
+        .collect()
+}
+
+/// One cache entry as the ranking query sees it: its key values and what it
+/// costs against each budget.
+struct EntryCost {
+    key: Vec<(String, Option<String>)>,
+    rows: u64,
+    bytes: u64,
+    /// `min(_fetched_at)` over the entry's rows, or `None` where they carry no
+    /// fetch time. An entry is only as fresh as its least fresh row, which is
+    /// the same rule `check_cache_freshness` applies on read.
+    oldest: Option<i64>,
+    /// `max(_fetched_at)` over the entry's rows at the moment it was ranked.
+    ///
+    /// Carried into the delete predicate so a delete cannot take rows written
+    /// after the ranking that chose this entry. See [`entry_predicate`].
+    newest: Option<i64>,
+    /// True when the dataset's own retention predicate matched any row of this
+    /// entry.
+    ///
+    /// Judged per entry rather than per row: a retention rule that matches one
+    /// page of a paginated response must take the whole response, or the pages
+    /// it leaves behind would be served as though they were all there was.
+    matches_configured: bool,
+}
+
+impl EntryCost {
+    /// True when this entry can no longer be served, so keeping it only
+    /// consumes budget.
+    ///
+    /// An entry with no fetch time at all is expired: there is no deadline to
+    /// hold it to, and the read path treats a null timestamp as expired too.
+    fn expired_at(&self, cutoff: i64) -> bool {
+        self.oldest.is_none_or(|oldest| oldest <= cutoff)
+    }
+}
+
+/// Where a budget cuts a ranked entry list.
+///
+/// An index rather than a second vector, because the evicted set is always a
+/// contiguous tail: the caller splits the list it already holds instead of
+/// re-deriving the boundary by comparing entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Selection {
+    /// How many of the most recent entries stay.
+    keep: usize,
+    /// How many the sweep left for the next tick, having capped the delete.
+    deferred: usize,
+}
+
+/// Chooses which entries to evict from `entries`, which must be ordered
+/// most-recently-fetched first.
+///
+/// Returns the doomed entries and how many more were left for the next sweep.
+///
+/// Eviction takes a contiguous *oldest* suffix rather than whatever happens not
+/// to fit, so the cache always holds the most recent entries it can afford. If
+/// more entries are doomed than one `DELETE` predicate should name, the
+/// **oldest** of them go first — trimming the other end would keep the least
+/// valuable entries and re-doom the same ones every sweep.
+fn select_doomed_refs(entries: &[&EntryCost], budget: Budget) -> Selection {
+    let allowance = budget.allowance();
+    let mut spent: u64 = 0;
+    let mut first_doomed = entries.len();
+
+    for (index, entry) in entries.iter().enumerate() {
+        let cost = match budget {
+            Budget::Items(_) => entry.rows,
+            Budget::Bytes(_) => entry.bytes,
+        };
+        if spent.saturating_add(cost) > allowance {
+            first_doomed = index;
+            break;
+        }
+        spent = spent.saturating_add(cost);
+    }
+
+    // Take from the end: `entries` is newest-first, so the oldest are last, and
+    // the ones a capped sweep defers are the newest of the doomed.
+    let deferred = (entries.len() - first_doomed).saturating_sub(MAX_ENTRIES_PER_SWEEP);
+    Selection {
+        keep: first_doomed + deferred,
+        deferred,
+    }
+}
+
+/// Groups the stored rows into cache entries and orders them
+/// most-recently-fetched first, with what each one costs against either budget.
+///
+/// This is the sweep's only pass over the accelerator, so it collects
+/// everything both budgets need at once: a row count, a payload-byte total, and
+/// the key to name the entry in a `DELETE`.
+async fn rank_entries(
+    accelerator: &Arc<dyn TableProvider>,
+    io_runtime: &Handle,
+    key_columns: &[String],
+    schema: &arrow::datatypes::Schema,
+    configured: Option<Expr>,
+    max_size_bytes: Option<u64>,
+) -> DataFusionResult<Vec<EntryCost>> {
+    // Only measured when something charges against it. Summing `octet_length`
+    // over the payload means reading every cached response body off disk, and
+    // for a dataset with a TTL and no byte budget the figure is discarded.
+    let size_expr = max_size_bytes.and_then(|_| payload_bytes_expr(schema));
+    let has_size = size_expr.is_some();
+    let has_fetched_at = schema.column_with_name(CACHE_REFRESHED_AT_COLUMN).is_some();
+
+    let mut aggregates = vec![count(lit(1)).alias("rows")];
+    if let Some(size_expr) = size_expr {
+        aggregates.push(sum(size_expr).alias("bytes"));
+    }
+    if has_fetched_at {
+        // Rank on — and expire by — the entry's *oldest* page: an entry is only
+        // as fresh as the least fresh row a query would be served from it.
+        aggregates.push(min(col(CACHE_REFRESHED_AT_COLUMN)).alias("oldest"));
+        aggregates.push(max(col(CACHE_REFRESHED_AT_COLUMN)).alias("newest"));
+    }
+    let has_configured = configured.is_some();
+    if let Some(configured) = configured {
+        aggregates.push(bool_or(configured).alias("configured"));
+    }
+
+    // Built the way every other query against this accelerator is, so the
+    // aggregate is planned with the runtime's config and object-store registry
+    // and can be pushed down to the engine holding the data. A bare
+    // `SessionContext` would pull every payload column of every cached row
+    // through DataFusion to produce two numbers.
+    let ctx = SessionContext::new_with_config_rt(
+        get_df_default_config(),
+        default_runtime_env(io_runtime.clone()),
+    );
+    let mut df = ctx
+        .read_table(Arc::clone(accelerator))?
+        .aggregate(key_columns.iter().map(col).collect(), aggregates)?;
+
+    if has_fetched_at {
+        df = df.sort(vec![col("oldest").sort(false, false)])?;
+    }
+
+    let batches = df.collect().await?;
+
+    let mut entries = Vec::new();
+    for batch in &batches {
+        for row in 0..batch.num_rows() {
+            let key = key_columns
+                .iter()
+                .map(|name| (name.clone(), read_utf8(batch, name, row)))
+                .collect();
+            entries.push(EntryCost {
+                key,
+                rows: read_u64_at(batch, "rows", row).unwrap_or(0),
+                bytes: if has_size {
+                    read_u64_at(batch, "bytes", row).unwrap_or(0)
+                } else {
+                    0
+                },
+                oldest: if has_fetched_at {
+                    read_timestamp_nanos(batch, "oldest", row)
+                } else {
+                    None
+                },
+                newest: if has_fetched_at {
+                    read_timestamp_nanos(batch, "newest", row)
+                } else {
+                    None
+                },
+                matches_configured: has_configured && read_bool(batch, "configured", row),
+            });
+        }
+    }
+
+    Ok(entries)
+}
+
+/// Builds `col = value AND ...` identifying exactly one cache entry, bounded to
+/// the rows that entry held when it was ranked.
+///
+/// A NULL key component is matched with `IS NULL` rather than `= NULL`, which
+/// is never true and would leave the entry undeletable — an entry with no query
+/// string is the common case, not an edge one.
+///
+/// `ranked_newest` is what makes it safe to rank without holding the write
+/// lock. A refresh replaces an entry by deleting it and appending rows with a
+/// newer `_fetched_at`, so an entry refreshed between the ranking and the delete
+/// has no row at or below the timestamp it was ranked at, and the predicate
+/// matches nothing — the entry survives whole rather than being deleted out from
+/// under the refresh that just repaired it. Without this a sweep could turn a
+/// successfully refreshed response into a cache miss, which is precisely what
+/// `stale_if_error` exists to avoid during an origin outage.
+///
+/// A row with no fetch time is included: it cannot have come from a refresh, and
+/// excluding it would leave part of the entry behind.
+fn entry_predicate(key: &[(String, Option<String>)], ranked_newest: Option<i64>) -> Option<Expr> {
+    let identity = key
+        .iter()
+        .map(|(name, value)| match value {
+            Some(value) => col(name).eq(lit(value.as_str())),
+            None => col(name).is_null(),
+        })
+        .reduce(Expr::and)?;
+
+    let Some(ranked_newest) = ranked_newest else {
+        return Some(identity);
+    };
+
+    Some(
+        identity.and(
+            col(CACHE_REFRESHED_AT_COLUMN)
+                .lt_eq(lit(ScalarValue::TimestampNanosecond(
+                    Some(ranked_newest),
+                    None,
+                )))
+                .or(col(CACHE_REFRESHED_AT_COLUMN).is_null()),
+        ),
+    )
+}
+
+/// The subset of [`REQUEST_KEY_COLUMNS`] this accelerator stores, plus the cache
+/// namespace when present.
+///
+/// The namespace belongs in the key: two principals can hold entries under the
+/// same request key, and evicting by request alone would take out a row the
+/// budget never charged to that entry.
+fn entry_key_columns(schema: &arrow::datatypes::Schema) -> Vec<String> {
+    let mut columns: Vec<String> = REQUEST_KEY_COLUMNS
+        .iter()
+        .filter(|name| is_utf8_column(schema, name))
+        .map(|name| (*name).to_string())
+        .collect();
+
+    if !columns.is_empty() && is_utf8_column(schema, CACHE_NAMESPACE_COLUMN) {
+        columns.push(CACHE_NAMESPACE_COLUMN.to_string());
+    }
+
+    columns
+}
+
+/// Key columns are read back as strings to rebuild the delete predicate, so a
+/// column of another type is not one this eviction can key on.
+fn is_utf8_column(schema: &arrow::datatypes::Schema, name: &str) -> bool {
+    schema
+        .column_with_name(name)
+        .is_some_and(|(_, field)| matches!(field.data_type(), DataType::Utf8 | DataType::LargeUtf8))
+}
+
+fn nanos_since_epoch(time: SystemTime) -> Option<i64> {
+    i64::try_from(time.duration_since(SystemTime::UNIX_EPOCH).ok()?.as_nanos()).ok()
+}
+
+/// Reads a non-negative count out of an aggregate result, whatever integer
+/// width the engine produced it as.
+fn read_u64_at(batch: &RecordBatch, name: &str, row: usize) -> Option<u64> {
+    let array = batch.column_by_name(name)?;
+    if !array.is_valid(row) {
+        return None;
+    }
+    let scalar = ScalarValue::try_from_array(array, row).ok()?;
+    match scalar {
+        ScalarValue::UInt64(Some(v)) => Some(v),
+        ScalarValue::Int64(Some(v)) => u64::try_from(v).ok(),
+        ScalarValue::UInt32(Some(v)) => Some(u64::from(v)),
+        ScalarValue::Int32(Some(v)) => u64::try_from(v).ok(),
+        ScalarValue::Decimal128(Some(v), _, 0) => u64::try_from(v).ok(),
+        _ => None,
+    }
+}
+
+/// Reads a boolean aggregate, treating NULL (no rows matched) as false.
+fn read_bool(batch: &RecordBatch, name: &str, row: usize) -> bool {
+    batch
+        .column_by_name(name)
+        .filter(|array| array.is_valid(row))
+        .and_then(|array| ScalarValue::try_from_array(array, row).ok())
+        .is_some_and(|scalar| matches!(scalar, ScalarValue::Boolean(Some(true))))
+}
+
+/// Reads a timestamp aggregate back as nanoseconds, whatever precision the
+/// engine stored it at — Cayenne keeps microseconds.
+fn read_timestamp_nanos(batch: &RecordBatch, name: &str, row: usize) -> Option<i64> {
+    let array = batch.column_by_name(name)?;
+    if !array.is_valid(row) {
+        return None;
+    }
+    match ScalarValue::try_from_array(array, row).ok()? {
+        ScalarValue::TimestampNanosecond(v, _) => v,
+        ScalarValue::TimestampMicrosecond(v, _) => v.map(|v| v.saturating_mul(1_000)),
+        ScalarValue::TimestampMillisecond(v, _) => v.map(|v| v.saturating_mul(1_000_000)),
+        ScalarValue::TimestampSecond(v, _) => v.map(|v| v.saturating_mul(1_000_000_000)),
+        _ => None,
+    }
+}
+
+fn read_utf8(batch: &RecordBatch, name: &str, row: usize) -> Option<String> {
+    let array = batch.column_by_name(name)?;
+    if !array.is_valid(row) {
+        return None;
+    }
+    array
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .map(|a| a.value(row).to_string())
+        .or_else(|| {
+            ScalarValue::try_from_array(array, row)
+                .ok()
+                .and_then(|s| match s {
+                    ScalarValue::Utf8(v) | ScalarValue::LargeUtf8(v) => v,
+                    _ => None,
+                })
+        })
+}
+
+#[expect(clippy::unwrap_used, reason = "test helpers")]
+#[cfg(test)]
+mod tests {
+    use super::super::caching::CacheRefreshHelper;
+    use super::super::retention::apply_retention_filters_once;
+    use super::*;
+    use crate::federated::FederatedTable;
+    use arrow::datatypes::{Field, Schema, TimeUnit};
+
+    fn http_cache_schema() -> Schema {
+        Schema::new(vec![
+            Field::new("request_path", DataType::Utf8, false),
+            Field::new("request_query", DataType::Utf8, true),
+            Field::new("request_body", DataType::Utf8, true),
+            Field::new("content", DataType::Utf8, false),
+            Field::new(
+                CACHE_REFRESHED_AT_COLUMN,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+            Field::new(CACHE_NAMESPACE_COLUMN, DataType::Utf8, false),
+        ])
+    }
+
+    #[test]
+    fn entry_key_includes_the_namespace_so_one_principal_does_not_evict_another() {
+        let columns = entry_key_columns(&http_cache_schema());
+        assert_eq!(
+            columns,
+            vec![
+                "request_path".to_string(),
+                "request_query".to_string(),
+                "request_body".to_string(),
+                CACHE_NAMESPACE_COLUMN.to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn entry_key_is_empty_without_request_columns() {
+        // A non-HTTP caching dataset has no request key, so eviction must fall
+        // back rather than key on the namespace alone — which would evict every
+        // entry a principal owns at once.
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(CACHE_NAMESPACE_COLUMN, DataType::Utf8, false),
+        ]);
+        assert!(entry_key_columns(&schema).is_empty());
+    }
+
+    #[test]
+    fn entry_predicate_matches_a_null_component_with_is_null() {
+        let key = vec![
+            ("request_path".to_string(), Some("/users".to_string())),
+            ("request_query".to_string(), None),
+        ];
+        let rendered = entry_predicate(&key, None).unwrap().to_string();
+        assert!(
+            rendered.contains("IS NULL"),
+            "a NULL key component must be matched with IS NULL, or the entry can never be evicted: {rendered}"
+        );
+    }
+
+    #[test]
+    fn entry_predicate_of_an_empty_key_is_none() {
+        // Guards the delete path: an unconstrained predicate would delete the
+        // whole cache.
+        assert!(entry_predicate(&[], None).is_none());
+    }
+
+    #[test]
+    fn expiry_alone_is_worth_sweeping_for() {
+        // Default (`stale_if_error` disabled, no budgets) still expires rows,
+        // which is the retention the caching accelerator has always needed.
+        assert!(CacheLimits::default().is_enforced());
+    }
+
+    #[test]
+    fn stale_if_error_without_a_budget_is_the_unbounded_case() {
+        // Regression guard for #13525: `stale_if_error` keeps expired entries
+        // servable, so with no budget nothing can ever remove one.
+        let limits = CacheLimits {
+            stale_if_error: true,
+            ..Default::default()
+        };
+        assert!(
+            !limits.is_enforced(),
+            "nothing would ever evict from this cache"
+        );
+
+        // A budget makes it bounded again — and enforced.
+        for bounded in [
+            CacheLimits {
+                stale_if_error: true,
+                max_items: Some(10),
+                ..Default::default()
+            },
+            CacheLimits {
+                stale_if_error: true,
+                max_size_bytes: Some(1024),
+                ..Default::default()
+            },
+        ] {
+            assert!(bounded.is_enforced());
+        }
+    }
+
+    #[test]
+    fn sweep_interval_is_clamped_at_both_ends() {
+        // A one-second TTL must not schedule a sweep every second...
+        assert_eq!(
+            sweep_interval(Some(Duration::from_secs(1))),
+            MIN_SWEEP_INTERVAL
+        );
+        // ...and a year-long one must not schedule effectively one sweep ever,
+        // which is what deriving the interval straight from the TTL did.
+        assert_eq!(
+            sweep_interval(Some(Duration::from_hours(365 * 24))),
+            MAX_SWEEP_INTERVAL
+        );
+        assert_eq!(
+            sweep_interval(Some(Duration::from_secs(90))),
+            Duration::from_secs(90)
+        );
+        assert_eq!(sweep_interval(None), MIN_SWEEP_INTERVAL);
+    }
+
+    /// Entries as `rank_entries` hands them over: most-recently-fetched first.
+    fn ranked(costs: &[(u64, u64)]) -> Vec<EntryCost> {
+        costs
+            .iter()
+            .enumerate()
+            .map(|(i, (rows, bytes))| EntryCost {
+                key: vec![("request_path".to_string(), Some(format!("/{i}")))],
+                rows: *rows,
+                bytes: *bytes,
+                // Newest-first ordering is the caller's contract, so the value
+                // only has to be non-null; the budget tests do not expire.
+                oldest: Some(i64::MAX),
+                newest: Some(i64::MAX),
+                matches_configured: false,
+            })
+            .collect()
+    }
+
+    fn doomed_paths(entries: &[EntryCost], budget: Budget) -> (Vec<String>, usize) {
+        let refs: Vec<&EntryCost> = entries.iter().collect();
+        let Selection { keep, deferred } = select_doomed_refs(&refs, budget);
+        let paths = refs[keep..]
+            .iter()
+            .filter_map(|e| e.key.first().and_then(|(_, v)| v.clone()))
+            .collect();
+        (paths, deferred)
+    }
+
+    #[test]
+    fn selection_keeps_a_contiguous_most_recent_prefix() {
+        // Entries are newest-first, so /0 is newest. A budget of 2 rows keeps
+        // /0 and /1 and dooms the rest — not whichever happen to fit.
+        let entries = ranked(&[(1, 10), (1, 10), (1, 10), (1, 10)]);
+        let (doomed, deferred) = doomed_paths(&entries, Budget::Items(2));
+        assert_eq!(doomed, vec!["/2".to_string(), "/3".to_string()]);
+        assert_eq!(deferred, 0);
+    }
+
+    #[test]
+    fn selection_charges_bytes_against_a_byte_budget() {
+        let entries = ranked(&[(1, 100), (1, 100), (1, 100)]);
+        let (doomed, _) = doomed_paths(&entries, Budget::Bytes(250));
+        assert_eq!(doomed, vec!["/2".to_string()]);
+    }
+
+    #[test]
+    fn selection_evicts_nothing_when_everything_fits() {
+        let entries = ranked(&[(1, 10), (1, 10)]);
+        let refs: Vec<&EntryCost> = entries.iter().collect();
+        assert_eq!(
+            select_doomed_refs(&refs, Budget::Items(10)).keep,
+            refs.len()
+        );
+        assert_eq!(
+            select_doomed_refs(&refs, Budget::Bytes(1024)).keep,
+            refs.len()
+        );
+    }
+
+    #[test]
+    fn a_single_entry_larger_than_the_whole_budget_is_evicted() {
+        // Otherwise one oversized response would pin the cache over its budget
+        // for good.
+        let entries = ranked(&[(1, 5_000)]);
+        let (doomed, _) = doomed_paths(&entries, Budget::Bytes(1_000));
+        assert_eq!(doomed, vec!["/0".to_string()]);
+    }
+
+    #[test]
+    fn an_overflowing_sweep_evicts_the_oldest_entries_first() {
+        // More entries are doomed than one DELETE should name. The ones that go
+        // must be the *oldest* — taking the other end would keep the least
+        // valuable entries and re-doom the same ones every sweep, so the cache
+        // would never converge on its budget.
+        let count = MAX_ENTRIES_PER_SWEEP + 10;
+        let entries = ranked(&vec![(1_u64, 10_u64); count]);
+
+        let (doomed, deferred) = doomed_paths(&entries, Budget::Items(0));
+        assert_eq!(doomed.len(), MAX_ENTRIES_PER_SWEEP);
+        assert_eq!(deferred, 10);
+        assert_eq!(
+            doomed.last().map(String::as_str),
+            Some(format!("/{}", count - 1).as_str()),
+            "the oldest entry must be in this sweep"
+        );
+        assert_eq!(
+            doomed.first().map(String::as_str),
+            Some(format!("/{}", count - MAX_ENTRIES_PER_SWEEP).as_str()),
+            "the newest of the doomed entries are the ones deferred"
+        );
+    }
+
+    /// One stored row, in the shape a caching HTTP accelerator holds.
+    #[derive(Clone, Copy)]
+    struct Row {
+        path: &'static str,
+        query: Option<&'static str>,
+        /// How long ago this row was fetched.
+        age: Duration,
+        /// Payload. Its byte length is what the size budget charges for.
+        content: &'static str,
+    }
+
+    /// Payload bytes the size expression charges a fixture row, so the budget
+    /// tests can state a budget in entries rather than in magic numbers:
+    /// `request_path` + `content` (`request_query`/`request_body` are NULL and
+    /// cost nothing) + 8 for the `_fetched_at` timestamp.
+    fn row_bytes(row: &Row) -> u64 {
+        (row.path.len() + row.content.len() + 8) as u64
+    }
+
+    fn row(path: &'static str, age: Duration) -> Row {
+        Row {
+            path,
+            query: None,
+            age,
+            content: "body",
+        }
+    }
+
+    /// Builds an in-memory accelerator holding `rows`. `MemTable` implements
+    /// `delete_from`, so the sweep exercises the same delete path a `DuckDB` or
+    /// Cayenne accelerator takes.
+    fn cache_table(rows: &[Row]) -> (Arc<dyn TableProvider>, Arc<FederatedTable>) {
+        use arrow::array::{StringArray, TimestampNanosecondArray};
+        use data_components::arrow::write::MemTable;
+
+        let schema = Arc::new(http_cache_schema());
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.path).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.query).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(StringArray::from(vec![None::<&str>; rows.len()])) as _,
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.content).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(TimestampNanosecondArray::from(
+                    rows.iter()
+                        .map(|r| Some(nanos_ago(r.age)))
+                        .collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(StringArray::from(vec!["public"; rows.len()])) as _,
+            ],
+        )
+        .expect("batch");
+
+        let table = MemTable::try_new(schema, vec![vec![batch]]).expect("mem table");
+        let accelerator = Arc::new(table) as Arc<dyn TableProvider>;
+        let federated = Arc::new(FederatedTable::new_unchecked(Arc::clone(&accelerator)));
+        (accelerator, federated)
+    }
+
+    /// The `(request_path, request_query)` pairs still stored, sorted.
+    async fn remaining(accelerator: &Arc<dyn TableProvider>) -> Vec<(String, Option<String>)> {
+        let ctx = SessionContext::new();
+        let batches = ctx
+            .read_table(Arc::clone(accelerator))
+            .expect("read")
+            .collect()
+            .await
+            .expect("collect");
+
+        let mut out = Vec::new();
+        for batch in &batches {
+            for r in 0..batch.num_rows() {
+                out.push((
+                    read_utf8(batch, "request_path", r).unwrap_or_default(),
+                    read_utf8(batch, "request_query", r),
+                ));
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// Runs one tick the way `start_retention_check` does: resolve the
+    /// predicate, then delete whatever it named. Returns the rows removed.
+    async fn sweep(
+        accelerator: &Arc<dyn TableProvider>,
+        federated: &Arc<FederatedTable>,
+        limits: CacheLimits,
+    ) -> u64 {
+        sweep_with_configured(accelerator, federated, limits, None).await
+    }
+
+    /// As [`sweep`], with a dataset-configured retention predicate in play.
+    async fn sweep_with_configured(
+        accelerator: &Arc<dyn TableProvider>,
+        federated: &Arc<FederatedTable>,
+        limits: CacheLimits,
+        configured: Option<Expr>,
+    ) -> u64 {
+        let dataset_name = TableReference::bare("http_cache");
+        let predicate =
+            CacheEvictionPredicate::new(dataset_name.clone(), limits, Handle::current());
+        let Some(expr) = predicate
+            .delete_expr(accelerator, configured)
+            .await
+            .expect("resolve")
+        else {
+            return 0;
+        };
+        apply_retention_filters_once(
+            &dataset_name,
+            accelerator,
+            federated,
+            expr,
+            &Handle::current(),
+        )
+        .await
+        .expect("delete")
+    }
+
+    fn nanos_ago(age: Duration) -> i64 {
+        let now = nanos_since_epoch(SystemTime::now()).expect("clock");
+        now - i64::try_from(age.as_nanos()).expect("age")
+    }
+
+    /// A TTL long enough that no fixture row expires during a budget test.
+    fn no_expiry() -> CacheLimits {
+        CacheLimits {
+            ttl: Some(Duration::from_hours(1)),
+            ..Default::default()
+        }
+    }
+
+    /// One row for , fetched just now — what a refresh writes back.
+    fn refreshed_row(path: &str) -> RecordBatch {
+        use arrow::array::{StringArray, TimestampNanosecondArray};
+        RecordBatch::try_new(
+            Arc::new(http_cache_schema()),
+            vec![
+                Arc::new(StringArray::from(vec![path])) as _,
+                Arc::new(StringArray::from(vec![None::<&str>])) as _,
+                Arc::new(StringArray::from(vec![None::<&str>])) as _,
+                Arc::new(StringArray::from(vec!["refreshed"])) as _,
+                Arc::new(TimestampNanosecondArray::from(vec![Some(nanos_ago(
+                    Duration::ZERO,
+                ))])) as _,
+                Arc::new(StringArray::from(vec!["public"])) as _,
+            ],
+        )
+        .expect("batch")
+    }
+
+    #[tokio::test]
+    async fn an_entry_refreshed_after_ranking_is_not_evicted() {
+        // The sweep ranks without the write lock, so a refresh can replace an
+        // entry between the ranking that chose it and the delete that removes
+        // it. Deleting by key alone would take the refreshed rows too, turning a
+        // response that was just repaired into a cache miss — exactly what
+        // `stale_if_error` exists to prevent during an origin outage.
+        let (accelerator, federated) = cache_table(&[
+            row("/oldest", Duration::from_mins(3)),
+            row("/newest", Duration::from_mins(1)),
+        ]);
+
+        // Rank the two entries as the sweep would.
+        let schema = accelerator.schema();
+        let key_columns = entry_key_columns(&schema);
+        let dataset_name = TableReference::bare("http_cache");
+        let entries = rank_entries(
+            &accelerator,
+            &Handle::current(),
+            &key_columns,
+            &schema,
+            None,
+            None,
+        )
+        .await
+        .expect("rank");
+        let doomed: Vec<&EntryCost> = entries
+            .iter()
+            .filter(|e| e.key.iter().any(|(_, v)| v.as_deref() == Some("/oldest")))
+            .collect();
+        assert_eq!(doomed.len(), 1, "one entry should be chosen");
+
+        // A refresh lands before the delete: the entry is replaced with a row
+        // fetched just now, which is newer than anything the ranking saw.
+        CacheRefreshHelper::batched_upsert_into_accelerator(
+            &accelerator,
+            "http_cache",
+            &[vec![col("request_path").eq(lit("/oldest"))]],
+            vec![refreshed_row("/oldest")],
+        )
+        .await
+        .expect("refresh");
+
+        // Delete exactly what the ranking chose, as the retention loop would.
+        let expr = combine_exprs_balanced(
+            doomed
+                .iter()
+                .filter_map(|entry| entry_predicate(&entry.key, entry.newest))
+                .collect(),
+            Expr::or,
+        )
+        .expect("predicate");
+        let deleted = apply_retention_filters_once(
+            &dataset_name,
+            &accelerator,
+            &federated,
+            expr,
+            &Handle::current(),
+        )
+        .await
+        .expect("delete");
+
+        assert_eq!(deleted, 0, "the refreshed entry must not be deleted");
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/newest".to_string(), None), ("/oldest".to_string(), None)],
+            "a refresh that landed after the ranking must survive the sweep"
+        );
+    }
+
+    #[tokio::test]
+    async fn rows_past_ttl_plus_swr_are_deleted_and_live_ones_kept() {
+        let (accelerator, federated) = cache_table(&[
+            row("/live", Duration::from_secs(1)),
+            row("/dead", Duration::from_mins(30)),
+        ]);
+
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                ttl: Some(Duration::from_mins(5)),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert_eq!(deleted, 1);
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/live".to_string(), None)]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_multi_page_entry_is_expired_whole_or_not_at_all() {
+        // A paginated response is one cache entry whose pages were fetched
+        // separately, so its rows carry different `_fetched_at` values. Expiring
+        // by a timestamp range would delete only the pages past the cutoff and
+        // leave the rest — and the read path, which judges freshness over the
+        // rows that remain, would then find that remainder fresh and serve it as
+        // if it were the whole response.
+        let (accelerator, federated) = cache_table(&[
+            Row {
+                path: "/paged",
+                query: Some("page=1"),
+                age: Duration::from_mins(30),
+                content: "page one",
+            },
+            Row {
+                path: "/paged",
+                query: Some("page=1"),
+                age: Duration::from_secs(1),
+                content: "page two",
+            },
+            row("/fresh", Duration::from_secs(1)),
+        ]);
+
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                ttl: Some(Duration::from_mins(5)),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        // The entry is only as fresh as its oldest page, so the whole entry goes.
+        assert_eq!(deleted, 2);
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/fresh".to_string(), None)],
+            "a multi-page entry must expire whole, never leaving a servable remnant"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_entry_is_kept_while_its_oldest_page_is_still_within_the_window() {
+        // The mirror of the test above: judging by the *newest* page instead
+        // would keep an entry a query can no longer be served in full.
+        let (accelerator, federated) = cache_table(&[Row {
+            path: "/paged",
+            query: Some("page=1"),
+            age: Duration::from_mins(2),
+            content: "page one",
+        }]);
+
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                ttl: Some(Duration::from_mins(5)),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert_eq!(deleted, 0);
+        assert_eq!(remaining(&accelerator).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn the_stale_while_revalidate_window_holds_a_row_past_its_ttl() {
+        // A row inside its SWR window is still servable, so expiring it would
+        // delete data a query is entitled to.
+        let (accelerator, federated) = cache_table(&[row("/swr", Duration::from_mins(10))]);
+
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                ttl: Some(Duration::from_mins(5)),
+                stale_while_revalidate: Some(Duration::from_hours(1)),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert_eq!(deleted, 0);
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/swr".to_string(), None)]
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unset_ttl_uses_the_same_default_the_read_path_does() {
+        // The sweep must not evict rows the read path still calls fresh. Both
+        // read `DEFAULT_CACHING_TTL`, so they cannot diverge; the ages here are
+        // written out rather than derived from it, so this still measures the
+        // behaviour instead of restating the constant.
+        assert_eq!(
+            effective_max_age(None),
+            Duration::from_secs(30),
+            "the read path's default; the fixture ages below are chosen against it"
+        );
+        let (accelerator, federated) = cache_table(&[
+            row("/fresh", Duration::from_secs(5)),
+            row("/stale", Duration::from_secs(90)),
+        ]);
+
+        let deleted = sweep(&accelerator, &federated, CacheLimits::default()).await;
+
+        assert_eq!(deleted, 1);
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/fresh".to_string(), None)]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_item_budget_evicts_the_least_recently_fetched_entries() {
+        let (accelerator, federated) = cache_table(&[
+            row("/oldest", Duration::from_mins(3)),
+            row("/middle", Duration::from_mins(2)),
+            row("/newest", Duration::from_mins(1)),
+        ]);
+
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                max_items: Some(2),
+                ..no_expiry()
+            },
+        )
+        .await;
+
+        assert_eq!(deleted, 1);
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/middle".to_string(), None), ("/newest".to_string(), None)]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_byte_budget_evicts_the_least_recently_fetched_entries() {
+        let rows = [
+            row("/oldest", Duration::from_mins(3)),
+            row("/middle", Duration::from_mins(2)),
+            row("/newest", Duration::from_mins(1)),
+        ];
+        // Every fixture row is the same size, so a budget of two rows' worth
+        // must leave exactly the two most recent.
+        let each = row_bytes(&rows[0]);
+        let (accelerator, federated) = cache_table(&rows);
+
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                max_size_bytes: Some(each * 2),
+                ..no_expiry()
+            },
+        )
+        .await;
+
+        assert_eq!(deleted, 1);
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/middle".to_string(), None), ("/newest".to_string(), None)]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_byte_budget_charges_for_the_payload_each_entry_actually_holds() {
+        // A budget measured in rows rather than bytes would evict the same
+        // entry whatever it weighed. The big entry must be the one that goes,
+        // even though it is not the oldest by much.
+        let big = Row {
+            path: "/big",
+            query: None,
+            age: Duration::from_mins(2),
+            content: "x".repeat(400).leak(),
+        };
+        let small = Row {
+            path: "/small",
+            query: None,
+            age: Duration::from_mins(1),
+            content: "y",
+        };
+        let (accelerator, federated) = cache_table(&[big, small]);
+
+        let budget = row_bytes(&big) + row_bytes(&small) - 1;
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                max_size_bytes: Some(budget),
+                ..no_expiry()
+            },
+        )
+        .await;
+
+        assert_eq!(deleted, 1);
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/small".to_string(), None)]
+        );
+    }
+
+    #[test]
+    fn a_nested_payload_column_is_reported_as_unweighable() {
+        use arrow::datatypes::Fields;
+
+        // `octet_length` takes text only, so a column of another shape is not
+        // charged for. That is accurate for what a caching accelerator stores
+        // today — an HTTP body is text, and a decomposed body decomposes into
+        // text columns — but if one ever is not, the budget under-counts and
+        // the operator has to be told rather than left to discover it as
+        // unexplained growth.
+        let schema = Schema::new(vec![
+            Field::new("request_path", DataType::Utf8, false),
+            Field::new("content", DataType::Utf8, false),
+            Field::new(
+                "decoded_body",
+                DataType::Struct(Fields::from(vec![Field::new("k", DataType::Utf8, true)])),
+                true,
+            ),
+        ]);
+
+        assert_eq!(
+            unmeasurable_payload_columns(&schema),
+            vec!["decoded_body".to_string()]
+        );
+    }
+
+    #[test]
+    fn the_header_map_every_response_carries_is_not_reported() {
+        // It is a `Map` on every HTTP response and small beside the body, so
+        // reporting it would put a warning in the log of every ordinary caching
+        // dataset with a budget — which is how a warning stops being read.
+        let schema = Schema::new(vec![
+            Field::new("content", DataType::Utf8, false),
+            Field::new(
+                "response_headers",
+                DataType::Map(
+                    Arc::new(Field::new_struct(
+                        "entries",
+                        vec![
+                            Arc::new(Field::new("keys", DataType::Utf8, false)),
+                            Arc::new(Field::new("values", DataType::Utf8, true)),
+                        ],
+                        false,
+                    )),
+                    false,
+                ),
+                true,
+            ),
+        ]);
+
+        assert!(unmeasurable_payload_columns(&schema).is_empty());
+    }
+
+    #[test]
+    fn the_caching_accelerators_own_columns_are_not_charged_to_the_budget() {
+        // The budget bounds what was cached, not the bookkeeping around it.
+        let schema = http_cache_schema();
+        let expr = payload_bytes_expr(&schema).expect("measurable").to_string();
+        assert!(
+            !expr.contains(CACHE_NAMESPACE_COLUMN),
+            "reserved columns must not be counted: {expr}"
+        );
+        assert!(
+            expr.contains("content"),
+            "the payload must be counted: {expr}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_multi_page_entry_is_evicted_whole_or_not_at_all() {
+        // A paginated response is one cache entry whose pages were fetched
+        // separately, so its rows carry different `_fetched_at` values. Trimming
+        // by a timestamp boundary would cut it in half and leave the remainder
+        // to be served as if it were the whole response — which is why eviction
+        // names entries by key rather than deleting a time range.
+        let (accelerator, federated) = cache_table(&[
+            Row {
+                path: "/paged",
+                query: Some("page=1"),
+                age: Duration::from_mins(3),
+                content: "body",
+            },
+            Row {
+                path: "/paged",
+                query: Some("page=1"),
+                age: Duration::from_secs(30),
+                content: "body",
+            },
+            row("/other", Duration::from_mins(2)),
+        ]);
+
+        // Room for two rows only. `/paged` straddles `/other` in fetch time, so
+        // any timestamp-range trim would split it.
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                max_items: Some(2),
+                ..no_expiry()
+            },
+        )
+        .await;
+
+        assert!(
+            deleted > 0,
+            "three rows against a budget of two must evict something"
+        );
+
+        let left = remaining(&accelerator).await;
+        let paged_rows = left.iter().filter(|(p, _)| p == "/paged").count();
+        assert!(
+            paged_rows == 0 || paged_rows == 2,
+            "a multi-page entry must survive or go whole, never in part: {left:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_if_error_keeps_expired_entries_but_a_budget_still_evicts() {
+        // `stale_if_error` means an expired entry is still wanted, so it is not
+        // expired away — but a budget bounds the cache regardless, which is what
+        // was missing.
+        let rows = [
+            row("/oldest", Duration::from_mins(30)),
+            row("/newest", Duration::from_mins(20)),
+        ];
+        let (accelerator, federated) = cache_table(&rows);
+        let expired = CacheLimits {
+            ttl: Some(Duration::from_mins(5)),
+            stale_if_error: true,
+            ..Default::default()
+        };
+
+        let kept = sweep(&accelerator, &federated, expired).await;
+        assert_eq!(kept, 0, "expired entries are the fallback");
+        assert_eq!(remaining(&accelerator).await.len(), 2);
+
+        let bounded = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                max_items: Some(1),
+                ..expired
+            },
+        )
+        .await;
+        assert_eq!(bounded, 1, "the budget still evicts one entry");
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/newest".to_string(), None)]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_dataset_retention_rule_takes_whole_entries_not_matching_rows() {
+        // A `retention_period`/`retention_sql` the user sets still applies in
+        // caching mode, but per entry. Matching one page of a paginated response
+        // must take the whole response: leaving the other pages behind would let
+        // the read path serve them as though they were all there was.
+        let (accelerator, federated) = cache_table(&[
+            Row {
+                path: "/paged",
+                query: Some("page=1"),
+                age: Duration::from_secs(1),
+                content: "drop-me",
+            },
+            Row {
+                path: "/paged",
+                query: Some("page=1"),
+                age: Duration::from_secs(1),
+                content: "keep-me",
+            },
+            row("/other", Duration::from_secs(1)),
+        ]);
+
+        // Matches exactly one row of the two-row entry.
+        let configured = col("content").eq(lit("drop-me"));
+        let deleted =
+            sweep_with_configured(&accelerator, &federated, no_expiry(), Some(configured)).await;
+
+        assert_eq!(deleted, 2, "both rows of the matched entry must go");
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/other".to_string(), None)],
+            "the unmatched entry stays; the matched one goes whole"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_dataset_retention_rule_that_matches_nothing_deletes_nothing() {
+        let (accelerator, federated) = cache_table(&[row("/a", Duration::from_secs(1))]);
+
+        let deleted = sweep_with_configured(
+            &accelerator,
+            &federated,
+            no_expiry(),
+            Some(col("content").eq(lit("no-such-content"))),
+        )
+        .await;
+
+        assert_eq!(deleted, 0);
+        assert_eq!(remaining(&accelerator).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_dataset_retention_rule_applies_alongside_expiry_and_budgets() {
+        // All three policies resolve into one predicate, so an entry the user's
+        // rule removes is not also charged against the budget.
+        let (accelerator, federated) = cache_table(&[
+            row("/newest", Duration::from_secs(1)),
+            Row {
+                path: "/tagged",
+                query: None,
+                age: Duration::from_secs(2),
+                content: "drop-me",
+            },
+            row("/expired", Duration::from_mins(30)),
+        ]);
+
+        let deleted = sweep_with_configured(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                ttl: Some(Duration::from_mins(5)),
+                max_items: Some(2),
+                ..Default::default()
+            },
+            Some(col("content").eq(lit("drop-me"))),
+        )
+        .await;
+
+        // `/expired` goes on expiry and `/tagged` on the user's rule; that
+        // leaves one entry, which is inside the budget of two — so the budget
+        // evicts nothing on top.
+        assert_eq!(deleted, 2);
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/newest".to_string(), None)]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_cache_within_its_budgets_is_left_alone() {
+        let rows = [
+            row("/a", Duration::from_secs(1)),
+            row("/b", Duration::from_secs(2)),
+        ];
+        let total: u64 = rows.iter().map(row_bytes).sum();
+        let (accelerator, federated) = cache_table(&rows);
+
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                max_items: Some(10),
+                max_size_bytes: Some(total * 2),
+                ..no_expiry()
+            },
+        )
+        .await;
+
+        assert_eq!(deleted, 0);
+        assert_eq!(remaining(&accelerator).await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn expiry_works_where_the_engine_stores_microseconds() {
+        // Cayenne stores timestamps at microsecond precision, so the stored
+        // fetch-time column is not the nanosecond type the predicate's literal
+        // carries. The comparison must still select the right rows.
+        use arrow::array::{StringArray, TimestampMicrosecondArray};
+        use data_components::arrow::write::MemTable;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("request_path", DataType::Utf8, false),
+            Field::new("request_query", DataType::Utf8, true),
+            Field::new("request_body", DataType::Utf8, true),
+            Field::new("content", DataType::Utf8, false),
+            Field::new(
+                CACHE_REFRESHED_AT_COLUMN,
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                true,
+            ),
+            Field::new(CACHE_NAMESPACE_COLUMN, DataType::Utf8, false),
+        ]));
+
+        let live_us = nanos_ago(Duration::from_secs(1)) / 1_000;
+        let dead_us = nanos_ago(Duration::from_mins(30)) / 1_000;
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["/live", "/dead"])) as _,
+                Arc::new(StringArray::from(vec![None::<&str>, None])) as _,
+                Arc::new(StringArray::from(vec![None::<&str>, None])) as _,
+                Arc::new(StringArray::from(vec!["a", "b"])) as _,
+                Arc::new(TimestampMicrosecondArray::from(vec![
+                    Some(live_us),
+                    Some(dead_us),
+                ])) as _,
+                Arc::new(StringArray::from(vec!["public", "public"])) as _,
+            ],
+        )
+        .expect("batch");
+
+        let table = MemTable::try_new(schema, vec![vec![batch]]).expect("mem table");
+        let accelerator = Arc::new(table) as Arc<dyn TableProvider>;
+        let federated = Arc::new(FederatedTable::new_unchecked(Arc::clone(&accelerator)));
+
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                ttl: Some(Duration::from_mins(5)),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert_eq!(deleted, 1);
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/live".to_string(), None)]
+        );
+    }
+}

--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -945,7 +945,7 @@ impl Builder {
         let refresh_params = Arc::new(RwLock::new(self.refresh));
         // Create the in-flight revalidations tracker to avoid duplicate upstream requests during SWR window.
         let in_flight_revalidations: caching::InFlightRevalidations =
-            Arc::new(Mutex::new(std::collections::HashSet::new()));
+            Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
         // Create last_updated_at atomic to track insert_into timestamps, shared with Refresher for snapshots.
         // Initialize from bootstrap metadata if available.
         let last_updated_at = Arc::new(
@@ -968,6 +968,7 @@ impl Builder {
         refresher.with_completion_notifier(Arc::clone(&on_complete_notification));
         refresher.with_last_updated_at(Arc::clone(&last_updated_at));
         refresher.caching(&self.caching);
+        refresher.in_flight_revalidations(Arc::clone(&in_flight_revalidations));
         refresher.checkpointer(self.checkpointer);
         refresher.refresh_on_startup(self.refresh_on_startup);
         refresher.set_initial_load_completed(self.initial_load_complete);

--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -1064,48 +1064,25 @@ impl Builder {
             None
         };
 
-        // A caching accelerator is bounded by `caching_eviction` as a retention
-        // filter rather than by a loop of its own, so the cache is swept by the
-        // same ticker, write lock and index-aware delete every other dataset
-        // uses. Attached before the retention task is spawned below.
+        // A caching accelerator is bounded by `caching_eviction` as a computed
+        // retention policy rather than by a loop of its own, so the cache is
+        // swept by the same ticker, write lock and index-aware delete every
+        // other dataset uses. Attached before the retention task is spawned
+        // below.
         let retention = if refresh_mode == RefreshMode::Caching {
-            let limits = caching_eviction::CacheLimits {
-                max_size_bytes: self.caching_max_size_bytes,
-                max_items: self.caching_max_items,
-                ttl: self.caching_ttl,
-                stale_while_revalidate: self.caching_stale_while_revalidate_ttl,
-                stale_if_error: self.caching_stale_if_error,
-            };
-            let predicate = Arc::new(caching_eviction::CacheEvictionPredicate::new(
-                self.dataset_name.clone(),
-                limits,
-                self.io_runtime.clone(),
-            ));
-            // Built directly rather than through the builder's `enabled` gate:
-            // `retention_check_enabled` governs the dataset's own retention
-            // rules, and switching those off must not also switch off
-            // `caching_ttl`, `caching_max_size` and `caching_max_items`.
-            let sweep_interval = caching_eviction::sweep_interval(self.caching_ttl);
-            let (mut filters, check_interval) = match self.retention {
-                // Sweep at whichever cadence is tighter. The user's
-                // `retention_check_interval` must not slow the cache bounds
-                // down, and the cache's cadence must not make their retention
-                // rule run less often than they asked.
-                Some(retention) => (
-                    retention.filters,
-                    retention.check_interval.min(sweep_interval),
-                ),
-                None => (Vec::new(), sweep_interval),
-            };
-            // After the user's filters are known: a `retention_period` or
-            // `retention_sql` rule evicts entries too, so whether anything
-            // bounds the cache is not decidable from the cache's own limits.
-            predicate.warn_about_unenforceable(&self.accelerator, !filters.is_empty());
-            filters.push(DataRetentionFilter::Computed { predicate });
-            Some(Retention {
-                filters,
-                check_interval,
-            })
+            Some(caching_eviction::retention(
+                caching_eviction::CacheLimits {
+                    max_size_bytes: self.caching_max_size_bytes,
+                    max_items: self.caching_max_items,
+                    ttl: self.caching_ttl,
+                    stale_while_revalidate: self.caching_stale_while_revalidate_ttl,
+                    stale_if_error: self.caching_stale_if_error,
+                },
+                self.retention,
+                &self.accelerator,
+                &self.dataset_name,
+                &self.io_runtime,
+            ))
         } else {
             self.retention
         };
@@ -2339,11 +2316,6 @@ pub enum DataRetentionFilter {
     Expression {
         delete_expr: Box<Expr>,
     },
-    /// Decided per tick rather than at configuration time. Has the last word:
-    /// see [`RetentionPredicate`].
-    Computed {
-        predicate: Arc<dyn RetentionPredicate>,
-    },
 }
 
 pub struct RetentionBuilder {
@@ -2467,6 +2439,9 @@ impl RetentionBuilder {
         Some(Retention {
             filters,
             check_interval,
+            // The builder configures a dataset's own retention rules; a
+            // computed policy is attached by whatever owns it.
+            computed: None,
         })
     }
 }
@@ -2480,6 +2455,16 @@ impl Default for RetentionBuilder {
 pub struct Retention {
     pub(crate) filters: Vec<DataRetentionFilter>,
     pub(crate) check_interval: Duration,
+    /// A policy decided per tick rather than at configuration time, which has
+    /// the last word on what `filters` resolved to: see [`RetentionPredicate`].
+    ///
+    /// A field rather than another `filters` variant, because it does not
+    /// compose the way they do. Every variant in that list is OR'd together;
+    /// this one is handed their combined result and may widen it, narrow it or
+    /// replace it. Putting it in the list would make "at most one, applied
+    /// last" a convention the loop has to enforce by hand, and a second one
+    /// would silently disable the first.
+    pub(crate) computed: Option<Arc<dyn RetentionPredicate>>,
 }
 
 impl Retention {

--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -66,6 +66,7 @@ use tokio::sync::{Mutex, Notify, RwLock, Semaphore, mpsc};
 use tokio::task::JoinHandle;
 
 pub mod caching;
+pub mod caching_eviction;
 pub mod federation;
 pub mod refresh;
 pub mod refresh_task;
@@ -424,6 +425,8 @@ pub struct Builder {
     caching_ttl: Option<Duration>,
     caching_stale_while_revalidate_ttl: Option<Duration>,
     caching_stale_if_error: bool,
+    caching_max_size_bytes: Option<u64>,
+    caching_max_items: Option<u64>,
     resource_monitor: Option<runtime_resources::ResourceMonitor>,
     bootstrap_status: BootstrapStatus,
     /// Whether the acceleration uses S3 Express One Zone storage.
@@ -481,6 +484,8 @@ impl Builder {
             caching_ttl: None,
             caching_stale_while_revalidate_ttl: None,
             caching_stale_if_error: false,
+            caching_max_size_bytes: None,
+            caching_max_items: None,
             resource_monitor: None,
             bootstrap_status: BootstrapStatus::none(),
             acceleration_layout: None,
@@ -732,6 +737,18 @@ impl Builder {
     /// Set whether to serve expired data on upstream error in cache mode
     pub fn caching_stale_if_error(&mut self, enabled: bool) -> &mut Self {
         self.caching_stale_if_error = enabled;
+        self
+    }
+
+    /// Set the byte budget (`caching_max_size`) for cache mode
+    pub fn caching_max_size_bytes(&mut self, max_size_bytes: Option<u64>) -> &mut Self {
+        self.caching_max_size_bytes = max_size_bytes;
+        self
+    }
+
+    /// Set the row budget (`caching_max_items`) for cache mode
+    pub fn caching_max_items(&mut self, max_items: Option<u64>) -> &mut Self {
+        self.caching_max_items = max_items;
         self
     }
 
@@ -1047,7 +1064,51 @@ impl Builder {
             None
         };
 
-        if let Some(retention) = self.retention {
+        // A caching accelerator is bounded by `caching_eviction` as a retention
+        // filter rather than by a loop of its own, so the cache is swept by the
+        // same ticker, write lock and index-aware delete every other dataset
+        // uses. Attached before the retention task is spawned below.
+        let retention = if refresh_mode == RefreshMode::Caching {
+            let limits = caching_eviction::CacheLimits {
+                max_size_bytes: self.caching_max_size_bytes,
+                max_items: self.caching_max_items,
+                ttl: self.caching_ttl,
+                stale_while_revalidate: self.caching_stale_while_revalidate_ttl,
+                stale_if_error: self.caching_stale_if_error,
+            };
+            let predicate = Arc::new(caching_eviction::CacheEvictionPredicate::new(
+                self.dataset_name.clone(),
+                limits,
+                self.io_runtime.clone(),
+            ));
+            predicate.warn_about_unenforceable(&self.accelerator);
+
+            // Built directly rather than through the builder's `enabled` gate:
+            // `retention_check_enabled` governs the dataset's own retention
+            // rules, and switching those off must not also switch off
+            // `caching_ttl`, `caching_max_size` and `caching_max_items`.
+            let sweep_interval = caching_eviction::sweep_interval(self.caching_ttl);
+            let (mut filters, check_interval) = match self.retention {
+                // Sweep at whichever cadence is tighter. The user's
+                // `retention_check_interval` must not slow the cache bounds
+                // down, and the cache's cadence must not make their retention
+                // rule run less often than they asked.
+                Some(retention) => (
+                    retention.filters,
+                    retention.check_interval.min(sweep_interval),
+                ),
+                None => (Vec::new(), sweep_interval),
+            };
+            filters.push(DataRetentionFilter::Computed { predicate });
+            Some(Retention {
+                filters,
+                check_interval,
+            })
+        } else {
+            self.retention
+        };
+
+        if let Some(retention) = retention {
             let retention_check_handle = tokio::spawn(AcceleratedTable::start_retention_check(
                 self.dataset_name.clone(),
                 Arc::clone(&self.accelerator),
@@ -2229,6 +2290,41 @@ fn filters_for_accelerator_scan(
     Ok(accelerator_filters)
 }
 
+/// Resolves what a retention check should delete, computed fresh on every tick.
+///
+/// The two static filter kinds can only express a predicate fixed when the
+/// dataset was configured. This one is asked each tick, so a policy that has to
+/// *measure* the table before it can decide — a byte or row budget, which is
+/// knowable only by aggregating what is stored — can be a retention filter
+/// rather than a second eviction loop running beside this one.
+///
+/// It is given whatever the dataset's own retention filters resolved to and has
+/// the last word on the result. An implementation may widen that predicate,
+/// narrow it, or ignore it: a caching accelerator translates it from rows to
+/// whole cache entries, because deleting part of a multi-row cached response
+/// would leave the rest to be served as though it were complete.
+#[async_trait::async_trait]
+pub trait RetentionPredicate: Send + Sync + std::fmt::Debug {
+    /// The rows to delete this tick, or `None` when there is nothing to remove.
+    ///
+    /// `configured` is what this dataset's static retention filters resolved
+    /// to, or `None` when it has none. An implementation that ignores it drops
+    /// a `retention_period` or `retention_sql` the user wrote, silently — so it
+    /// must either fold `configured` into what it returns or be able to say why
+    /// that rule cannot apply.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `DataFusionError` if the accelerator cannot be queried for
+    /// whatever the decision needs. The tick is skipped and retried on the next
+    /// interval.
+    async fn delete_expr(
+        &self,
+        accelerator: &Arc<dyn TableProvider>,
+        configured: Option<Expr>,
+    ) -> datafusion::error::Result<Option<Expr>>;
+}
+
 #[derive(Debug)]
 pub enum DataRetentionFilter {
     Time {
@@ -2240,6 +2336,11 @@ pub enum DataRetentionFilter {
     },
     Expression {
         delete_expr: Box<Expr>,
+    },
+    /// Decided per tick rather than at configuration time. Has the last word:
+    /// see [`RetentionPredicate`].
+    Computed {
+        predicate: Arc<dyn RetentionPredicate>,
     },
 }
 

--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -1081,8 +1081,6 @@ impl Builder {
                 limits,
                 self.io_runtime.clone(),
             ));
-            predicate.warn_about_unenforceable(&self.accelerator);
-
             // Built directly rather than through the builder's `enabled` gate:
             // `retention_check_enabled` governs the dataset's own retention
             // rules, and switching those off must not also switch off
@@ -1099,6 +1097,10 @@ impl Builder {
                 ),
                 None => (Vec::new(), sweep_interval),
             };
+            // After the user's filters are known: a `retention_period` or
+            // `retention_sql` rule evicts entries too, so whether anything
+            // bounds the cache is not decidable from the cache's own limits.
+            predicate.warn_about_unenforceable(&self.accelerator, !filters.is_empty());
             filters.push(DataRetentionFilter::Computed { predicate });
             Some(Retention {
                 filters,

--- a/crates/runtime-table/src/accelerated/refresh.rs
+++ b/crates/runtime-table/src/accelerated/refresh.rs
@@ -542,6 +542,9 @@ pub struct Refresher {
     accelerator: Arc<dyn TableProvider>,
     // `Weak` reference to `Caching` is used to prevent blocking cache cleanup during runtime termination.
     caching: Option<Weak<Caching>>,
+    /// The caching accelerator's claim set, forwarded to the refresh task so
+    /// its periodic stale-row refresh claims the keys it replaces.
+    in_flight_revalidations: Option<crate::accelerated::caching::InFlightRevalidations>,
     refresh_task_runner: Option<RefreshTaskRunner>,
     checkpointer: Option<Arc<dyn DatasetCheckpointer>>,
     refresh_on_startup: RefreshOnStartup,
@@ -611,6 +614,7 @@ impl Refresher {
             refresh,
             accelerator,
             caching: None,
+            in_flight_revalidations: None,
             refresh_task_runner: None,
             checkpointer: None,
             refresh_on_startup: RefreshOnStartup::default(),
@@ -634,6 +638,14 @@ impl Refresher {
             engine_type_rewrites: &[],
             cdc_param_overrides: None,
         }
+    }
+
+    pub fn in_flight_revalidations(
+        &mut self,
+        in_flight_revalidations: crate::accelerated::caching::InFlightRevalidations,
+    ) -> &mut Self {
+        self.in_flight_revalidations = Some(in_flight_revalidations);
+        self
     }
 
     pub fn caching(&mut self, caching: &Option<Arc<Caching>>) -> &mut Self {
@@ -927,6 +939,11 @@ impl Refresher {
 
         refresh_task_runner = refresh_task_runner
             .with_initial_load_completed(Arc::clone(&self.initial_load_completed));
+
+        if let Some(in_flight_revalidations) = &self.in_flight_revalidations {
+            refresh_task_runner = refresh_task_runner
+                .with_in_flight_revalidations(Arc::clone(in_flight_revalidations));
+        }
 
         let mut refresh_task_runner = refresh_task_runner.build();
 

--- a/crates/runtime-table/src/accelerated/refresh_task.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task.rs
@@ -248,6 +248,11 @@ pub struct RefreshTaskBuilder {
     /// Per-dataset `cdc_*` parameter overrides drawn from
     /// `dataset.acceleration.params`.
     cdc_param_overrides: Option<Arc<HashMap<String, String>>>,
+    /// The cache keys a write is pending for, shared with the caching scan and
+    /// its batched writer. `RefreshMode::Caching`'s periodic stale-row refresh
+    /// replaces the entries it refreshes, so it has to claim each key for the
+    /// same reason every other writer does — see [`caching::CacheKeyClaim`].
+    in_flight_revalidations: super::caching::InFlightRevalidations,
 }
 
 impl RefreshTaskBuilder {
@@ -281,6 +286,9 @@ impl RefreshTaskBuilder {
             engine_type_rewrites: &[],
             snapshot_refresh_state: None,
             cdc_param_overrides: None,
+            in_flight_revalidations: Arc::new(parking_lot::Mutex::new(
+                std::collections::HashSet::new(),
+            )),
         }
     }
 
@@ -369,6 +377,17 @@ impl RefreshTaskBuilder {
         self
     }
 
+    /// Share the caching accelerator's claim set, so the periodic stale-row
+    /// refresh claims the keys it replaces.
+    #[must_use]
+    pub fn with_in_flight_revalidations(
+        mut self,
+        in_flight_revalidations: super::caching::InFlightRevalidations,
+    ) -> RefreshTaskBuilder {
+        self.in_flight_revalidations = in_flight_revalidations;
+        self
+    }
+
     /// Provide per-dataset `cdc_*` parameter overrides. These layer on top of
     /// the process-global [`changes::CdcConfig`] only for this dataset's
     /// changes stream.
@@ -444,6 +463,7 @@ impl RefreshTaskBuilder {
             snapshot_refresh_state: self.snapshot_refresh_state,
             cdc_insert_plan_cache: Arc::new(Mutex::new(None)),
             cdc_param_overrides: self.cdc_param_overrides,
+            in_flight_revalidations: self.in_flight_revalidations,
         }
     }
 }
@@ -522,6 +542,7 @@ pub struct RefreshTask {
     cdc_insert_plan_cache: Arc<Mutex<Option<changes::CdcInsertPlanCache>>>,
     /// Per-dataset `cdc_*` parameter overrides drawn from `dataset.acceleration.params`.
     pub(crate) cdc_param_overrides: Option<Arc<HashMap<String, String>>>,
+    in_flight_revalidations: super::caching::InFlightRevalidations,
 }
 
 impl std::fmt::Debug for RefreshTask {
@@ -1208,6 +1229,7 @@ impl RefreshTask {
             self.dataset_name.to_string().as_str(),
             ttl,
             Arc::clone(&self.accelerator_write_mutex),
+            Arc::clone(&self.in_flight_revalidations),
         )
         .await
         .map_err(|e| RetryError::permanent(super::Error::FailedToRefreshDataset { source: e }))?;

--- a/crates/runtime-table/src/accelerated/refresh_task_runner.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task_runner.rs
@@ -63,6 +63,9 @@ pub struct RefreshTaskRunnerBuilder {
     is_s3_express_acceleration: bool,
     engine_type_rewrites: arrow_tools::type_rewrite::TypeRewriteRules,
     snapshot_refresh_state: Option<crate::accelerated::snapshots::SnapshotRefreshState>,
+    /// Forwarded to the refresh task so the caching stale-row refresh claims
+    /// the keys it replaces.
+    in_flight_revalidations: Option<crate::accelerated::caching::InFlightRevalidations>,
 }
 
 impl RefreshTaskRunnerBuilder {
@@ -97,6 +100,7 @@ impl RefreshTaskRunnerBuilder {
             is_s3_express_acceleration: false,
             engine_type_rewrites: &[],
             snapshot_refresh_state: None,
+            in_flight_revalidations: None,
         }
     }
 
@@ -170,6 +174,17 @@ impl RefreshTaskRunnerBuilder {
         self
     }
 
+    /// Shares the caching accelerator's claim set with the refresh task, so
+    /// its periodic stale-row refresh claims the keys it replaces.
+    #[must_use]
+    pub fn with_in_flight_revalidations(
+        mut self,
+        in_flight_revalidations: crate::accelerated::caching::InFlightRevalidations,
+    ) -> Self {
+        self.in_flight_revalidations = Some(in_flight_revalidations);
+        self
+    }
+
     #[must_use]
     pub fn build(self) -> RefreshTaskRunner {
         let mut refresh_task_builder = RefreshTask::builder(
@@ -206,6 +221,11 @@ impl RefreshTaskRunnerBuilder {
 
         if let Some(flag) = self.initial_load_completed {
             refresh_task_builder = refresh_task_builder.with_initial_load_completed(flag);
+        }
+
+        if let Some(in_flight_revalidations) = self.in_flight_revalidations {
+            refresh_task_builder =
+                refresh_task_builder.with_in_flight_revalidations(in_flight_revalidations);
         }
 
         let refresh_task = Arc::new(refresh_task_builder.build());

--- a/crates/runtime-table/src/accelerated/retention.rs
+++ b/crates/runtime-table/src/accelerated/retention.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use std::{sync::Arc, time::SystemTime};
 
 use crate::accelerated::{
-    DataRetentionFilter, Retention, refresh, refresh_task::collect_all_indexes,
+    DataRetentionFilter, Retention, RetentionPredicate, refresh, refresh_task::collect_all_indexes,
 };
 use crate::federated::FederatedTable;
 use crate::filter_converter::{TimestampFilterConvert, create_timestamp_filter_convert};
@@ -176,10 +176,8 @@ impl super::AcceleratedTable {
         loop {
             interval_timer.tick().await;
 
-            // Lock the accelerator to protect concurrent access to the accelerator during cache/snapshot operations
-            let _lock_guard = accelerator_write_mutex.lock().await;
-
             let mut exprs = Vec::new();
+            let mut computed: Option<&Arc<dyn RetentionPredicate>> = None;
 
             // convert retention filters into data eviction expressions
             for filter in &retention.filters {
@@ -187,6 +185,12 @@ impl super::AcceleratedTable {
                     DataRetentionFilter::Expression { delete_expr } => {
                         log_retention_action(&dataset_name, "using SQL expression");
                         exprs.push(delete_expr.clone());
+                    }
+                    DataRetentionFilter::Computed { predicate } => {
+                        // Resolved below, once the static filters have been
+                        // combined — it is given their result and has the last
+                        // word on it.
+                        computed = Some(predicate);
                     }
                     DataRetentionFilter::Time {
                         period,
@@ -255,12 +259,35 @@ impl super::AcceleratedTable {
             }
 
             // Combine all expressions into a single OR expression as time and SQL expressions are applied independently
-            let Some(expr) = exprs.into_iter().map(|e| *e).reduce(Expr::or) else {
-                tracing::warn!(
-                    "[retention] No valid retention filters found for dataset {dataset_name}"
-                );
-                continue;
+            let configured = exprs.into_iter().map(|e| *e).reduce(Expr::or);
+
+            let expr = if let Some(predicate) = computed {
+                match predicate.delete_expr(&accelerator, configured).await {
+                    // Nothing to remove this tick is the ordinary case for a
+                    // budget that is not yet exceeded, so it is not a warning.
+                    Ok(None) => continue,
+                    Ok(Some(expr)) => expr,
+                    Err(e) => {
+                        tracing::warn!(
+                            "[retention] Failed to resolve what to delete for dataset {dataset_name}, so it keeps whatever is past its retention until the next check. Cause: {e}"
+                        );
+                        continue;
+                    }
+                }
+            } else {
+                let Some(expr) = configured else {
+                    tracing::warn!(
+                        "[retention] No valid retention filters found for dataset {dataset_name}"
+                    );
+                    continue;
+                };
+                expr
             };
+
+            // Taken only around the delete. Resolving the predicate above can
+            // query the accelerator, and holding this across that query would
+            // stall every write for its duration.
+            let _lock_guard = accelerator_write_mutex.lock().await;
 
             if let Ok(num_records) = apply_retention_filters_once(
                 &dataset_name,

--- a/crates/runtime-table/src/accelerated/retention.rs
+++ b/crates/runtime-table/src/accelerated/retention.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use std::{sync::Arc, time::SystemTime};
 
 use crate::accelerated::{
-    DataRetentionFilter, Retention, RetentionPredicate, refresh, refresh_task::collect_all_indexes,
+    DataRetentionFilter, Retention, refresh, refresh_task::collect_all_indexes,
 };
 use crate::federated::FederatedTable;
 use crate::filter_converter::{TimestampFilterConvert, create_timestamp_filter_convert};
@@ -177,7 +177,6 @@ impl super::AcceleratedTable {
             interval_timer.tick().await;
 
             let mut exprs = Vec::new();
-            let mut computed: Option<&Arc<dyn RetentionPredicate>> = None;
 
             // convert retention filters into data eviction expressions
             for filter in &retention.filters {
@@ -185,12 +184,6 @@ impl super::AcceleratedTable {
                     DataRetentionFilter::Expression { delete_expr } => {
                         log_retention_action(&dataset_name, "using SQL expression");
                         exprs.push(delete_expr.clone());
-                    }
-                    DataRetentionFilter::Computed { predicate } => {
-                        // Resolved below, once the static filters have been
-                        // combined — it is given their result and has the last
-                        // word on it.
-                        computed = Some(predicate);
                     }
                     DataRetentionFilter::Time {
                         period,
@@ -261,7 +254,7 @@ impl super::AcceleratedTable {
             // Combine all expressions into a single OR expression as time and SQL expressions are applied independently
             let configured = exprs.into_iter().map(|e| *e).reduce(Expr::or);
 
-            let expr = if let Some(predicate) = computed {
+            let expr = if let Some(predicate) = retention.computed.as_ref() {
                 match predicate.delete_expr(&accelerator, configured).await {
                     // Nothing to remove this tick is the ordinary case for a
                     // budget that is not yet exceeded, so it is not a warning.
@@ -312,7 +305,7 @@ impl super::AcceleratedTable {
     }
 }
 
-fn create_timestamp_filter_converter(
+pub(crate) fn create_timestamp_filter_converter(
     accelerator: &Arc<dyn TableProvider>,
     time_column: &str,
     time_format: Option<TimeFormat>,

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -3010,41 +3010,23 @@ impl DataFusion {
                 );
             }
 
-            // Auto-configure cache retention when stale_if_error is disabled.
-            // Expired cache entries (past max_age + SWR) are never served and waste storage.
-            if !acceleration_settings.caching_stale_if_error.is_enabled() {
-                if dataset.retention_period().is_some() {
-                    tracing::warn!(
-                        dataset = %dataset.name,
-                        "User-specified retention_period is overridden by automatic cache retention in caching mode",
-                    );
-                }
-
-                let max_age = acceleration_settings
-                    .caching_ttl
-                    .unwrap_or(Duration::from_secs(30));
-                let swr = acceleration_settings
-                    .caching_stale_while_revalidate_ttl
-                    .unwrap_or_default();
-                let retention_period = max_age + swr;
-                let check_interval = retention_period.max(Duration::from_secs(30));
-
-                let cache_retention = Retention::builder()
-                    .time_column(Some(crate::accelerated::caching::CACHE_REFRESHED_AT_COLUMN))
-                    .time_period(Some(retention_period))
-                    .check_interval(Some(check_interval))
-                    .enabled(true)
-                    .build();
-
-                accelerated_table_builder.retention(cache_retention);
-            }
-
+            // A caching accelerator's retention is enforced by
+            // `accelerated::caching_eviction`, attached as a retention filter by
+            // the accelerated-table builder. A `retention_period` or
+            // `retention_sql` the user sets still applies, but is evaluated per
+            // cache entry rather than per row: a cached response can span
+            // several rows (a paginated one is fetched a page at a time), and a
+            // row-level delete could take part of one and leave the rest to be
+            // served as though it were the whole response.
             accelerated_table_builder.caching_ttl(acceleration_settings.caching_ttl);
             accelerated_table_builder.caching_stale_while_revalidate_ttl(
                 acceleration_settings.caching_stale_while_revalidate_ttl,
             );
             accelerated_table_builder
                 .caching_stale_if_error(acceleration_settings.caching_stale_if_error.is_enabled());
+            accelerated_table_builder
+                .caching_max_size_bytes(acceleration_settings.caching_max_size);
+            accelerated_table_builder.caching_max_items(acceleration_settings.caching_max_items);
         }
 
         // Get the acceleration layout (used for snapshots and size metrics)

--- a/scripts/check_table_layers.py
+++ b/scripts/check_table_layers.py
@@ -62,6 +62,7 @@ ALLOWED: dict[str, str] = {
     "SlowProvider": "test double",
     "WriteOrderRecordingProvider": "test double",
     "DelayedNativeTableProvider": "test double",
+    "CountingAccelerator": "test double",
 }
 
 STRUCT = re.compile(r"(?:pub(?:\([^)]*\))? )?struct (\w+)\s*\{([^}]*)\}")


### PR DESCRIPTION
Backport of #13604 to `release/2.2`.

## Summary
- Cherry-picks the 5 commits from #13604 onto `release/2.2`. All applied cleanly (auto-merged on `Cargo.lock`, `acceleration.rs`, `refresh.rs`, `datafusion/mod.rs`).
- See #13604 for the full description of the change: bounds a `refresh_mode: caching` accelerator by size (`caching_max_size`) and count (`caching_max_items`), makes eviction entry-granular, fixes `caching_stale_if_error` to act on a failing origin, and stops cache-entry replacement from rewriting the whole acceleration.

## Test plan
- [ ] Full test suite / sign-off on this branch
- [ ] Confirm behavior matches #13604 once that PR is reviewed/merged to trunk