### PR TITLE
fix(duckdb): lower-case the hex digits a federated to_hex gets back (fixes #13818)

### DIFF
--- a/crates/runtime-datafusion/src/dialect/duckdb.rs
+++ b/crates/runtime-datafusion/src/dialect/duckdb.rs
@@ -160,12 +160,8 @@ pub(crate) fn to_hex_to_lowercase_hex(
     args: &[Expr],
 ) -> Result<Option<ast::Expr>, DataFusionError> {
     match args {
-        [_] => {
-            let Some(hex) = renamed_fn_to_sql(unparser, args, TO_HEX_NAME)? else {
-                return Ok(None);
-            };
-            Ok(Some(wrap_in_call(hex, LOWER_NAME)))
-        }
+        [_] => Ok(renamed_fn_to_sql(unparser, args, TO_HEX_NAME)?
+            .map(|hex| wrap_in_call(hex, LOWER_NAME))),
         // `to_hex` is a single-argument function, so the planner cannot build
         // this. Fail rather than fall through to `Ok(None)`, which would put
         // the un-lowered `to_hex` back into the DuckDB SQL.

--- a/crates/runtime-datafusion/src/dialect/duckdb.rs
+++ b/crates/runtime-datafusion/src/dialect/duckdb.rs
@@ -35,6 +35,14 @@ pub(crate) const TRIM_NAME: &str = "trim";
 /// [`btrim_to_trim`] for why it has to be passed to `DuckDB` explicitly.
 const ASCII_SPACE: &str = " ";
 
+/// The name both engines give the integer-to-hex function. They disagree only
+/// on the case of the digits — see [`to_hex_to_lowercase_hex`].
+const TO_HEX_NAME: &str = "to_hex";
+
+/// `DuckDB`'s lower-casing function, applied over [`TO_HEX_NAME`] to match
+/// `DataFusion`'s lower-case hex digits.
+const LOWER_NAME: &str = "lower";
+
 /// Renders `args` as a call to `duckdb_fn`, in the order given.
 ///
 /// The caller is responsible for having already put `args` into the shape
@@ -107,6 +115,62 @@ pub(crate) fn btrim_to_trim(
         // which would put `btrim` back into the DuckDB SQL.
         _ => Err(DataFusionError::Plan(format!(
             "btrim takes one or two arguments, got {}; cannot render it as DuckDB SQL.",
+            args.len()
+        ))),
+    }
+}
+
+/// Renders `inner` as the sole argument of a call to `function_name`.
+fn wrap_in_call(inner: ast::Expr, function_name: &str) -> ast::Expr {
+    ast::Expr::Function(Function {
+        name: ObjectName(vec![ast::ObjectNamePart::Identifier(Ident::new(
+            function_name,
+        ))]),
+        args: ast::FunctionArguments::List(ast::FunctionArgumentList {
+            duplicate_treatment: None,
+            args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(inner))],
+            clauses: vec![],
+        }),
+        filter: None,
+        null_treatment: None,
+        over: None,
+        within_group: vec![],
+        parameters: ast::FunctionArguments::None,
+        uses_odbc_syntax: false,
+    })
+}
+
+/// Lower-cases `DuckDB`'s `to_hex`, which upper-cases the digits `DataFusion`
+/// renders in lower case.
+///
+/// Both engines have a `to_hex`, so nothing denied the call and nothing
+/// rewrote it: it was pushed into the accelerated store verbatim and came back
+/// with different characters. `to_hex(255)` is `ff` from the kernel and `FF`
+/// from `DuckDB`, so the same query over the same rows answered differently
+/// depending on whether the dataset happened to be accelerated, with no error
+/// and no warning (issue #13818). A predicate such as
+/// `WHERE to_hex(h) = 'deadbeef'` simply matched nothing.
+///
+/// Case is the *only* divergence: measured across `Int16`, `Int32` and `Int64`
+/// inputs, negative values, zero and NULL, both engines widen to 64 bits and
+/// produce the same digits in the same order, so wrapping the call in
+/// [`LOWER_NAME`] makes the two answers identical rather than merely closer.
+pub(crate) fn to_hex_to_lowercase_hex(
+    unparser: &datafusion::sql::unparser::Unparser,
+    args: &[Expr],
+) -> Result<Option<ast::Expr>, DataFusionError> {
+    match args {
+        [_] => {
+            let Some(hex) = renamed_fn_to_sql(unparser, args, TO_HEX_NAME)? else {
+                return Ok(None);
+            };
+            Ok(Some(wrap_in_call(hex, LOWER_NAME)))
+        }
+        // `to_hex` is a single-argument function, so the planner cannot build
+        // this. Fail rather than fall through to `Ok(None)`, which would put
+        // the un-lowered `to_hex` back into the DuckDB SQL.
+        _ => Err(DataFusionError::Plan(format!(
+            "to_hex takes one argument, got {}; cannot render it as DuckDB SQL.",
             args.len()
         ))),
     }
@@ -390,25 +454,6 @@ impl DuckDBRegexpFunction {
         Ok(())
     }
 
-    fn wrap_function(ast_fn: ast::Expr, function_name: &str) -> ast::Expr {
-        ast::Expr::Function(Function {
-            name: ObjectName(vec![ast::ObjectNamePart::Identifier(Ident::new(
-                function_name,
-            ))]),
-            args: ast::FunctionArguments::List(ast::FunctionArgumentList {
-                duplicate_treatment: None,
-                args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(ast_fn))],
-                clauses: vec![],
-            }),
-            filter: None,
-            null_treatment: None,
-            over: None,
-            within_group: vec![],
-            parameters: ast::FunctionArguments::None,
-            uses_odbc_syntax: false,
-        })
-    }
-
     fn postprocess_function(&self, mut ast_fn: ast::Expr) -> ast::Expr {
         match self {
             DuckDBRegexpFunction::Match => {
@@ -424,7 +469,7 @@ impl DuckDBRegexpFunction {
             }
             DuckDBRegexpFunction::Count => {
                 // Wrap the extract array in a ``len()``
-                ast_fn = Self::wrap_function(ast_fn, "len");
+                ast_fn = wrap_in_call(ast_fn, "len");
             }
             _ => {}
         }
@@ -732,6 +777,59 @@ mod tests {
             .expr_to_sql(&call)
             .expect("btrim unparses for DuckDB");
         assert_eq!(rendered.to_string(), "trim('  hi  ', ' ')");
+    }
+
+    /// Both engines have a `to_hex`, so the call federated verbatim and came
+    /// back with upper-case digits where the kernel produces lower-case ones —
+    /// a silently different answer, not an error (regression test for #13818).
+    #[test]
+    fn to_hex_unparses_to_a_lowercased_duckdb_to_hex() {
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        let column = Expr::Column(Column {
+            relation: Some(TableReference::bare("t")),
+            name: "h".to_string(),
+            spans: Spans::new(),
+        });
+
+        let rendered = to_hex_to_lowercase_hex(&unparser, &[column])
+            .expect("should execute successfully")
+            .expect("should return expression");
+        assert_eq!(rendered.to_string(), r#"lower(to_hex("t"."h"))"#);
+    }
+
+    /// `to_hex` takes exactly one argument, so this is a defensive arm — but it
+    /// must be an error, not `Ok(None)`, which would hand the un-lowered
+    /// `to_hex` straight back to `DuckDB`.
+    #[test]
+    fn to_hex_with_an_impossible_arity_is_an_error_not_a_passthrough() {
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+
+        let error = to_hex_to_lowercase_hex(&unparser, &[lit(1_i64), lit(2_i64)])
+            .expect_err("two arguments cannot be rendered");
+        assert!(
+            error.to_string().contains("to_hex takes one argument"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// The whole `to_hex` call, planned from the `DataFusion` UDF and unparsed
+    /// through the dialect, so a handler that is written but never installed
+    /// fails here rather than in a federated query.
+    #[test]
+    fn duckdb_dialect_installs_the_to_hex_override() {
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        let call = Expr::ScalarFunction(ScalarFunction::new_udf(
+            datafusion::functions::string::to_hex(),
+            vec![lit(255_i64)],
+        ));
+
+        let rendered = unparser
+            .expr_to_sql(&call)
+            .expect("to_hex unparses for DuckDB");
+        assert_eq!(rendered.to_string(), "lower(to_hex(255))");
     }
 
     #[test]

--- a/crates/runtime-datafusion/src/dialect/mod.rs
+++ b/crates/runtime-datafusion/src/dialect/mod.rs
@@ -33,6 +33,7 @@ const REGEXP_REPLACE_FLAGS_POSITION: usize = 3; // The position of the flags arg
 const REGEXP_COUNT_FLAGS_POSITION: usize = 3; // The position of the flags argument in regexp_count function calls
 
 const BTRIM_NAME: &str = "btrim";
+const TO_HEX_NAME: &str = "to_hex";
 
 pub(crate) const REGEXP_LIKE_NAME: &str = "regexp_like";
 pub(crate) const REGEXP_MATCH_NAME: &str = "regexp_match";
@@ -111,14 +112,25 @@ fn duckdb_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
 /// [`duckdb_native_function_names`]: that list is the federation deny-list's
 /// carve-out, and a built-in federates unless it is denied, so carving one out
 /// would do nothing. What a built-in needs is the handler — without one the
-/// unparser emits the `DataFusion` name verbatim into SQL `DuckDB` rejects.
+/// unparser emits the `DataFusion` call verbatim, and `DuckDB` either rejects
+/// the name (`btrim`) or accepts it and answers differently (`to_hex`, whose
+/// digits come back upper-case). The second is the worse of the two: it is a
+/// silently different result rather than a query error.
 fn duckdb_builtin_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
-    vec![(
-        // DuckDB dialect: trim(string[, characters])
-        // DataFusion dialect: btrim(str[, trim_str]) — `trim` is only its alias
-        BTRIM_NAME,
-        Box::new(duckdb::btrim_to_trim) as ScalarFnToSqlHandler,
-    )]
+    vec![
+        (
+            // DuckDB dialect: trim(string[, characters])
+            // DataFusion dialect: btrim(str[, trim_str]) — `trim` is only its alias
+            BTRIM_NAME,
+            Box::new(duckdb::btrim_to_trim) as ScalarFnToSqlHandler,
+        ),
+        (
+            // DuckDB dialect: to_hex(int) — upper-case digits
+            // DataFusion dialect: to_hex(int) — lower-case digits
+            TO_HEX_NAME,
+            Box::new(duckdb::to_hex_to_lowercase_hex) as ScalarFnToSqlHandler,
+        ),
+    ]
 }
 
 /// Names of the Spice functions [`new_duckdb_dialect`] rewrites to native

--- a/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
+++ b/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
@@ -69,6 +69,23 @@ fn write_unicode_space_source(path: &Path) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Integers whose hex rendering exercises the case divergence: a value with
+/// digits above 9 in both nibbles, a wide one, zero (whose single digit is the
+/// same in either case, which is why a spot check can miss this), the negative
+/// bound, and NULL.
+fn write_hex_source(path: &Path) -> Result<(), anyhow::Error> {
+    std::fs::write(
+        path,
+        "id,h\n\
+         1,255\n\
+         2,3735928559\n\
+         3,0\n\
+         4,-1\n\
+         5,\n",
+    )?;
+    Ok(())
+}
+
 fn duckdb_accelerated(from: &str, name: &str) -> Dataset {
     let mut dataset = Dataset::new(from, name);
     dataset.params = Some(Params::from_string_map(
@@ -236,6 +253,105 @@ async fn duckdb_accelerated_btrim_leaves_unicode_separators_alone() -> Result<()
                 to_pretty_display(&accelerated)?.to_string(),
                 to_pretty_display(&local)?.to_string(),
                 "a Zs-padded string must trim identically accelerated and local"
+            );
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}
+
+/// `to_hex` exists in both engines, so nothing denied the call and — before the
+/// dialect rewrote it — nothing changed it either: it was pushed into the
+/// accelerated store verbatim and came back with **upper-case** digits where
+/// the kernel produces lower-case ones. No error and no warning; the same query
+/// over the same rows just answered differently once the dataset was
+/// accelerated (regression test for #13818).
+///
+/// The predicate is the shape that makes this data loss rather than cosmetics:
+/// `WHERE to_hex(h) = 'deadbeef'` matched nothing accelerated and matched a row
+/// unaccelerated.
+#[tokio::test]
+async fn duckdb_accelerated_to_hex_agrees_with_local() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let dir = tempfile::tempdir()?;
+            let csv = dir.path().join("hex.csv");
+            write_hex_source(&csv)?;
+            let from = format!("file://{}", csv.display());
+
+            let app = AppBuilder::new("duckdb_builtin_pushdown_to_hex")
+                .with_dataset(duckdb_accelerated(&from, "accelerated"))
+                .with_dataset(unaccelerated(&from, "local"))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            load_runtime_datasets(&rt, LOAD_TIMEOUT).await?;
+
+            // The call must reach DuckDB for this to be testing anything: an
+            // accelerated query that evaluated `to_hex` locally would agree
+            // with the control even with the rewrite removed. `base_sql` is the
+            // SQL the federated scan sends, so it is the only part of the plan
+            // that says what DuckDB is asked to evaluate.
+            let plan = to_pretty_display(
+                &run_query(&rt, "EXPLAIN SELECT to_hex(h) FROM accelerated").await?,
+            )?
+            .to_string();
+            let remote_sql: String = plan
+                .split("base_sql=")
+                .skip(1)
+                .map(|tail| tail.split('\n').next().unwrap_or_default().to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                remote_sql.contains("lower(to_hex("),
+                "the hex rendering must be pushed down to DuckDB inside a `lower(..)`; \
+                 plan was:\n{plan}"
+            );
+
+            let query = "SELECT id, to_hex(h) AS hx FROM {table} ORDER BY id";
+            let accelerated = run_query(&rt, &query.replace("{table}", "accelerated")).await?;
+            let local = run_query(&rt, &query.replace("{table}", "local")).await?;
+
+            let expected = [
+                "+----+------------------+",
+                "| id | hx               |",
+                "+----+------------------+",
+                "| 1  | ff               |",
+                "| 2  | deadbeef         |",
+                "| 3  | 0                |",
+                "| 4  | ffffffffffffffff |",
+                "| 5  |                  |",
+                "+----+------------------+",
+            ];
+            assert_batches_eq!(expected, &accelerated);
+
+            // The accelerator's answer is only right if it is the answer
+            // DataFusion gives; an upper-cased rendering shows up here as a
+            // divergence, not as a query error.
+            assert_eq!(
+                to_pretty_display(&accelerated)?.to_string(),
+                to_pretty_display(&local)?.to_string(),
+                "DuckDB-accelerated to_hex must agree with local evaluation"
+            );
+
+            // A predicate over the hex string: with the digits upper-cased
+            // remotely this returned no rows at all.
+            let predicate = "SELECT id FROM {table} WHERE to_hex(h) = 'deadbeef'";
+            let accelerated = run_query(&rt, &predicate.replace("{table}", "accelerated")).await?;
+            let local = run_query(&rt, &predicate.replace("{table}", "local")).await?;
+            assert_batches_eq!(
+                ["+----+", "| id |", "+----+", "| 2  |", "+----+",],
+                &accelerated
+            );
+            assert_eq!(
+                to_pretty_display(&accelerated)?.to_string(),
+                to_pretty_display(&local)?.to_string(),
+                "a predicate over to_hex must select the same rows accelerated and local"
             );
 
             rt.shutdown().await;

--- a/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
+++ b/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
@@ -86,6 +86,20 @@ fn write_hex_source(path: &Path) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// The SQL each federated scan in `plan` sends to `DuckDB`, one per line.
+///
+/// `base_sql` is the only part of an `EXPLAIN` that says what `DuckDB` is asked
+/// to evaluate — the logical plan above it names the `DataFusion` function
+/// whether or not the dialect rewrote the call — so every test here that claims
+/// a rewrite reached the remote engine reads it rather than the whole plan.
+fn pushed_down_sql(plan: &str) -> String {
+    plan.split("base_sql=")
+        .skip(1)
+        .map(|tail| tail.split('\n').next().unwrap_or_default().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 fn duckdb_accelerated(from: &str, name: &str) -> Dataset {
     let mut dataset = Dataset::new(from, name);
     dataset.params = Some(Params::from_string_map(
@@ -153,12 +167,7 @@ async fn duckdb_accelerator_answers_btrim_and_agrees_with_local() -> Result<(), 
                 .await?,
             )?
             .to_string();
-            let remote_sql: String = plan
-                .split("base_sql=")
-                .skip(1)
-                .map(|tail| tail.split('\n').next().unwrap_or_default().to_string())
-                .collect::<Vec<_>>()
-                .join("\n");
+            let remote_sql = pushed_down_sql(&plan);
             assert!(
                 remote_sql.contains("trim("),
                 "the trims must be pushed down to DuckDB, not evaluated locally; plan was:\n{plan}"
@@ -294,19 +303,12 @@ async fn duckdb_accelerated_to_hex_agrees_with_local() -> Result<(), anyhow::Err
 
             // The call must reach DuckDB for this to be testing anything: an
             // accelerated query that evaluated `to_hex` locally would agree
-            // with the control even with the rewrite removed. `base_sql` is the
-            // SQL the federated scan sends, so it is the only part of the plan
-            // that says what DuckDB is asked to evaluate.
+            // with the control even with the rewrite removed.
             let plan = to_pretty_display(
                 &run_query(&rt, "EXPLAIN SELECT to_hex(h) FROM accelerated").await?,
             )?
             .to_string();
-            let remote_sql: String = plan
-                .split("base_sql=")
-                .skip(1)
-                .map(|tail| tail.split('\n').next().unwrap_or_default().to_string())
-                .collect::<Vec<_>>()
-                .join("\n");
+            let remote_sql = pushed_down_sql(&plan);
             assert!(
                 remote_sql.contains("lower(to_hex("),
                 "the hex rendering must be pushed down to DuckDB inside a `lower(..)`; \


### PR DESCRIPTION
## Summary

`to_hex` exists in both engines, so nothing denied the call and nothing rewrote it: it was pushed
into the accelerated `DuckDB` store verbatim and came back with **upper-case** digits where the
kernel produces lower-case ones. The same query over the same rows answered differently depending
on whether the dataset happened to be accelerated — no error, no warning.

Measured on `trunk` at `f8d83e39f0` — one local CSV, two datasets over it (`t_duckdb` accelerated
into `DuckDB`, `t_local` unaccelerated as the control):

```
$ … -d "SELECT id, h, to_hex(h) AS hx FROM t_duckdb ORDER BY id"
[{"id":1,"h":255,"hx":"FF"},{"id":2,"h":3735928559,"hx":"DEADBEEF"},
 {"id":3,"h":0,"hx":"0"},{"id":4,"h":-1,"hx":"FFFFFFFFFFFFFFFF"}]

$ … -d "SELECT id, h, to_hex(h) AS hx FROM t_local ORDER BY id"
[{"id":1,"h":255,"hx":"ff"},{"id":2,"h":3735928559,"hx":"deadbeef"},
 {"id":3,"h":0,"hx":"0"},{"id":4,"h":-1,"hx":"ffffffffffffffff"}]
```

The `h` column itself agrees, so the divergence is the function's rendering and nothing else.
`to_hex(0)` agrees too, which is why a spot check can walk past this: the divergence needs a digit
above 9.

**The shape that makes it data loss rather than cosmetics is a predicate.** Same runtime, same
rows:

```
$ … -d "SELECT id FROM t_duckdb WHERE to_hex(h) = 'deadbeef'"
[]
$ … -d "SELECT id FROM t_local  WHERE to_hex(h) = 'deadbeef'"
[{"id":2}]
```

## Changes

**Rewrite the call in the `DuckDB` unparser dialect to `lower(to_hex(x))`**, joining `btrim` in
`duckdb_builtin_scalar_overrides()` — the table added by #13821 for exactly this shape.

Case is the *only* divergence, which is what makes `lower(..)` an exact fix rather than a closer
approximation. Measured across every integer width `to_hex` accepts, plus the boundary values and
NULL, comparing the candidate rendering evaluated **by `DuckDB`** against the kernel's answer:

| input | `lower(to_hex(x))` in `DuckDB` | `to_hex(x)` in `DataFusion` |
|---|---|---|
| `255` | `ff` | `ff` |
| `3735928559` | `deadbeef` | `deadbeef` |
| `0` | `0` | `0` |
| `-1` (`BIGINT`) | `ffffffffffffffff` | `ffffffffffffffff` |
| `CAST(-1 AS INT)` | `ffffffffffffffff` | `ffffffffffffffff` |
| `CAST(-1 AS SMALLINT)` | `ffffffffffffffff` | `ffffffffffffffff` |
| `NULL` | `null` | `null` |

Both engines widen to 64 bits and emit the same digits in the same order, so lower-casing makes the
two answers identical on every input, not merely closer. `to_hex`'s own signature admits exactly
one argument (`Coercion::new_exact(TypeSignatureClass::Integer)`), so the handler's other arm is
defensive — and it returns an error rather than `Ok(None)`, which would hand the un-lowered
`to_hex` straight back to `DuckDB`.

`DataFusion`'s lower case is not incidental: `to_hex.rs` renders from
`const HEX_CHARS: &[u8; 16] = b"0123456789abcdef"`.

**Two small refactors, both to avoid a second copy of something that already existed.**
`wrap_function` was a private associated function on `DuckDBRegexpFunction`, used only to wrap
`regexp_extract_all` in `len(..)`; it is now the module-level `wrap_in_call`, which the `to_hex`
handler calls rather than carrying its own. And the new integration test had copy-pasted the
`btrim` test's six-line `base_sql` extraction verbatim, so that is now one `pushed_down_sql`
helper both tests call.

## Scope — what else the sweep found, and what it did not

The issue reported one divergence. Rather than take that on trust, a differential sweep of **53**
expressions ran through the same live accelerator, each compared against the unaccelerated control:

- **40 agreed exactly.**
- **8 expressions fail loudly** on `DuckDB`, in two shapes — both the #10583 class, neither able to
  return a wrong row: `Catalog Error: Scalar Function with name … does not exist!` for `sha224`,
  `initcap`, `signum`, `nanvl` and `nvl`, and `Binder Error: No function matches the given name and
  argument types` for `encode(VARCHAR, STRING_LITERAL)` (both the `'hex'` and `'base64'` forms) and
  `octet_length(VARCHAR)`, where `DuckDB`'s own overloads take a `BLOB`/`BIT`.
- **2 apparent divergences were my harness's own, and are withdrawn.** `floor(f)` and `ceil(f)`
  differed only under the sweep's `CAST(… AS VARCHAR)` wrapper, which is itself pushed down; read
  directly, both agree on every row. Reported here because a negative result is part of the
  measurement.
- **3 real silent divergences**, of which this PR fixes one:
  - `to_hex` — **fixed here**. Case, exactly, with an exact rewrite.
  - `concat` over a NULL argument — `DuckDB` ignores the NULL, the kernel answers NULL. Filed as
    #13849 rather than fixed here, because **which side is authoritative is an open
    question**: `DataFusion` documents `concat` as ignoring NULLs and `simplify_concat` drops null
    literals, yet the runtime answers NULL. A rewrite that matched today's observed kernel would
    invert silently if `DataFusion` ever behaved as documented, so that decision does not belong in
    a `to_hex` PR.
  - `sha256` — the kernel returns the 32-byte digest as `Binary`; `DuckDB` returns its 64-character
    hex *text*, which `SchemaCastScanExec` then casts into the `Binary` column. Filed as
    #13850. The candidate fix (`unhex(sha256(x))`) cannot be exercised through `/v1/sql` at
    all — `unhex` is not a `DataFusion` function — so unlike `lower(to_hex(x))` it is unverified,
    and shipping it on inspection alone is exactly what this repo's evidence bar forbids.

So the bug class is swept and its members are each accounted for; the two left open are left open
deliberately, each with its measurement, not deferred for convenience.

**The sibling backend was measured too, and it is the loud kind.** `to_hex` on a `SQLite`
accelerator does not diverge — it fails outright, so no wrong row is ever returned:

```
$ … -d "SELECT id, to_hex(h) AS hx FROM t_sqlite ORDER BY id"
ConnectionError Error("no such function: to_hex in SELECT `t_sqlite`.`id`,
  to_hex(`t_sqlite`.`h`) AS `hx` FROM `t_sqlite` … at offset 24")
```

That is #10583's own `❌ to_hex(n)` row, and it is out of scope here for the reason #13840 gives:
`SQLite` has no dialect seam to rewrite through, so its lever is the `FunctionSupport` deny-list,
not this table. Measurement and a caution about #10583's suggested `hex(n)` equivalent are
[recorded on that issue](https://github.com/spiceai/spiceai/issues/10583) rather than fixed here.
`PostgreSQL` and `MySQL` were **not** measured for this function — no server on the rig — so this
PR makes no claim about them either way.

## Test plan

**Reproduced on `trunk` first** — the transcripts above are from that run; the same commands on the
branch are below, on the same rig.

```
$ SELECT id, h, to_hex(h) AS hx FROM t_duckdb ORDER BY id
[{"id":1,"h":255,"hx":"ff"},{"id":2,"h":3735928559,"hx":"deadbeef"},
 {"id":3,"h":0,"hx":"0"},{"id":4,"h":-1,"hx":"ffffffffffffffff"}]

$ SELECT id, h, to_hex(h) AS hx FROM t_local ORDER BY id
[{"id":1,"h":255,"hx":"ff"},{"id":2,"h":3735928559,"hx":"deadbeef"},
 {"id":3,"h":0,"hx":"0"},{"id":4,"h":-1,"hx":"ffffffffffffffff"}]

$ SELECT id FROM t_duckdb WHERE to_hex(h) = 'deadbeef'   ->  [{"id":2}]
$ SELECT id FROM t_local  WHERE to_hex(h) = 'deadbeef'   ->  [{"id":2}]
```

The two sides now agree on every row, and the predicate selects the row on both. `EXPLAIN` shows
the rewrite in the SQL that actually left the process — and that the call is still **pushed down**,
not pulled back above the scan:

```
VirtualExecutionPlan name=duckdb compute_context=:memory: \
  base_sql=SELECT lower(to_hex("t_duckdb"."h")) AS "hx" FROM "t_duckdb"
```

**Tests added, each neutered to confirm it is load-bearing:**

- `duckdb_accelerated_to_hex_agrees_with_local`
  (`crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs`) — the wired path: one CSV, a
  `DuckDB`-accelerated dataset and an unaccelerated twin, five rows (`255`, `3735928559`, `0`,
  `-1`, NULL). Asserts the pushed-down SQL from `base_sql` really carries `lower(to_hex(`, pins the
  accelerated rows, requires them to equal the local control, and repeats both for the
  `WHERE to_hex(h) = 'deadbeef'` predicate. This is the test that catches the class: a unit test
  over the handler cannot tell a rendering that parses from one `DuckDB` answers the same way.
- `to_hex_unparses_to_a_lowercased_duckdb_to_hex`, `duckdb_dialect_installs_the_to_hex_override`,
  `to_hex_with_an_impossible_arity_is_an_error_not_a_passthrough`
  (`crates/runtime-datafusion/src/dialect/duckdb.rs`) — the rendering, the fact that the handler is
  actually installed on the dialect (a handler written but never registered fails here rather than
  in a federated query), and the defensive arity arm.

**Neuter 1 — drop the `lower(..)` wrap, keep the handler registered (i.e. make the rewrite a bare
rename).** This is the neuter that matters, because a bare rename is the plausible wrong fix.

The integration test catches it, and its message carries the plan that proves *why*:

```
thread '…::duckdb_accelerated_to_hex_agrees_with_local' panicked at
  crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs:312:13:
the hex rendering must be pushed down to DuckDB inside a `lower(..)`; plan was:
  … VirtualExecutionPlan name=duckdb base_sql=SELECT to_hex("accelerated"."h") FROM "accelerated"
test result: FAILED. 2 passed; 1 failed; 373 filtered out
```

Note the two `btrim` tests still pass — the neuter was surgical, so the failure is attributable to
this change and not to a broken dialect.

The unit tests catch it too:

```
test dialect::duckdb::tests::to_hex_unparses_to_a_lowercased_duckdb_to_hex ... FAILED
  left: "to_hex(\"t\".\"h\")"
 right: "lower(to_hex(\"t\".\"h\"))"
test dialect::duckdb::tests::duckdb_dialect_installs_the_to_hex_override ... FAILED
  left: "to_hex(255)"
 right: "lower(to_hex(255))"
test result: FAILED. 11 passed; 2 failed
```

**Neuter 2 — un-register the handler**, leaving the (correct) rendering function unreachable. Only
the `installs` test can see this, which is the reason that test exists: a handler written but never
wired into the dialect is invisible to a test that calls the handler directly.

```
test dialect::duckdb::tests::duckdb_dialect_installs_the_to_hex_override ... FAILED
  left: "to_hex(255)"
 right: "lower(to_hex(255))"
test result: FAILED. 12 passed; 1 failed
```

Restored — unit and integration both green:

```
test result: ok. 55 passed; 0 failed; 0 ignored; 0 measured; 184 filtered out   # runtime-datafusion --lib dialect
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 373 filtered out    # runtime --test integration duckdb_builtin_pushdown
```

Full gate, run locally via `make signoff` (= `make lint` + `make build-cli` + `make nextest`):

```
make lint
make nextest
```


## Performance impact

One extra `lower(..)` call per row, inside `DuckDB`, on the projection of a query that already
called `to_hex`. It does not change which rows are scanned or how: `to_hex(h)` was never
index-usable on `h` in the first place, so `WHERE lower(to_hex(h)) = …` costs the same table scan
as `WHERE to_hex(h) = …` did. Nothing is moved out of the remote engine — the alternative fix
(deny-listing `to_hex`) *would* have done that, pulling the projection back above the federated
scan, which is one reason the dialect rewrite is preferable now that it is measured to be exact.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` not installed
- `/security-review`: no findings — the handler builds a `sqlparser` AST rather than concatenating SQL, both identifiers it introduces are `const` literals, the one argument goes through the same `unparser.expr_to_sql` path every existing handler uses, and the single new error message interpolates only `args.len()`
- `/simplify`: applied — collapsed the handler's early return into a `map`, and extracted the `base_sql` extraction my test had copy-pasted from the `btrim` test into one shared `pushed_down_sql` helper; light checks and both test suites re-run green afterwards

Fixes #13818

## Checklist

- [x] Reproduced the reported failure on `trunk` before writing the fix, and re-ran the same commands on the branch
- [x] The candidate rendering was evaluated **by `DuckDB`** against the kernel across every input `to_hex` accepts, so the rewrite is measured to be exact rather than argued to be
- [x] Regression tests added at both levels, each neutered to confirm it fails without the fix
- [x] The bug class was swept, not just the reported instance; the two members not fixed here are filed with their measurements (#13849, #13850)
- [ ] `make signoff` green and `Attestation` re-run (runs after the push that creates this PR)
