### PR TITLE
fix(acceleration,cayenne): Resolve quoted columns in keys, name which primary key columns are null

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "util",
 ]
 
 [[package]]
@@ -17793,6 +17794,7 @@ dependencies = [
  "snafu",
  "spicepod",
  "tracing",
+ "util",
 ]
 
 [[package]]
@@ -23118,6 +23120,7 @@ dependencies = [
  "pin-project",
  "rand 0.10.1",
  "serde_json",
+ "snafu",
  "tokio",
  "tokio-util",
  "tracing",

--- a/crates/accelerators/accelerator-duckdb/Cargo.toml
+++ b/crates/accelerators/accelerator-duckdb/Cargo.toml
@@ -49,6 +49,7 @@ duckdb.workspace = true
 itertools.workspace = true
 snafu.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }
+util = { path = "../../util" }
 
 [dev-dependencies]
 # Test-only, and deliberately dev-only: these sit in the `runtime` tier, so a normal

--- a/crates/accelerators/accelerator-duckdb/src/lib.rs
+++ b/crates/accelerators/accelerator-duckdb/src/lib.rs
@@ -55,7 +55,7 @@ use datafusion_table_providers::{
         self as db_connection_pool,
         duckdbpool::{DuckDbConnectionPool, DuckDbConnectionPoolBuilder},
     },
-    util::{column_reference::ColumnReference, indexes::IndexType},
+    util::indexes::IndexType,
 };
 use duckdb::AccessMode;
 use futures::StreamExt;
@@ -1763,9 +1763,7 @@ fn duckdb_unique_index_columns(cmd: &CreateExternalTable) -> Vec<Vec<String>> {
             if index_type != IndexType::Unique {
                 return None;
             }
-            ColumnReference::try_from(columns.as_str())
-                .ok()
-                .map(|columns| columns.iter().map(str::to_string).collect())
+            util::column_reference::parse(&columns).ok()
         })
         .collect()
 }

--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -52,6 +52,7 @@ use super::super::deletion_strategy::{
     Int64PkDeletionSnapshot, PkDeletionStrategyWithCache, RowConverterDeletionSnapshot,
 };
 use super::super::memory_account::CayenneMemoryAccount;
+use super::super::pk_validation::null_primary_key_message;
 use super::super::utils::{bytes_key, convert_to_u64_box, i64_key};
 use super::filter_exec::{InsertRecordHandling, is_pk_visible_i64, is_pk_visible_row_key};
 use super::vector_io::DeletionVectorWriteResult;
@@ -635,7 +636,7 @@ impl CayenneDeletionSink {
                         if pk_columns.iter().any(|column| column.null_count() > 0) {
                             return Err(Error::DataValidation {
                                 table: table_name.clone(),
-                                message: "Primary key values must be non-null".to_string(),
+                                message: null_primary_key_message(&batch, &projected_indices),
                             });
                         }
                         let rows = row_converter.convert_columns(&pk_columns)?;
@@ -719,7 +720,7 @@ impl CayenneDeletionSink {
         if pk_array.null_count() > 0 {
             return Err(Error::DataValidation {
                 table: table_name.clone(),
-                message: "Primary key values must be non-null".to_string(),
+                message: null_primary_key_message(batch, std::slice::from_ref(pk_column_index)),
             });
         }
 

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -98,6 +98,7 @@ pub(crate) mod overwrite;
 pub mod partitioned_wal;
 pub(crate) mod pk_index;
 pub(crate) mod pk_keyset_budget;
+pub(crate) mod pk_validation;
 pub(crate) mod predicate_stats;
 pub(crate) mod query_admission;
 pub(crate) mod retention;

--- a/crates/cayenne/src/provider/on_conflict.rs
+++ b/crates/cayenne/src/provider/on_conflict.rs
@@ -26,6 +26,7 @@ use super::pk_index::{
     CachedPkIndex, CheckedOutShardedPkIndex, PendingPkExistence, PkCheckoutGuard, PkDigestSet,
     PkExistenceRef,
 };
+use super::pk_validation::null_primary_key_message;
 use crate::metadata::InlinedData;
 
 use arrow::record_batch::RecordBatch;
@@ -708,8 +709,9 @@ impl futures::Stream for PrimaryKeyValidationStream {
                 {
                     Poll::Ready(Some(Err(datafusion_common::DataFusionError::Execution(
                         format!(
-                            "Data validation failed for table '{}': Primary key values must be non-null",
-                            this.table_name
+                            "Data validation failed for table '{}': {}",
+                            this.table_name,
+                            null_primary_key_message(&batch, &this.pk_indices)
                         ),
                     ))))
                 } else {

--- a/crates/cayenne/src/provider/pk_validation.rs
+++ b/crates/cayenne/src/provider/pk_validation.rs
@@ -1,0 +1,114 @@
+/*
+Copyright 2025-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! The message every write and delete path reports when a primary key column holds a
+//! null. A composite key is only actionable if the message says which of its columns
+//! carried the null, so the message is built from the batch rather than written out at
+//! each call site.
+
+use arrow::record_batch::RecordBatch;
+
+const FIX: &str = "Every primary key column must be non-null: populate it in the source data, or set `primary_key` to columns that are always present. For details, visit https://spiceai.org/docs/features/data-acceleration/constraints";
+
+/// The `DataValidation` message for a batch whose primary key columns (`pk_indices`,
+/// as positions in `batch`) are not all populated, naming the ones that hold a null.
+pub(crate) fn null_primary_key_message(batch: &RecordBatch, pk_indices: &[usize]) -> String {
+    let schema = batch.schema();
+    let columns: Vec<String> = pk_indices
+        .iter()
+        .filter(|&&index| {
+            batch
+                .columns()
+                .get(index)
+                .is_some_and(|column| column.null_count() > 0)
+        })
+        .map(|&index| format!("'{}'", schema.field(index).name()))
+        .collect();
+
+    match columns.as_slice() {
+        // The caller found a null the null counts no longer see (a batch swapped
+        // underneath, an index outside the batch): still report the violation.
+        [] => format!("Primary key values must be non-null. {FIX}"),
+        [column] => format!("Primary key column {column} has null values. {FIX}"),
+        _ => format!(
+            "Primary key columns {} have null values. {FIX}",
+            columns.join(", ")
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn batch(instance_ids: Vec<Option<&str>>, values: Vec<Option<i64>>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("time_unix_nano", DataType::Int64, false),
+            Field::new("service.instance.id", DataType::Utf8, true),
+            Field::new("value", DataType::Int64, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1_i64, 2])),
+                Arc::new(StringArray::from(instance_ids)),
+                Arc::new(Int64Array::from(values)),
+            ],
+        )
+        .expect("batch")
+    }
+
+    #[test]
+    fn names_the_null_column_of_a_composite_key() {
+        let message =
+            null_primary_key_message(&batch(vec![Some("a"), None], vec![None, None]), &[0, 1]);
+        assert!(
+            message.starts_with("Primary key column 'service.instance.id' has null values."),
+            "the null column must be named: {message}"
+        );
+        assert!(
+            message.contains("data-acceleration/constraints"),
+            "the message must link the constraints docs: {message}"
+        );
+    }
+
+    #[test]
+    fn names_every_null_column() {
+        let message =
+            null_primary_key_message(&batch(vec![None, None], vec![Some(1), None]), &[1, 2]);
+        assert!(
+            message.starts_with(
+                "Primary key columns 'service.instance.id', 'value' have null values."
+            ),
+            "both null columns must be named: {message}"
+        );
+    }
+
+    #[test]
+    fn reports_the_violation_without_a_column_when_none_is_null() {
+        let message = null_primary_key_message(
+            &batch(vec![Some("a"), Some("b")], vec![None, None]),
+            &[0, 1],
+        );
+        assert!(
+            message.starts_with("Primary key values must be non-null."),
+            "the fallback keeps reporting the violation: {message}"
+        );
+    }
+}

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -66,6 +66,7 @@ use super::pk_index::{
     RowLocation, ShardedPkIndex, approx_captured_file_bytes, deserialize_pk_bloom_sidecar,
     pk_digest, serialize_pk_bloom_sidecar, shard_of_pk,
 };
+use super::pk_validation::null_primary_key_message;
 use super::streaming::StreamingExec;
 use crate::bounded_fifo::BoundedFifoSet;
 use crate::catalog::{CatalogError, CatalogResult, MetadataCatalog, SnapshotSequenceCommit};
@@ -13147,7 +13148,7 @@ impl CayenneTableProvider {
             if any_pk_nullable && pk_columns.iter().any(|col| col.is_null(row_idx)) {
                 return Err(Error::DataValidation {
                     table: self.table_metadata.table_name.clone(),
-                    message: "Primary key values must be non-null".to_string(),
+                    message: null_primary_key_message(&batch, ctx.pk_indices),
                 });
             }
 
@@ -13550,7 +13551,7 @@ impl CayenneTableProvider {
                 {
                     return Err(Error::DataValidation {
                         table: self.table_metadata.table_name.clone(),
-                        message: "Primary key values must be non-null".to_string(),
+                        message: null_primary_key_message(&batch, pk_indices),
                     });
                 }
                 filtered_batches.push(batch);
@@ -14132,7 +14133,7 @@ impl CayenneTableProvider {
                 if pk_array.null_count() > 0 {
                     return Err(Error::DataValidation {
                         table: self.table_metadata.table_name.clone(),
-                        message: "Primary key values must be non-null".to_string(),
+                        message: null_primary_key_message(&batch, &pk_indices[..1]),
                     });
                 }
                 // Bulk values() iteration: the null gate proves the buffer
@@ -14168,7 +14169,7 @@ impl CayenneTableProvider {
                     if pk_columns.iter().any(|column| column.is_null(row_index)) {
                         return Err(Error::DataValidation {
                             table: self.table_metadata.table_name.clone(),
-                            message: "Primary key values must be non-null".to_string(),
+                            message: null_primary_key_message(&batch, pk_indices),
                         });
                     }
                     let should_delete = deleted_row_keys.contains(rows.row(row_index).as_ref());
@@ -26423,7 +26424,7 @@ impl CayenneTableProvider {
                 if pk_array.null_count() > 0 {
                     return Err(Error::DataValidation {
                         table: self.table_metadata.table_name.clone(),
-                        message: "Primary key values must be non-null".to_string(),
+                        message: null_primary_key_message(&batch, std::slice::from_ref(&pk_index)),
                     });
                 }
                 // Column sweep (see `DeletionIndex::get_batch`): bulk PK slice
@@ -26488,7 +26489,7 @@ impl CayenneTableProvider {
                 if pk_has_nulls {
                     return Err(Error::DataValidation {
                         table: self.table_metadata.table_name.clone(),
-                        message: "Primary key values must be non-null".to_string(),
+                        message: null_primary_key_message(&batch, &pk_indices),
                     });
                 }
 
@@ -30604,8 +30605,9 @@ impl CayenneTableProvider {
                     })?;
                 if pk_array.null_count() > 0 {
                     return Err(datafusion_common::DataFusionError::Execution(format!(
-                        "Primary key values must be non-null for table {}",
-                        self.table_metadata.table_name
+                        "Data validation failed for table '{}': {}",
+                        self.table_metadata.table_name,
+                        null_primary_key_message(batch, std::slice::from_ref(&pk_index))
                     )));
                 }
                 // Bulk slice copy (~5x over the per-row is_null+value+push
@@ -30633,8 +30635,9 @@ impl CayenneTableProvider {
                 for row_index in 0..batch.num_rows() {
                     if pk_columns.iter().any(|column| column.is_null(row_index)) {
                         return Err(datafusion_common::DataFusionError::Execution(format!(
-                            "Primary key values must be non-null for table {}",
-                            self.table_metadata.table_name
+                            "Data validation failed for table '{}': {}",
+                            self.table_metadata.table_name,
+                            null_primary_key_message(batch, &pk_indices)
                         )));
                     }
                     row_keys.push(bytes_key(rows.row(row_index).as_ref()));

--- a/crates/cayenne/tests/on_conflict_test.rs
+++ b/crates/cayenne/tests/on_conflict_test.rs
@@ -447,3 +447,108 @@ async fn test_upsert_in_batch_duplicate_composite_pk_impl(
     );
     Ok(())
 }
+
+// --- Null primary key values ---
+// A composite key is only actionable if the rejection says which of its columns
+// carried the null.
+
+test_with_backends!(test_null_composite_pk_names_the_null_column_impl);
+test_with_backends!(test_null_composite_pk_names_the_null_column_blind_append_impl);
+
+/// A table keyed on `(region, id)` whose `region` is nullable, so a null reaches the
+/// write path's validation instead of `DataFusion`'s non-nullable column check.
+async fn nullable_composite_pk_table(
+    fixture: &common::TestFixture,
+    table_name: &str,
+    vortex_config: VortexConfig,
+    on_conflict: Option<OnConflict>,
+) -> Result<SessionContext, Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("region", DataType::Utf8, true),
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, true),
+    ]));
+    let table_options = CreateTableOptions {
+        table_name: table_name.to_string(),
+        schema,
+        primary_key: vec!["region".to_string(), "id".to_string()],
+        on_conflict,
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config,
+    };
+    let catalog_arc: Arc<dyn MetadataCatalog> = fixture.catalog.clone();
+    let ctx = SessionContext::new();
+    let table = Arc::new(
+        CayenneTableProvider::create_table(catalog_arc, table_options, ctx.runtime_env()).await?,
+    );
+    ctx.register_table(
+        table_name,
+        Arc::clone(&table) as Arc<dyn datafusion::datasource::TableProvider>,
+    )?;
+    Ok(ctx)
+}
+
+fn assert_names_the_null_pk_column(err: &dyn std::error::Error, table_name: &str) {
+    let message = err.to_string();
+    assert!(
+        message.contains("Primary key column 'region' has null values"),
+        "the rejection must name the null column of the composite key: {message}"
+    );
+    assert!(
+        message.contains(table_name),
+        "the rejection must name the table: {message}"
+    );
+    assert!(
+        message.contains("https://spiceai.org/docs/features/data-acceleration/constraints"),
+        "the rejection must link the constraints docs: {message}"
+    );
+}
+
+async fn test_null_composite_pk_names_the_null_column_impl(
+    fixture: common::TestFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = nullable_composite_pk_table(
+        &fixture,
+        "null_composite_pk",
+        VortexConfig::default(),
+        Some(OnConflict::Upsert(ColumnReference::new(vec![
+            "region".to_string(),
+            "id".to_string(),
+        ]))),
+    )
+    .await?;
+
+    let err = ctx
+        .sql("INSERT INTO null_composite_pk VALUES ('US', 1, 100), (NULL, 2, 200)")
+        .await?
+        .collect()
+        .await
+        .expect_err("a null in a primary key column must be rejected");
+
+    assert_names_the_null_pk_column(&err, "null_composite_pk");
+    Ok(())
+}
+
+/// `pk_conflict_detection: none` skips the existence lookup but not the validation,
+/// and it reports the null column the same way.
+async fn test_null_composite_pk_names_the_null_column_blind_append_impl(
+    fixture: common::TestFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let vortex_config = VortexConfig {
+        pk_conflict_detection: PkConflictDetection::None,
+        ..VortexConfig::default()
+    };
+    let ctx = nullable_composite_pk_table(&fixture, "null_composite_pk_blind", vortex_config, None)
+        .await?;
+
+    let err = ctx
+        .sql("INSERT INTO null_composite_pk_blind VALUES ('US', 1, 100), (NULL, 2, 200)")
+        .await?
+        .collect()
+        .await
+        .expect_err("a null in a primary key column must be rejected");
+
+    assert_names_the_null_pk_column(&err, "null_composite_pk_blind");
+    Ok(())
+}

--- a/crates/data_components/src/arrow.rs
+++ b/crates/data_components/src/arrow.rs
@@ -109,17 +109,9 @@ fn parse_indexes_option(
             continue;
         }
 
-        // Parse column reference - may be compound like "(col1, col2)" or just "col1"
-        let columns: Vec<String> = if col_part.starts_with('(') && col_part.ends_with(')') {
-            // Compound key: "(col1, col2)"
-            col_part[1..col_part.len() - 1]
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect()
-        } else {
-            vec![col_part.to_string()]
-        };
+        // May be compound like "(col1, col2)" or just "col1", with quoted names.
+        let columns = util::column_reference::parse(col_part)
+            .map_err(|e| DataFusionError::Configuration(e.to_string()))?;
 
         // Validate all columns exist in schema
         for col in &columns {
@@ -529,6 +521,23 @@ mod tests {
 
         assert_eq!(result[2].0, vec!["col2".to_string(), "col3".to_string()]);
         assert_eq!(result[2].1, IndexType::Unique);
+    }
+
+    #[test]
+    fn test_parse_indexes_quoted_column_name() {
+        let schema = create_schema_with_columns(&[
+            ("service.instance.id", arrow::datatypes::DataType::Utf8),
+            ("col1", arrow::datatypes::DataType::Int64),
+        ]);
+
+        let result = parse_indexes_option(r#"("service.instance.id",col1):unique"#, &schema)
+            .expect("parse failed");
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].0,
+            vec!["service.instance.id".to_string(), "col1".to_string()]
+        );
+        assert_eq!(result[0].1, IndexType::Unique);
     }
 
     #[test]

--- a/crates/runtime-acceleration/src/acceleration.rs
+++ b/crates/runtime-acceleration/src/acceleration.rs
@@ -34,10 +34,10 @@ use std::{collections::HashMap, fmt::Display, sync::Arc, time::Duration};
 /// Errors that can occur when parsing acceleration configuration.
 #[derive(Debug, Snafu)]
 pub enum ParseError {
-    #[snafu(display("Unable to parse column reference {column_ref}: {source}"))]
+    #[snafu(display("Failed to parse the column reference '{column_ref}': {source}"))]
     UnableToParseColumnReference {
         column_ref: String,
-        source: datafusion_table_providers::util::column_reference::Error,
+        source: util::column_reference::Error,
     },
 
     #[snafu(display("Error parsing {field} as duration: {source}"))]
@@ -750,12 +750,12 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
         acceleration: spicepod_acceleration::Acceleration,
     ) -> std::result::Result<Self, Self::Error> {
         let try_parse_column_reference = |column: &str| {
-            ColumnReference::try_from(column).map_err(|e| {
-                ParseError::UnableToParseColumnReference {
+            util::column_reference::parse(column)
+                .map(ColumnReference::new)
+                .map_err(|e| ParseError::UnableToParseColumnReference {
                     column_ref: column.to_string(),
                     source: e,
-                }
-            })
+                })
         };
 
         let try_parse_duration = |field: &str, duration: Option<String>| {
@@ -1279,6 +1279,67 @@ mod tests {
         acceleration
             .validate_primary_key(&schema_with(&["marker_id", "value"]))
             .expect("primary key column present, so validation passes");
+    }
+
+    /// A column whose name contains dots is referenced the way it would be written in
+    /// SQL, so the quotes are not part of the name.
+    #[test]
+    fn quoted_primary_key_column_resolves_to_the_schema_column() {
+        let acceleration = spicepod_acceleration::Acceleration {
+            primary_key: Some(r#"(time_unix_nano, "service.instance.id")"#.to_string()),
+            ..Default::default()
+        };
+        let parsed = Acceleration::try_from(acceleration).expect("acceleration should parse");
+
+        let schema = schema_with(&["time_unix_nano", "service.instance.id", "value"]);
+        parsed
+            .validate_primary_key(&schema)
+            .expect("quoted primary key column present, so validation passes");
+
+        let constraints = parsed
+            .table_constraints(Arc::clone(&schema))
+            .expect("constraints should build")
+            .expect("a primary key was configured");
+        assert_eq!(
+            constraints,
+            Constraints::new_unverified(vec![Constraint::PrimaryKey(vec![1, 0])]),
+            "the primary key must point at both configured columns"
+        );
+    }
+
+    #[test]
+    fn quoted_index_column_resolves_to_the_schema_column() {
+        let acceleration = spicepod_acceleration::Acceleration {
+            indexes: HashMap::from([(
+                r#""service.instance.id""#.to_string(),
+                spicepod_acceleration::IndexType::Enabled,
+            )]),
+            ..Default::default()
+        };
+        let parsed = Acceleration::try_from(acceleration).expect("acceleration should parse");
+
+        parsed
+            .validate_indexes(&schema_with(&["service.instance.id", "value"]))
+            .expect("quoted index column present, so validation passes");
+    }
+
+    #[test]
+    fn malformed_primary_key_reference_names_the_reference() {
+        let acceleration = spicepod_acceleration::Acceleration {
+            primary_key: Some(r#"(time_unix_nano, "service.instance.id"#.to_string()),
+            ..Default::default()
+        };
+        let err = Acceleration::try_from(acceleration).expect_err("unterminated quote must fail");
+
+        assert!(
+            matches!(err, ParseError::UnableToParseColumnReference { .. }),
+            "expected UnableToParseColumnReference, got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains(r#"(time_unix_nano, "service.instance.id"#) && msg.contains("closing"),
+            "message should name the reference and what is missing: {msg}"
+        );
     }
 
     /// The exact configuration that turns durable federated write-back on.

--- a/crates/runtime-acceleration/src/acceleration.rs
+++ b/crates/runtime-acceleration/src/acceleration.rs
@@ -1337,7 +1337,8 @@ mod tests {
         );
         let msg = err.to_string();
         assert!(
-            msg.contains(r#"(time_unix_nano, "service.instance.id"#) && msg.contains("closing"),
+            msg.contains(r#"(time_unix_nano, "service.instance.id"#)
+                && msg.contains("must end with ')'"),
             "message should name the reference and what is missing: {msg}"
         );
     }

--- a/crates/runtime-component/Cargo.toml
+++ b/crates/runtime-component/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true, features = ["derive"] }
 snafu.workspace = true
 spicepod = { path = "../spicepod" }
 tracing.workspace = true
+util = { path = "../util" }
 
 [lints]
 workspace = true

--- a/crates/runtime-component/src/dataset/mod.rs
+++ b/crates/runtime-component/src/dataset/mod.rs
@@ -25,7 +25,6 @@ use datafusion::sql::{
         parser::{Parser, ParserError},
     },
 };
-use datafusion_table_providers::util::column_reference;
 use snafu::prelude::*;
 use spicepod::{
     component::{dataset as spicepod_dataset, embeddings::ColumnEmbeddingConfig},
@@ -84,10 +83,10 @@ pub enum Error {
     ))]
     OnConflictTargetMismatch { extra_detail: String },
 
-    #[snafu(display("Error parsing column reference {column_ref}: {source}"))]
+    #[snafu(display("Failed to parse the column reference '{column_ref}': {source}"))]
     UnableToParseColumnReference {
         column_ref: String,
-        source: column_reference::Error,
+        source: util::column_reference::Error,
     },
 
     #[snafu(display("Error parsing {field} as duration: {source}"))]

--- a/crates/runtime/src/model/nsql.rs
+++ b/crates/runtime/src/model/nsql.rs
@@ -37,7 +37,6 @@ use datafusion::{
     common::{Constraint, Constraints, DataFusionError, utils::quote_identifier},
     sql::TableReference,
 };
-use datafusion_table_providers::util::column_reference::ColumnReference;
 use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 #[cfg(test)]
@@ -507,10 +506,7 @@ fn nsql_sql_context() -> NsqlSqlContext {
 }
 
 fn column_reference_columns(reference: &str) -> Vec<String> {
-    ColumnReference::try_from(reference).map_or_else(
-        |_| vec![reference.to_string()],
-        |columns| columns.iter().map(ToString::to_string).collect(),
-    )
+    util::column_reference::parse(reference).unwrap_or_else(|_| vec![reference.to_string()])
 }
 
 fn configured_acceleration_indexes(

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -19,6 +19,7 @@ humantime.workspace = true
 pin-project = { workspace = true, optional = true }
 rand.workspace = true
 serde_json.workspace = true
+snafu.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
 tokio-util = { workspace = true, optional = true }
 tracing = { workspace = true }

--- a/crates/util/src/column_reference.rs
+++ b/crates/util/src/column_reference.rs
@@ -16,11 +16,14 @@ limitations under the License.
 
 //! Parsing of the column reference strings used by `acceleration.primary_key`,
 //! `acceleration.indexes` and `acceleration.on_conflict`: a single column, or a
-//! compound `(column_a, column_b)` list.
+//! comma-separated list optionally wrapped in parentheses.
 //!
-//! A name may be double-quoted, the way it would be written in SQL, which is how a
-//! column whose name contains dots (`"service.instance.id"`) is referenced. The
-//! parsed names are always the unquoted names as they appear in the schema.
+//! The names are literal Arrow field names, NOT SQL identifiers, so a SQL identifier
+//! parser is the wrong tool: `sqlparser` reads `service.instance.id` as three
+//! qualifiers and rejects the `sentry-environment` and `2xx_count` field names an `OTel`
+//! schema is full of. A name may still be double-quoted the way SQL writes it, which is
+//! how a name containing dots is told apart from those qualifiers; the parsed names are
+//! always the unquoted names as they appear in the schema.
 
 use snafu::prelude::*;
 
@@ -32,14 +35,9 @@ pub enum Error {
     EmptyColumnReference { column_ref: String },
 
     #[snafu(display(
-        "The compound column reference '{column_ref}' is missing its closing ')'. Write a compound key as '(column_a, column_b)' and try again."
+        "The compound column reference '{column_ref}' must end with ')'. Write a compound key as '(column_a, column_b)' and try again."
     ))]
-    MissingClosingParenthesis { column_ref: String },
-
-    #[snafu(display(
-        "The column reference '{column_ref}' has unexpected text after its closing ')'. Write a compound key as '(column_a, column_b)' and try again."
-    ))]
-    TrailingText { column_ref: String },
+    UnclosedParenthesis { column_ref: String },
 
     #[snafu(display(
         "The column reference '{column_ref}' contains an empty column name. Remove the extra ',' and try again."
@@ -50,11 +48,6 @@ pub enum Error {
         "The quoted column name in the column reference '{column_ref}' is missing its closing '\"'. Quote a column name as '\"column.name\"' and try again."
     ))]
     UnterminatedQuotedName { column_ref: String },
-
-    #[snafu(display(
-        "The column reference '{column_ref}' has a '\"' in the middle of a column name. Quote a whole column name as '\"column.name\"', doubling any '\"' it contains, and try again."
-    ))]
-    MisplacedQuote { column_ref: String },
 
     #[snafu(display(
         "The column name '{column}' in the column reference '{column_ref}' contains an unsupported character '{character}'. Reference a column whose name does not contain ',', ';', ':', '(', ')' or '\"' and try again."
@@ -95,108 +88,28 @@ pub fn parse(column_ref: &str) -> Result<Vec<String>, Error> {
     );
 
     let inner = match trimmed.strip_prefix('(') {
-        Some(rest) => {
-            let end =
-                closing_parenthesis(rest).context(MissingClosingParenthesisSnafu { column_ref })?;
-            ensure!(
-                rest[end + 1..].trim().is_empty(),
-                TrailingTextSnafu { column_ref }
-            );
-            &rest[..end]
-        }
+        Some(rest) => rest
+            .strip_suffix(')')
+            .context(UnclosedParenthesisSnafu { column_ref })?,
         None => trimmed,
     };
 
-    split_names(inner, column_ref)
+    inner
+        .split(',')
+        .map(|name| parse_name(name.trim(), column_ref))
+        .collect()
 }
 
-/// The byte offset of the `)` closing the reference opened by the `(` that precedes
-/// `rest`, ignoring any `)` inside a quoted name.
-fn closing_parenthesis(rest: &str) -> Option<usize> {
-    let mut in_quotes = false;
-    for (offset, c) in rest.char_indices() {
-        match c {
-            '"' => in_quotes = !in_quotes,
-            ')' if !in_quotes => return Some(offset),
-            _ => {}
-        }
-    }
-    None
-}
+/// One name of a reference: the schema name, with the quotes an optionally quoted name
+/// is written with removed.
+fn parse_name(name: &str, column_ref: &str) -> Result<String, Error> {
+    let name = match name.strip_prefix('"') {
+        Some(rest) => rest
+            .strip_suffix('"')
+            .context(UnterminatedQuotedNameSnafu { column_ref })?,
+        None => name,
+    };
 
-/// Where the scan is within the name it is reading.
-enum State {
-    /// Before the first character of a name.
-    Start,
-    /// Reading an unquoted name.
-    Bare,
-    /// Inside `"`.
-    Quoted,
-    /// After the `"` that closed a name.
-    AfterQuote,
-}
-
-fn split_names(inner: &str, column_ref: &str) -> Result<Vec<String>, Error> {
-    let mut names: Vec<String> = Vec::new();
-    let mut current = String::new();
-    let mut state = State::Start;
-    let mut chars = inner.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        match state {
-            State::Start => match c {
-                ',' => return EmptyColumnNameSnafu { column_ref }.fail(),
-                '"' => state = State::Quoted,
-                c if c.is_whitespace() => {}
-                c => {
-                    current.push(c);
-                    state = State::Bare;
-                }
-            },
-            State::Bare => match c {
-                ',' => {
-                    push_name(&mut names, current.trim().to_string(), column_ref)?;
-                    current.clear();
-                    state = State::Start;
-                }
-                // A quoted name has to be the whole name: `a"b"` is ambiguous.
-                '"' => return MisplacedQuoteSnafu { column_ref }.fail(),
-                c => current.push(c),
-            },
-            State::Quoted => match c {
-                // `""` is an escaped quote within the name.
-                '"' if chars.peek() == Some(&'"') => {
-                    chars.next();
-                    current.push('"');
-                }
-                '"' => state = State::AfterQuote,
-                c => current.push(c),
-            },
-            State::AfterQuote => match c {
-                ',' => {
-                    push_name(&mut names, std::mem::take(&mut current), column_ref)?;
-                    state = State::Start;
-                }
-                c if c.is_whitespace() => {}
-                _ => return MisplacedQuoteSnafu { column_ref }.fail(),
-            },
-        }
-    }
-
-    match state {
-        State::Start if names.is_empty() => {
-            return EmptyColumnReferenceSnafu { column_ref }.fail();
-        }
-        State::Start => return EmptyColumnNameSnafu { column_ref }.fail(),
-        State::Bare => push_name(&mut names, current.trim().to_string(), column_ref)?,
-        State::Quoted => return UnterminatedQuotedNameSnafu { column_ref }.fail(),
-        State::AfterQuote => push_name(&mut names, current, column_ref)?,
-    }
-
-    Ok(names)
-}
-
-fn push_name(names: &mut Vec<String>, name: String, column_ref: &str) -> Result<(), Error> {
     ensure!(!name.is_empty(), EmptyColumnNameSnafu { column_ref });
     if let Some(character) = name.chars().find(|c| UNSUPPORTED_CHARACTERS.contains(c)) {
         return UnsupportedCharacterInNameSnafu {
@@ -206,8 +119,8 @@ fn push_name(names: &mut Vec<String>, name: String, column_ref: &str) -> Result<
         }
         .fail();
     }
-    names.push(name);
-    Ok(())
+
+    Ok(name.to_string())
 }
 
 #[cfg(test)]
@@ -227,6 +140,19 @@ mod tests {
         assert_eq!(names(" ( foo , bar ) "), vec!["foo", "bar"]);
         // The parentheses are optional: a comma-separated list is a compound key too.
         assert_eq!(names("foo, bar"), vec!["foo", "bar"]);
+    }
+
+    /// The names are literal field names, so what a SQL identifier parser would read as
+    /// a qualifier chain or reject outright is a single column here.
+    #[test]
+    fn parses_names_that_are_not_sql_identifiers() {
+        assert_eq!(names("service.instance.id"), vec!["service.instance.id"]);
+        assert_eq!(names("sentry-environment"), vec!["sentry-environment"]);
+        assert_eq!(names("2xx_count"), vec!["2xx_count"]);
+        assert_eq!(
+            names("(time_unix_nano, sd-routing-key)"),
+            vec!["time_unix_nano", "sd-routing-key"]
+        );
     }
 
     #[test]
@@ -254,59 +180,39 @@ mod tests {
             "The column reference '' is empty. Name the column to use, or a compound key as '(column_a, column_b)', and try again."
         );
         assert_eq!(
-            parse("()").expect_err("no columns"),
-            Error::EmptyColumnReference {
-                column_ref: "()".to_string()
-            }
-        );
-        assert_eq!(
             parse("(foo,bar").expect_err("unclosed paren"),
-            Error::MissingClosingParenthesis {
+            Error::UnclosedParenthesis {
                 column_ref: "(foo,bar".to_string()
             }
         );
         assert_eq!(
             parse("(foo, bar) baz").expect_err("trailing text"),
-            Error::TrailingText {
+            Error::UnclosedParenthesis {
                 column_ref: "(foo, bar) baz".to_string()
             }
         );
         assert_eq!(
-            parse("(foo,,bar)").expect_err("empty name"),
+            parse("()").expect_err("no columns"),
             Error::EmptyColumnName {
-                column_ref: "(foo,,bar)".to_string()
+                column_ref: "()".to_string()
             }
         );
-        assert_eq!(
-            parse("(foo,)").expect_err("trailing comma"),
-            Error::EmptyColumnName {
-                column_ref: "(foo,)".to_string()
-            }
-        );
-        assert_eq!(
-            parse("(,foo)").expect_err("leading comma"),
-            Error::EmptyColumnName {
-                column_ref: "(,foo)".to_string()
-            }
-        );
-        assert_eq!(
-            parse(r#""service.instance.id"#).expect_err("unterminated quote"),
-            Error::UnterminatedQuotedName {
-                column_ref: r#""service.instance.id"#.to_string()
-            }
-        );
-        assert_eq!(
-            parse(r#"(a"b")"#).expect_err("misplaced quote"),
-            Error::MisplacedQuote {
-                column_ref: r#"(a"b")"#.to_string()
-            }
-        );
-        assert_eq!(
-            parse(r#"("a"b)"#).expect_err("misplaced quote"),
-            Error::MisplacedQuote {
-                column_ref: r#"("a"b)"#.to_string()
-            }
-        );
+        for column_ref in ["(foo,,bar)", "(foo,)", "(,foo)"] {
+            assert_eq!(
+                parse(column_ref).expect_err("empty column name"),
+                Error::EmptyColumnName {
+                    column_ref: column_ref.to_string()
+                }
+            );
+        }
+        for column_ref in [r#""service.instance.id"#, r#"("a"b)"#] {
+            assert_eq!(
+                parse(column_ref).expect_err("unterminated quoted name"),
+                Error::UnterminatedQuotedName {
+                    column_ref: column_ref.to_string()
+                }
+            );
+        }
     }
 
     #[test]
@@ -314,41 +220,26 @@ mod tests {
         // A name holding one of the separators the reference is carried in cannot be
         // read back, so it is refused rather than silently split.
         assert_eq!(
-            parse(r#"("a,b")"#).expect_err("comma in name"),
+            parse(r#"(a"b)"#).expect_err("quote in name"),
             Error::UnsupportedCharacterInName {
-                column_ref: r#"("a,b")"#.to_string(),
-                column: "a,b".to_string(),
-                character: ',',
-            }
-        );
-        assert_eq!(
-            parse(r#""a""b""#).expect_err("quote in name"),
-            Error::UnsupportedCharacterInName {
-                column_ref: r#""a""b""#.to_string(),
+                column_ref: r#"(a"b)"#.to_string(),
                 column: r#"a"b"#.to_string(),
                 character: '"',
             }
         );
-        for character in [';', ':', '(', ')'] {
-            let column_ref = format!("a{character}b");
+        assert_eq!(
+            parse(r#"("a.b(c)")"#).expect_err("parenthesis in name"),
+            Error::UnsupportedCharacterInName {
+                column_ref: r#"("a.b(c)")"#.to_string(),
+                column: "a.b(c)".to_string(),
+                character: '(',
+            }
+        );
+        for column_ref in ["a;b", "a:b", r#"("a,b")"#] {
             assert!(
-                parse(&column_ref).is_err(),
+                parse(column_ref).is_err(),
                 "'{column_ref}' should be refused"
             );
         }
-    }
-
-    #[test]
-    fn quoted_names_may_contain_parentheses_and_dots() {
-        // `)` inside quotes does not close the compound reference.
-        assert_eq!(names(r#"("a.b", c)"#), vec!["a.b", "c"]);
-        assert_eq!(
-            parse(r#"("a)b", c)"#).expect_err("parenthesis in name"),
-            Error::UnsupportedCharacterInName {
-                column_ref: r#"("a)b", c)"#.to_string(),
-                column: "a)b".to_string(),
-                character: ')',
-            }
-        );
     }
 }

--- a/crates/util/src/column_reference.rs
+++ b/crates/util/src/column_reference.rs
@@ -1,0 +1,354 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Parsing of the column reference strings used by `acceleration.primary_key`,
+//! `acceleration.indexes` and `acceleration.on_conflict`: a single column, or a
+//! compound `(column_a, column_b)` list.
+//!
+//! A name may be double-quoted, the way it would be written in SQL, which is how a
+//! column whose name contains dots (`"service.instance.id"`) is referenced. The
+//! parsed names are always the unquoted names as they appear in the schema.
+
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu, PartialEq, Eq)]
+pub enum Error {
+    #[snafu(display(
+        "The column reference '{column_ref}' is empty. Name the column to use, or a compound key as '(column_a, column_b)', and try again."
+    ))]
+    EmptyColumnReference { column_ref: String },
+
+    #[snafu(display(
+        "The compound column reference '{column_ref}' is missing its closing ')'. Write a compound key as '(column_a, column_b)' and try again."
+    ))]
+    MissingClosingParenthesis { column_ref: String },
+
+    #[snafu(display(
+        "The column reference '{column_ref}' has unexpected text after its closing ')'. Write a compound key as '(column_a, column_b)' and try again."
+    ))]
+    TrailingText { column_ref: String },
+
+    #[snafu(display(
+        "The column reference '{column_ref}' contains an empty column name. Remove the extra ',' and try again."
+    ))]
+    EmptyColumnName { column_ref: String },
+
+    #[snafu(display(
+        "The quoted column name in the column reference '{column_ref}' is missing its closing '\"'. Quote a column name as '\"column.name\"' and try again."
+    ))]
+    UnterminatedQuotedName { column_ref: String },
+
+    #[snafu(display(
+        "The column reference '{column_ref}' has a '\"' in the middle of a column name. Quote a whole column name as '\"column.name\"', doubling any '\"' it contains, and try again."
+    ))]
+    MisplacedQuote { column_ref: String },
+
+    #[snafu(display(
+        "The column name '{column}' in the column reference '{column_ref}' contains an unsupported character '{character}'. Reference a column whose name does not contain ',', ';', ':', '(', ')' or '\"' and try again."
+    ))]
+    UnsupportedCharacterInName {
+        column_ref: String,
+        column: String,
+        character: char,
+    },
+}
+
+/// Characters that cannot appear in a referenced column name: each one is a separator in
+/// the strings a column reference is carried in (`(a, b)`, `index:unique;other:enabled`,
+/// `upsert:(a, b)`), so a name containing one could not be read back unambiguously.
+const UNSUPPORTED_CHARACTERS: [char; 6] = [',', ';', ':', '(', ')', '"'];
+
+/// Parses a column reference into the column names it references, in the order written.
+///
+/// ```rust
+/// # use util::column_reference::parse;
+/// assert_eq!(parse("id").expect("valid"), vec!["id"]);
+/// assert_eq!(
+///     parse(r#"(time_unix_nano, "service.instance.id")"#).expect("valid"),
+///     vec!["time_unix_nano", "service.instance.id"]
+/// );
+/// ```
+///
+/// # Errors
+///
+/// Returns an [`Error`] if the reference is malformed (an unclosed `(` or `"`, an empty
+/// column name) or names a column that cannot be referenced (see
+/// [`UNSUPPORTED_CHARACTERS`]).
+pub fn parse(column_ref: &str) -> Result<Vec<String>, Error> {
+    let trimmed = column_ref.trim();
+    ensure!(
+        !trimmed.is_empty(),
+        EmptyColumnReferenceSnafu { column_ref }
+    );
+
+    let inner = match trimmed.strip_prefix('(') {
+        Some(rest) => {
+            let end =
+                closing_parenthesis(rest).context(MissingClosingParenthesisSnafu { column_ref })?;
+            ensure!(
+                rest[end + 1..].trim().is_empty(),
+                TrailingTextSnafu { column_ref }
+            );
+            &rest[..end]
+        }
+        None => trimmed,
+    };
+
+    split_names(inner, column_ref)
+}
+
+/// The byte offset of the `)` closing the reference opened by the `(` that precedes
+/// `rest`, ignoring any `)` inside a quoted name.
+fn closing_parenthesis(rest: &str) -> Option<usize> {
+    let mut in_quotes = false;
+    for (offset, c) in rest.char_indices() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            ')' if !in_quotes => return Some(offset),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Where the scan is within the name it is reading.
+enum State {
+    /// Before the first character of a name.
+    Start,
+    /// Reading an unquoted name.
+    Bare,
+    /// Inside `"`.
+    Quoted,
+    /// After the `"` that closed a name.
+    AfterQuote,
+}
+
+fn split_names(inner: &str, column_ref: &str) -> Result<Vec<String>, Error> {
+    let mut names: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut state = State::Start;
+    let mut chars = inner.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match state {
+            State::Start => match c {
+                ',' => return EmptyColumnNameSnafu { column_ref }.fail(),
+                '"' => state = State::Quoted,
+                c if c.is_whitespace() => {}
+                c => {
+                    current.push(c);
+                    state = State::Bare;
+                }
+            },
+            State::Bare => match c {
+                ',' => {
+                    push_name(&mut names, current.trim().to_string(), column_ref)?;
+                    current.clear();
+                    state = State::Start;
+                }
+                // A quoted name has to be the whole name: `a"b"` is ambiguous.
+                '"' => return MisplacedQuoteSnafu { column_ref }.fail(),
+                c => current.push(c),
+            },
+            State::Quoted => match c {
+                // `""` is an escaped quote within the name.
+                '"' if chars.peek() == Some(&'"') => {
+                    chars.next();
+                    current.push('"');
+                }
+                '"' => state = State::AfterQuote,
+                c => current.push(c),
+            },
+            State::AfterQuote => match c {
+                ',' => {
+                    push_name(&mut names, std::mem::take(&mut current), column_ref)?;
+                    state = State::Start;
+                }
+                c if c.is_whitespace() => {}
+                _ => return MisplacedQuoteSnafu { column_ref }.fail(),
+            },
+        }
+    }
+
+    match state {
+        State::Start if names.is_empty() => {
+            return EmptyColumnReferenceSnafu { column_ref }.fail();
+        }
+        State::Start => return EmptyColumnNameSnafu { column_ref }.fail(),
+        State::Bare => push_name(&mut names, current.trim().to_string(), column_ref)?,
+        State::Quoted => return UnterminatedQuotedNameSnafu { column_ref }.fail(),
+        State::AfterQuote => push_name(&mut names, current, column_ref)?,
+    }
+
+    Ok(names)
+}
+
+fn push_name(names: &mut Vec<String>, name: String, column_ref: &str) -> Result<(), Error> {
+    ensure!(!name.is_empty(), EmptyColumnNameSnafu { column_ref });
+    if let Some(character) = name.chars().find(|c| UNSUPPORTED_CHARACTERS.contains(c)) {
+        return UnsupportedCharacterInNameSnafu {
+            column_ref,
+            column: name,
+            character,
+        }
+        .fail();
+    }
+    names.push(name);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(column_ref: &str) -> Vec<String> {
+        parse(column_ref).expect("valid column reference")
+    }
+
+    #[test]
+    fn parses_single_and_compound_references() {
+        assert_eq!(names("id"), vec!["id"]);
+        assert_eq!(names(" id "), vec!["id"]);
+        assert_eq!(names("(foo, bar)"), vec!["foo", "bar"]);
+        assert_eq!(names("(foo,bar)"), vec!["foo", "bar"]);
+        assert_eq!(names(" ( foo , bar ) "), vec!["foo", "bar"]);
+        // The parentheses are optional: a comma-separated list is a compound key too.
+        assert_eq!(names("foo, bar"), vec!["foo", "bar"]);
+    }
+
+    #[test]
+    fn parses_quoted_names() {
+        assert_eq!(
+            names(r#""service.instance.id""#),
+            vec!["service.instance.id"]
+        );
+        assert_eq!(
+            names(r#"(time_unix_nano, "service.instance.id")"#),
+            vec!["time_unix_nano", "service.instance.id"]
+        );
+        assert_eq!(
+            names(r#"("service.instance.id" , time_unix_nano)"#),
+            vec!["service.instance.id", "time_unix_nano"]
+        );
+        // Quoting preserves whitespace and case inside the name.
+        assert_eq!(names(r#"" Mixed Case ""#), vec![" Mixed Case "]);
+    }
+
+    #[test]
+    fn rejects_malformed_references() {
+        assert_eq!(
+            parse("").expect_err("empty").to_string(),
+            "The column reference '' is empty. Name the column to use, or a compound key as '(column_a, column_b)', and try again."
+        );
+        assert_eq!(
+            parse("()").expect_err("no columns"),
+            Error::EmptyColumnReference {
+                column_ref: "()".to_string()
+            }
+        );
+        assert_eq!(
+            parse("(foo,bar").expect_err("unclosed paren"),
+            Error::MissingClosingParenthesis {
+                column_ref: "(foo,bar".to_string()
+            }
+        );
+        assert_eq!(
+            parse("(foo, bar) baz").expect_err("trailing text"),
+            Error::TrailingText {
+                column_ref: "(foo, bar) baz".to_string()
+            }
+        );
+        assert_eq!(
+            parse("(foo,,bar)").expect_err("empty name"),
+            Error::EmptyColumnName {
+                column_ref: "(foo,,bar)".to_string()
+            }
+        );
+        assert_eq!(
+            parse("(foo,)").expect_err("trailing comma"),
+            Error::EmptyColumnName {
+                column_ref: "(foo,)".to_string()
+            }
+        );
+        assert_eq!(
+            parse("(,foo)").expect_err("leading comma"),
+            Error::EmptyColumnName {
+                column_ref: "(,foo)".to_string()
+            }
+        );
+        assert_eq!(
+            parse(r#""service.instance.id"#).expect_err("unterminated quote"),
+            Error::UnterminatedQuotedName {
+                column_ref: r#""service.instance.id"#.to_string()
+            }
+        );
+        assert_eq!(
+            parse(r#"(a"b")"#).expect_err("misplaced quote"),
+            Error::MisplacedQuote {
+                column_ref: r#"(a"b")"#.to_string()
+            }
+        );
+        assert_eq!(
+            parse(r#"("a"b)"#).expect_err("misplaced quote"),
+            Error::MisplacedQuote {
+                column_ref: r#"("a"b)"#.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_names_that_cannot_round_trip() {
+        // A name holding one of the separators the reference is carried in cannot be
+        // read back, so it is refused rather than silently split.
+        assert_eq!(
+            parse(r#"("a,b")"#).expect_err("comma in name"),
+            Error::UnsupportedCharacterInName {
+                column_ref: r#"("a,b")"#.to_string(),
+                column: "a,b".to_string(),
+                character: ',',
+            }
+        );
+        assert_eq!(
+            parse(r#""a""b""#).expect_err("quote in name"),
+            Error::UnsupportedCharacterInName {
+                column_ref: r#""a""b""#.to_string(),
+                column: r#"a"b"#.to_string(),
+                character: '"',
+            }
+        );
+        for character in [';', ':', '(', ')'] {
+            let column_ref = format!("a{character}b");
+            assert!(
+                parse(&column_ref).is_err(),
+                "'{column_ref}' should be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn quoted_names_may_contain_parentheses_and_dots() {
+        // `)` inside quotes does not close the compound reference.
+        assert_eq!(names(r#"("a.b", c)"#), vec!["a.b", "c"]);
+        assert_eq!(
+            parse(r#"("a)b", c)"#).expect_err("parenthesis in name"),
+            Error::UnsupportedCharacterInName {
+                column_ref: r#"("a)b", c)"#.to_string(),
+                column: "a)b".to_string(),
+                character: ')',
+            }
+        );
+    }
+}

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -22,6 +22,7 @@ use std::{
 
 #[cfg(feature = "http")]
 pub mod cancel_guard_body;
+pub mod column_reference;
 pub mod fibonacci_backoff;
 pub mod home_dir;
 pub mod levenshtein;


### PR DESCRIPTION
## Problem

- `acceleration.primary_key` (and `indexes` / `on_conflict`) could not reference a column whose name contains dots. Quoting it the way SQL does left the quotes in the name, so the column was reported missing: `Primary key column '"service.instance.id"' was not found in the schema. Valid columns: ..., service.instance.id, ...`
- A compound key written without parentheses (`primary_key: a, b`) was read as one column name and failed the same way.
- When a primary key value was null, every Cayenne write/delete path reported the same fixed sentence — `Primary key values must be non-null` — so for a composite key nothing said *which* column was null.

## What changed

- Column references are now parsed in one place (`util::column_reference`), used by the acceleration config, the two accelerator paths that re-parse the `indexes` option string, and the NSQL context.
  - A name may be double-quoted the way SQL writes it; the parentheses around a compound key are optional.
  - A name holding a character these strings use as a separator (`,` `;` `:` `(` `)` `"`) can't be read back, so it's refused with a typed configuration error instead of being silently split by a later consumer.
  - The names are literal Arrow field names, not SQL identifiers, so `sqlparser` is deliberately not used: it rejects field names like `sentry-environment` and `2xx_count` and reads the unquoted `service.instance.id` form as a qualifier chain. A test pins those names.
- Cayenne now builds the null-primary-key message from the batch, naming the columns that hold the null and giving the fix plus a docs link: `Primary key column 'region' has null values. Every primary key column must be non-null: populate it in the source data, or set `primary_key` to columns that are always present.` Every path that enforces the invariant reports through it, so the wording can't drift between them.