### PR TITLE
test(ducklake): guard the DuckDB dialect on the catalog route (refs #13825)

### DIFF
--- a/crates/runtime/tests/ducklake/mod.rs
+++ b/crates/runtime/tests/ducklake/mod.rs
@@ -701,9 +701,10 @@ fn bootstrap_ducklake_names(metadata_path: &str, data_path: &str) {
 /// `Catalog Error: Scalar Function with name btrim does not exist!`.
 ///
 /// The dataset route in the same app is the control: it registers the same
-/// table through the connector, which has always attached the dialect, so the
-/// two routes disagreeing is the asymmetry this pins (regression test for
-/// #13825).
+/// table through the connector, which attaches the dialect at its own
+/// construction site (`connector-ducklake/src/lib.rs`). The two routes must
+/// therefore answer alike, and their disagreeing is the asymmetry this pins
+/// (regression test for #13825).
 ///
 /// The `base_sql` assertions are what make this a guard rather than a smoke
 /// test. They read the statement `DuckDB` is actually asked to run, so the test
@@ -804,10 +805,10 @@ async fn ducklake_catalog_route_installs_the_duckdb_dialect() -> Result<(), anyh
                 &from_catalog
             );
 
-            // The dataset route over the same table, which has always carried
-            // the dialect. Answering the same thing is the point: a rewrite
-            // that reached DuckDB but changed the answer would pass every
-            // assertion above and fail here.
+            // The dataset route over the same table, which carries the
+            // dialect from its own construction site. Answering the same thing
+            // is the point: a rewrite that reached DuckDB but changed the
+            // answer would pass every assertion above and fail here.
             let from_dataset: Vec<RecordBatch> = rt
                 .datafusion()
                 .query_builder(&query.replace("{table}", "names_ds"))

--- a/crates/runtime/tests/ducklake/mod.rs
+++ b/crates/runtime/tests/ducklake/mod.rs
@@ -45,10 +45,9 @@ async fn explain_plan(rt: &Runtime, sql: &str) -> String {
         .to_string()
 }
 
-/// Bootstrap a `DuckLake` catalog at the given metadata path with test tables.
-///
-/// Creates tables: `orders`, `customers`, `products` under the `main` schema.
-fn bootstrap_ducklake(metadata_path: &str, data_path: &str) {
+/// Opens an in-memory `DuckDB` connection with the `ducklake` extension loaded
+/// and the lake at `metadata_path` attached under `alias`.
+fn attach_ducklake(alias: &str, metadata_path: &str, data_path: &str) -> duckdb::Connection {
     let db = duckdb::Connection::open_in_memory().expect("open in-memory DuckDB");
     db.execute("INSTALL ducklake", [])
         .expect("install ducklake");
@@ -57,8 +56,17 @@ fn bootstrap_ducklake(metadata_path: &str, data_path: &str) {
     let escaped_metadata = metadata_path.replace('\'', "''");
     let escaped_data = data_path.replace('\'', "''");
     let attach_sql =
-        format!("ATTACH 'ducklake:{escaped_metadata}' AS test_lake (DATA_PATH '{escaped_data}')");
+        format!("ATTACH 'ducklake:{escaped_metadata}' AS {alias} (DATA_PATH '{escaped_data}')");
     db.execute(&attach_sql, []).expect("attach ducklake");
+
+    db
+}
+
+/// Bootstrap a `DuckLake` catalog at the given metadata path with test tables.
+///
+/// Creates tables: `orders`, `customers`, `products` under the `main` schema.
+fn bootstrap_ducklake(metadata_path: &str, data_path: &str) {
+    let db = attach_ducklake("test_lake", metadata_path, data_path);
 
     db.execute(
         "CREATE TABLE test_lake.main.orders (id INTEGER, customer_id INTEGER, total DOUBLE)",
@@ -650,6 +658,170 @@ async fn ducklake_catalog_read_write_insert() -> Result<(), anyhow::Error> {
                     "+----+-------------+-------+",
                 ],
                 &results
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// A `DuckLake` catalog whose one table carries the strings the rewritten
+/// built-ins are measured on: space-padded, character-padded, neither, and
+/// NULL.
+///
+/// Deliberately a separate lake from [`bootstrap_ducklake`]: the tests above
+/// assert the exact set of tables `information_schema` reports, so adding a
+/// table to the shared fixture would change what they see.
+fn bootstrap_ducklake_names(metadata_path: &str, data_path: &str) {
+    let db = attach_ducklake("name_lake", metadata_path, data_path);
+
+    db.execute(
+        "CREATE TABLE name_lake.main.names (id INTEGER, name VARCHAR)",
+        [],
+    )
+    .expect("create names");
+    db.execute(
+        "INSERT INTO name_lake.main.names VALUES \
+         (1, '  padded  '), (2, 'xyhelloyx'), (3, 'Alpha'), (4, NULL)",
+        [],
+    )
+    .expect("insert names");
+}
+
+/// The `DuckDB` unparser dialect has to be installed on the **catalog** route,
+/// not only the dataset one.
+///
+/// `DuckLake` is `DuckDB`, so the SQL a federated scan sends it has to be
+/// spelled the way `DuckDB` spells it. Two `DataFusion` built-ins federate to a
+/// name `DuckDB` does not have: `trim` reaches the unparser as `btrim` (its own
+/// name — `trim` is only an alias), and `regexp_like` has to become
+/// `regexp_matches`. Only the dialect rewrites either, and nothing withholds a
+/// built-in from pushdown, so a catalog built with the stock dialect sends
+/// `DuckDB` a statement it rejects with
+/// `Catalog Error: Scalar Function with name btrim does not exist!`.
+///
+/// The dataset route in the same app is the control: it registers the same
+/// table through the connector, which has always attached the dialect, so the
+/// two routes disagreeing is the asymmetry this pins (regression test for
+/// #13825).
+///
+/// The `base_sql` assertions are what make this a guard rather than a smoke
+/// test. They read the statement `DuckDB` is actually asked to run, so the test
+/// fails if the call stops being pushed down at all — which is the other way an
+/// answer-only assertion could go green with the dialect removed.
+#[tokio::test]
+async fn ducklake_catalog_route_installs_the_duckdb_dialect() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("runtime=DEBUG,data_components=DEBUG"));
+    register_test_connectors().await;
+
+    let tmp_dir = TempDir::new()?;
+    let metadata_path = tmp_dir
+        .path()
+        .join("test_names.ducklake")
+        .display()
+        .to_string();
+    let data_path = tmp_dir.path().join("data_names").display().to_string();
+    std::fs::create_dir_all(&data_path)?;
+
+    bootstrap_ducklake_names(&metadata_path, &data_path);
+
+    test_request_context()
+        .scope(async {
+            let mut catalog = Catalog::new("ducklake".to_string(), "name_lake".to_string());
+            catalog.params = Some(make_ducklake_catalog_params(&metadata_path));
+
+            let mut dataset =
+                Dataset::new("ducklake:main.names".to_string(), "names_ds".to_string());
+            dataset.params = Some(Params::from_string_map(HashMap::from([(
+                "ducklake_connection_string".to_string(),
+                metadata_path.clone(),
+            )])));
+
+            let app = AppBuilder::new("ducklake_dialect_test")
+                .with_catalog(catalog)
+                .with_dataset(dataset)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_mins(1)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let query = "SELECT id, trim(name) AS trimmed, \
+                         regexp_like(name, 'ell') AS matched \
+                         FROM {table} ORDER BY id";
+            let catalog_query = query.replace("{table}", "name_lake.main.names");
+
+            // `base_sql` is the statement the federated scan sends DuckDB, and
+            // the only part of the plan that says how the call is spelled: the
+            // logical plan above it names the DataFusion function either way.
+            let plan = explain_plan(&rt, &catalog_query).await;
+            let remote_sql: String = plan
+                .split("base_sql=")
+                .skip(1)
+                .map(|tail| tail.split('\n').next().unwrap_or_default().to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                remote_sql.contains("trim(") && !remote_sql.contains("btrim("),
+                "DuckDB has no `btrim`; the catalog route must push down `trim`. Plan was:\n{plan}"
+            );
+            assert!(
+                remote_sql.contains("regexp_matches(") && !remote_sql.contains("regexp_like("),
+                "DuckDB has no `regexp_like`; the catalog route must push down \
+                 `regexp_matches`. Plan was:\n{plan}"
+            );
+
+            let from_catalog: Vec<RecordBatch> = rt
+                .datafusion()
+                .query_builder(&catalog_query)
+                .build()
+                .run()
+                .await?
+                .data
+                .try_collect()
+                .await?;
+
+            assert_batches_eq!(
+                &[
+                    "+----+-----------+---------+",
+                    "| id | trimmed   | matched |",
+                    "+----+-----------+---------+",
+                    "| 1  | padded    | false   |",
+                    "| 2  | xyhelloyx | true    |",
+                    "| 3  | Alpha     | false   |",
+                    "| 4  |           |         |",
+                    "+----+-----------+---------+",
+                ],
+                &from_catalog
+            );
+
+            // The dataset route over the same table, which has always carried
+            // the dialect. Answering the same thing is the point: a rewrite
+            // that reached DuckDB but changed the answer would pass every
+            // assertion above and fail here.
+            let from_dataset: Vec<RecordBatch> = rt
+                .datafusion()
+                .query_builder(&query.replace("{table}", "names_ds"))
+                .build()
+                .run()
+                .await?
+                .data
+                .try_collect()
+                .await?;
+
+            assert_eq!(
+                arrow::util::pretty::pretty_format_batches(&from_catalog)?.to_string(),
+                arrow::util::pretty::pretty_format_batches(&from_dataset)?.to_string(),
+                "the catalog and dataset routes over one DuckLake table must agree"
             );
 
             Ok(())


### PR DESCRIPTION
## Summary

`DuckLake` is `DuckDB`, so the SQL a federated scan sends it has to be spelled the way `DuckDB`
spells it. Two `DataFusion` built-ins federate under a name `DuckDB` does not have: `trim` reaches
the unparser as `btrim` (its own name — `trim` is only an alias, #13794), and `regexp_like` has to
become `regexp_matches`. Only the unparser dialect rewrites either, and nothing withholds a
built-in from pushdown, so a catalog whose table factory carries the stock dialect sends `DuckDB`
a statement it rejects.

#13731 wired `new_duckdb_dialect()` into `DuckLakeCatalogProvider::new` and closed that gap. What
it did not leave behind is anything that fails if the wiring goes missing again: the tests beside
it exercise `ducklake_federation()` directly, so they still pass with the value never reaching the
factory. That is the shape a reviewer already flagged once on #13823 — a helper test that survives
the deletion of the call site it exists to protect.

This adds the end-to-end guard, with the **dataset route over the same table as the control** —
those two routes are exactly what diverged. It is a test-only change; no runtime behaviour moves.

## Changes

One file, `crates/runtime/tests/ducklake/mod.rs`:

- `ducklake_catalog_route_installs_the_duckdb_dialect` — registers one `DuckLake` lake twice in
  one app, as a catalog and as a dataset, and asserts on both the SQL `DuckDB` receives and the
  rows that come back.
- `attach_ducklake` — the `INSTALL`/`LOAD`/`ATTACH` boilerplate the new fixture would otherwise
  have duplicated from `bootstrap_ducklake`, now shared by both.

The `base_sql` assertions are what make this a guard rather than a smoke test. They read the
statement `DuckDB` is actually asked to run, so the test also fails if the call stops being pushed
down at all — the other way an answer-only assertion could go green with the dialect removed. The
logical plan is identical either way, which is why asserting on it would prove nothing.

## Test plan

```bash
make lint
make nextest
```

The evidence below is what says the guard is load-bearing, since a test that has only ever run
green proves nothing. Same command throughout:

```bash
cargo test -p runtime --test integration --features duckdb \
  ducklake_catalog_route_installs_the_duckdb_dialect -- --nocapture
```

**On `trunk` at `2f9a874a97` (the fix from #13731 in place) — passes**, and this is the statement
it sends:

```
base_sql=SELECT "id", trim("names"."name", ' ') AS "trimmed",
         regexp_matches("names"."name", 'ell') AS "matched"
         FROM "ducklake"."main"."names" ORDER BY "id" ASC NULLS LAST
```

**With the wiring reverted to the pre-#13731 state** — `ducklake_federation()`'s `dialect` set back
to a stock `DuckDBDialect::new()`, which is what the un-dialected factory used — the same test
fails, and the `DataFusion` spellings go straight through:

```
base_sql=SELECT "id", btrim("names"."name") AS "trimmed",
         regexp_like("names"."name", 'ell') AS "matched"
         FROM "ducklake"."main"."names" ORDER BY "id" ASC NULLS LAST
```

Letting that statement run (plan assertions bypassed) reaches `DuckDB` and is rejected — the
symptom #13825 predicted, measured here for the first time:

```
Catalog Error: Scalar Function with name btrim does not exist!
Did you mean "trim"?
LINE 1: WITH fetch_schema AS ( SELECT "id", btrim("names"."name") AS "trimmed", regexp_like("names"...
```

The whole module is green with the change in place:

```
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 369 filtered out
```

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits."; `grok` not installed
- `/security-review`: no findings — the diff is confined to `crates/runtime/tests/`, adds no production code, no dependency and no `unsafe`; the only interpolation is a test-owned `TempDir` path into the fixture's `ATTACH`, quote-escaped as the pre-existing helper beside it already was
- `/simplify`: applied — folded the duplicated `INSTALL`/`LOAD`/`ATTACH` block into `attach_ducklake`; light checks re-run green (7/7). One finding skipped: the `base_sql` extraction idiom also appears in `crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs`, but sharing it would edit a file an open PR is already changing, for six lines

Re-stated for `7bebe0c30f`, which reworks two comments and no code. `/security-review` was not
re-run: a comment reword touches no security surface. Copilot's one finding — two comments saying
the dataset route had "always" attached the dialect, which narrates history rather than the
invariant — is fixed in that commit; the file now has zero hits for
`always|previously|originally|historically|moved from`.

Refs #13825

## Checklist

- [x] Reproduced the failure before the change and its absence after, with the same command
- [x] The whole `ducklake` module passes (7/7)
- [x] `cargo fmt --all` run as the last edit
- [x] Test-only change — no runtime behaviour altered