### PR TITLE
fix(acceleration): report a retention policy that cannot start instead of silently building none (fixes #13804)

### DIFF
--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -2446,7 +2446,7 @@ impl RetentionBuilder {
         // Add time-based filter if period and time_column are provided
         if let Some(period) = self.time_period {
             let Some(time_column) = self.time_column else {
-                return Err(RetentionRefusal::NoTimeColumn);
+                return Err(RetentionRefusal::TimeColumnUnset);
             };
 
             filters.push(DataRetentionFilter::Time {
@@ -2466,16 +2466,14 @@ impl RetentionBuilder {
         }
 
         if filters.is_empty() {
-            return Err(RetentionRefusal::NoFilter);
+            return Err(RetentionRefusal::NothingToDelete);
         }
 
         // Checked after the filters so that a configuration missing both is still
         // reported by the filter arm, as it was before the interval had an arm at
         // all: `retention_check_interval` has no default, so this is the arm a
         // dataset reaches when it configures everything else a policy needs.
-        let check_interval = self
-            .check_interval
-            .ok_or(RetentionRefusal::NoCheckInterval)?;
+        let check_interval = self.check_interval.ok_or(RetentionRefusal::Unscheduled)?;
 
         Ok(Retention {
             filters,
@@ -2496,11 +2494,11 @@ const RETENTION_DOCS_URL: &str = "https://spiceai.org/docs/components/data-accel
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RetentionRefusal {
     /// Neither `retention_period` nor `retention_sql` says what to delete.
-    NoFilter,
+    NothingToDelete,
     /// `retention_period` is set but `time_column` does not say what to compare.
-    NoTimeColumn,
+    TimeColumnUnset,
     /// Nothing says how often to delete, and `retention_check_interval` has no default.
-    NoCheckInterval,
+    Unscheduled,
 }
 
 impl RetentionRefusal {
@@ -2511,13 +2509,13 @@ impl RetentionRefusal {
         // otherwise break this line in two and forge a second one.
         let dataset_name = dataset_name.escape_debug();
         let cause_and_fix = match self {
-            Self::NoFilter => {
+            Self::NothingToDelete => {
                 "Cause: neither `retention_period` nor `retention_sql` is set, so nothing says which rows to delete. Set one of them."
             }
-            Self::NoTimeColumn => {
+            Self::TimeColumnUnset => {
                 "Cause: time-based retention compares `time_column` against the cutoff, and it is not set. Set `time_column` on the dataset, or delete by expression with `retention_sql` instead."
             }
-            Self::NoCheckInterval => {
+            Self::Unscheduled => {
                 "Cause: `retention_check_interval` is missing or is not a valid duration, and it has no default. Set it, for example `retention_check_interval: 1h`."
             }
         };
@@ -2832,7 +2830,7 @@ mod tests {
     fn test_a_retention_policy_without_a_check_interval_is_refused_and_named() {
         assert_eq!(
             interval_less_builder().assemble().err(),
-            Some(RetentionRefusal::NoCheckInterval),
+            Some(RetentionRefusal::Unscheduled),
             "a policy whose only missing setting is `retention_check_interval` must refuse with that reason, not silently"
         );
         assert!(
@@ -2871,7 +2869,7 @@ mod tests {
                 .enabled(true)
                 .assemble()
                 .err(),
-            Some(RetentionRefusal::NoTimeColumn)
+            Some(RetentionRefusal::TimeColumnUnset)
         );
     }
 
@@ -2887,7 +2885,7 @@ mod tests {
                     .enabled(true)
                     .assemble()
                     .err(),
-                Some(RetentionRefusal::NoFilter),
+                Some(RetentionRefusal::NothingToDelete),
                 "check_interval={check_interval:?}"
             );
         }
@@ -2896,9 +2894,9 @@ mod tests {
     #[test]
     fn test_every_retention_refusal_names_the_dataset_the_impact_and_the_fix() {
         for refusal in [
-            RetentionRefusal::NoFilter,
-            RetentionRefusal::NoTimeColumn,
-            RetentionRefusal::NoCheckInterval,
+            RetentionRefusal::NothingToDelete,
+            RetentionRefusal::TimeColumnUnset,
+            RetentionRefusal::Unscheduled,
         ] {
             let message = refusal.message("events");
             assert!(
@@ -2923,7 +2921,7 @@ mod tests {
     #[test]
     fn test_a_refusal_cannot_forge_a_second_log_line_through_the_dataset_name() {
         // A quoted Spicepod identifier may legally contain a newline.
-        let message = RetentionRefusal::NoCheckInterval
+        let message = RetentionRefusal::Unscheduled
             .message("events\n2026-01-01T00:00:00Z ERROR forged: line");
         assert!(
             !message.contains('\n'),
@@ -2958,7 +2956,7 @@ mod tests {
 
     #[test]
     fn test_the_missing_check_interval_refusal_names_the_setting_that_has_no_default() {
-        let message = RetentionRefusal::NoCheckInterval.message("events");
+        let message = RetentionRefusal::Unscheduled.message("events");
         assert!(
             message.contains("`retention_check_interval`") && message.contains("no default"),
             "the refusal must name the unset setting and say it has no default: {message}"

--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -2318,6 +2318,7 @@ pub enum DataRetentionFilter {
 }
 
 pub struct RetentionBuilder {
+    dataset_name: Arc<str>,
     time_column: Option<String>,
     time_format: Option<TimeFormat>,
     time_period: Option<Duration>,
@@ -2330,8 +2331,9 @@ pub struct RetentionBuilder {
 
 impl RetentionBuilder {
     #[must_use]
-    pub fn new() -> Self {
+    pub fn new(dataset_name: impl Into<Arc<str>>) -> Self {
         Self {
+            dataset_name: dataset_name.into(),
             time_column: None,
             time_format: None,
             time_partition_column: None,
@@ -2394,22 +2396,37 @@ impl RetentionBuilder {
         self
     }
 
+    /// Assemble the policy, reporting a refusal that leaves the dataset unbounded.
+    ///
+    /// `enabled: false` is the one `None` that is not a refusal — the operator asked
+    /// for no retention — so it returns before [`Self::assemble`] and stays silent.
     #[must_use]
     pub fn build(self) -> Option<Retention> {
         if !self.enabled {
             return None;
         }
 
-        let check_interval = self.check_interval?;
+        let dataset_name = Arc::clone(&self.dataset_name);
+        match self.assemble() {
+            Ok(retention) => Some(retention),
+            Err(refusal) => {
+                tracing::error!("{}", refusal.message(&dataset_name));
+                None
+            }
+        }
+    }
+
+    /// The policy this configuration describes, or why it describes none.
+    ///
+    /// Split from [`Self::build`] so the refusal is a value a test can assert on
+    /// rather than a log line, and so every refusal is reported by one call site.
+    fn assemble(self) -> Result<Retention, RetentionRefusal> {
         let mut filters = Vec::new();
 
         // Add time-based filter if period and time_column are provided
         if let Some(period) = self.time_period {
             let Some(time_column) = self.time_column else {
-                tracing::error!(
-                    "[retention] The `time_column` must be specified for time-based retention"
-                );
-                return None;
+                return Err(RetentionRefusal::NoTimeColumn);
             };
 
             filters.push(DataRetentionFilter::Time {
@@ -2429,22 +2446,59 @@ impl RetentionBuilder {
         }
 
         if filters.is_empty() {
-            tracing::error!(
-                "[retention] The `retention_period` or `retention_sql` must be specified for retention"
-            );
-            return None;
+            return Err(RetentionRefusal::NoFilter);
         }
 
-        Some(Retention {
+        // Checked after the filters so that a configuration missing both is still
+        // reported by the filter arm, as it was before the interval had an arm at
+        // all: `retention_check_interval` has no default, so this is the arm a
+        // dataset reaches when it configures everything else a policy needs.
+        let check_interval = self
+            .check_interval
+            .ok_or(RetentionRefusal::NoCheckInterval)?;
+
+        Ok(Retention {
             filters,
             check_interval,
         })
     }
 }
 
-impl Default for RetentionBuilder {
-    fn default() -> Self {
-        Self::new()
+/// The docs page every retention refusal points at.
+const RETENTION_DOCS_URL: &str = "https://spiceai.org/docs/components/data-accelerators";
+
+/// Why [`RetentionBuilder::assemble`] could not assemble a retention policy.
+///
+/// Every variant has the same user-visible outcome — no retention pass runs, so the
+/// accelerated table is unbounded — reached through a different missing setting, so
+/// [`Self::message`] states that impact once and each variant supplies its own cause
+/// and fix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetentionRefusal {
+    /// Neither `retention_period` nor `retention_sql` says what to delete.
+    NoFilter,
+    /// `retention_period` is set but `time_column` does not say what to compare.
+    NoTimeColumn,
+    /// Nothing says how often to delete, and `retention_check_interval` has no default.
+    NoCheckInterval,
+}
+
+impl RetentionRefusal {
+    fn message(self, dataset_name: &str) -> String {
+        let cause_and_fix = match self {
+            Self::NoFilter => {
+                "Cause: neither `retention_period` nor `retention_sql` is set, so nothing says which rows to delete. Set one of them."
+            }
+            Self::NoTimeColumn => {
+                "Cause: time-based retention compares `time_column` against the cutoff, and it is not set. Set `time_column` on the dataset, or delete by expression with `retention_sql` instead."
+            }
+            Self::NoCheckInterval => {
+                "Cause: `retention_check_interval` is missing or is not a valid duration, and it has no default. Set it, for example `retention_check_interval: 1h`."
+            }
+        };
+        format!(
+            "[retention] Retention is enabled for dataset '{dataset_name}' but no retention pass runs, so no data is ever evicted and the accelerated table grows without limit. {cause_and_fix} See: {RETENTION_DOCS_URL}"
+        )
     }
 }
 
@@ -2455,8 +2509,8 @@ pub struct Retention {
 
 impl Retention {
     #[must_use]
-    pub fn builder() -> RetentionBuilder {
-        RetentionBuilder::new()
+    pub fn builder(dataset_name: impl Into<Arc<str>>) -> RetentionBuilder {
+        RetentionBuilder::new(dataset_name)
     }
 }
 
@@ -2737,6 +2791,116 @@ mod tests {
 
         assert!(
             matches!(err, DataFusionError::Internal(message) if message.contains("accelerator filter support length mismatch"))
+        );
+    }
+
+    /// A retention policy an operator would reasonably think complete, minus the one
+    /// setting that has no default.
+    fn interval_less_builder() -> RetentionBuilder {
+        Retention::builder("events")
+            .time_column(Some("ts"))
+            .time_period(Some(Duration::from_secs(30)))
+            .enabled(true)
+    }
+
+    #[test]
+    fn test_a_retention_policy_without_a_check_interval_is_refused_and_named() {
+        assert_eq!(
+            interval_less_builder().assemble().err(),
+            Some(RetentionRefusal::NoCheckInterval),
+            "a policy whose only missing setting is `retention_check_interval` must refuse with that reason, not silently"
+        );
+        assert!(
+            interval_less_builder().build().is_none(),
+            "an unassemblable policy still builds into no retention task"
+        );
+    }
+
+    #[test]
+    fn test_a_complete_retention_policy_builds() {
+        let retention = interval_less_builder()
+            .check_interval(Some(Duration::from_secs(1)))
+            .build()
+            .expect("a policy with a time column, a period and a check interval must build");
+        assert_eq!(retention.check_interval, Duration::from_secs(1));
+        assert_eq!(retention.filters.len(), 1);
+    }
+
+    #[test]
+    fn test_retention_disabled_is_not_a_refusal() {
+        assert!(
+            Retention::builder("events")
+                .enabled(false)
+                .build()
+                .is_none(),
+            "`retention_check_enabled: false` is an operator opting out, so it must not report a refusal"
+        );
+    }
+
+    #[test]
+    fn test_a_period_without_a_time_column_is_refused() {
+        assert_eq!(
+            Retention::builder("events")
+                .time_period(Some(Duration::from_secs(30)))
+                .check_interval(Some(Duration::from_secs(1)))
+                .enabled(true)
+                .assemble()
+                .err(),
+            Some(RetentionRefusal::NoTimeColumn)
+        );
+    }
+
+    #[test]
+    fn test_a_policy_with_nothing_to_delete_is_refused_on_the_filter() {
+        // Precedence: a configuration missing both a filter and the interval keeps
+        // reporting the filter, which is the message it reported before the interval
+        // had an arm of its own.
+        for check_interval in [None, Some(Duration::from_secs(1))] {
+            assert_eq!(
+                Retention::builder("events")
+                    .check_interval(check_interval)
+                    .enabled(true)
+                    .assemble()
+                    .err(),
+                Some(RetentionRefusal::NoFilter),
+                "check_interval={check_interval:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_every_retention_refusal_names_the_dataset_the_impact_and_the_fix() {
+        for refusal in [
+            RetentionRefusal::NoFilter,
+            RetentionRefusal::NoTimeColumn,
+            RetentionRefusal::NoCheckInterval,
+        ] {
+            let message = refusal.message("events");
+            assert!(
+                message.contains("dataset 'events'"),
+                "{refusal:?} must name the dataset: {message}"
+            );
+            assert!(
+                message.contains("grows without limit"),
+                "{refusal:?} must state what the operator will observe: {message}"
+            );
+            assert!(
+                message.contains(RETENTION_DOCS_URL),
+                "{refusal:?} must link the docs: {message}"
+            );
+            assert!(
+                !message.contains('\n'),
+                "{refusal:?} must stay on one line: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_the_missing_check_interval_refusal_names_the_setting_that_has_no_default() {
+        let message = RetentionRefusal::NoCheckInterval.message("events");
+        assert!(
+            message.contains("`retention_check_interval`") && message.contains("no default"),
+            "the refusal must name the unset setting and say it has no default: {message}"
         );
     }
 }

--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -2397,23 +2397,43 @@ impl RetentionBuilder {
     }
 
     /// Assemble the policy, reporting a refusal that leaves the dataset unbounded.
-    ///
-    /// `enabled: false` is the one `None` that is not a refusal — the operator asked
-    /// for no retention — so it returns before [`Self::assemble`] and stays silent.
     #[must_use]
     pub fn build(self) -> Option<Retention> {
-        if !self.enabled {
-            return None;
-        }
-
         let dataset_name = Arc::clone(&self.dataset_name);
-        match self.assemble() {
-            Ok(retention) => Some(retention),
+        match self.declared_policy() {
+            Ok(retention) => retention,
             Err(refusal) => {
                 tracing::error!("{}", refusal.message(&dataset_name));
                 None
             }
         }
+    }
+
+    /// [`Self::build`], but silent about a refusal because the caller decides what
+    /// bounds the accelerator and reports that itself.
+    ///
+    /// Caching mode is the one such caller. When `caching_stale_if_error` is disabled
+    /// the caching parameters derive a retention policy of their own and install it
+    /// over whatever this builder produced, so a refusal reported here would say
+    /// nothing evicts while a policy that does was about to replace it.
+    /// `caching_retention` owns that decision, and its unbounded arm carries a warning
+    /// that already explains a declared policy which started nothing.
+    #[must_use]
+    pub fn build_unreported(self) -> Option<Retention> {
+        self.declared_policy().unwrap_or_default()
+    }
+
+    /// The policy this configuration declares — `None` for an operator who opted out —
+    /// or why a configuration that asked for one describes none.
+    ///
+    /// `enabled: false` is the one absent policy that is not a refusal, and it lives
+    /// here rather than in each `build` so the two cannot come to disagree about it.
+    fn declared_policy(self) -> Result<Option<Retention>, RetentionRefusal> {
+        if !self.enabled {
+            return Ok(None);
+        }
+
+        self.assemble().map(Some)
     }
 
     /// The policy this configuration describes, or why it describes none.
@@ -2485,6 +2505,11 @@ enum RetentionRefusal {
 
 impl RetentionRefusal {
     fn message(self, dataset_name: &str) -> String {
+        // `escape_debug` rather than the raw name, matching
+        // `unbounded_caching_retention_warning`: a Spicepod identifier may be quoted,
+        // and a quoted one may legally contain a newline, so a validated name can
+        // otherwise break this line in two and forge a second one.
+        let dataset_name = dataset_name.escape_debug();
         let cause_and_fix = match self {
             Self::NoFilter => {
                 "Cause: neither `retention_period` nor `retention_sql` is set, so nothing says which rows to delete. Set one of them."
@@ -2893,6 +2918,42 @@ mod tests {
                 "{refusal:?} must stay on one line: {message}"
             );
         }
+    }
+
+    #[test]
+    fn test_a_refusal_cannot_forge_a_second_log_line_through_the_dataset_name() {
+        // A quoted Spicepod identifier may legally contain a newline.
+        let message = RetentionRefusal::NoCheckInterval
+            .message("events\n2026-01-01T00:00:00Z ERROR forged: line");
+        assert!(
+            !message.contains('\n'),
+            "the dataset name must be escaped, not break the line: {message}"
+        );
+        assert!(
+            message.contains(r"events\n"),
+            "the newline must survive as an escape rather than vanish: {message}"
+        );
+    }
+
+    #[test]
+    fn test_build_unreported_refuses_the_same_policies_build_does() {
+        // The caching call site swaps `build` for this, so the only difference must
+        // be whether the refusal is logged.
+        assert!(interval_less_builder().build_unreported().is_none());
+        assert!(
+            Retention::builder("events")
+                .enabled(true)
+                .build_unreported()
+                .is_none(),
+            "a policy with nothing to delete assembles into nothing either way"
+        );
+        assert!(
+            interval_less_builder()
+                .check_interval(Some(Duration::from_secs(1)))
+                .build_unreported()
+                .is_some(),
+            "a complete policy must still build when the caller owns the reporting"
+        );
     }
 
     #[test]

--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -2487,10 +2487,16 @@ const RETENTION_DOCS_URL: &str = "https://spiceai.org/docs/components/data-accel
 
 /// Why [`RetentionBuilder::assemble`] could not assemble a retention policy.
 ///
-/// Every variant has the same user-visible outcome — no retention pass runs, so the
-/// accelerated table is unbounded — reached through a different missing setting, so
-/// [`Self::message`] states that impact once and each variant supplies its own cause
-/// and fix.
+/// Every variant has the same user-visible outcome — no *scheduled* retention pass runs —
+/// reached through a different missing setting, so [`Self::message`] states that impact
+/// once and each variant supplies its own cause and fix.
+///
+/// The impact stops at "nothing deletes on a schedule" deliberately. Two callers install
+/// something that still evicts: `create_accelerated_table` copies `retention_sql` into
+/// `refresh.write_retention_sql_delete_expr` for Arrow engines *before* building this, so
+/// refreshes go on deleting matching rows while `Unscheduled` or `TimeColumnUnset` refuses;
+/// and caching mode derives a policy after it (see [`RetentionBuilder::build_unreported`]).
+/// A claim about the table being unbounded is therefore not this builder's to make.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RetentionRefusal {
     /// Neither `retention_period` nor `retention_sql` says what to delete.
@@ -2510,7 +2516,7 @@ impl RetentionRefusal {
         let dataset_name = dataset_name.escape_debug();
         let cause_and_fix = match self {
             Self::NothingToDelete => {
-                "Cause: neither `retention_period` nor `retention_sql` is set, so nothing says which rows to delete. Set one of them."
+                "Cause: neither `retention_period` nor `retention_sql` is set to a valid value, so nothing says which rows to delete. Set one of them."
             }
             Self::TimeColumnUnset => {
                 "Cause: time-based retention compares `time_column` against the cutoff, and it is not set. Set `time_column` on the dataset, or delete by expression with `retention_sql` instead."
@@ -2520,7 +2526,7 @@ impl RetentionRefusal {
             }
         };
         format!(
-            "[retention] Retention is enabled for dataset '{dataset_name}' but no retention pass runs, so no data is ever evicted and the accelerated table grows without limit. {cause_and_fix} See: {RETENTION_DOCS_URL}"
+            "[retention] Retention is enabled for dataset '{dataset_name}' but no scheduled retention pass runs, so nothing deletes rows on a schedule. {cause_and_fix} See: {RETENTION_DOCS_URL}"
         )
     }
 }
@@ -2904,7 +2910,7 @@ mod tests {
                 "{refusal:?} must name the dataset: {message}"
             );
             assert!(
-                message.contains("grows without limit"),
+                message.contains("no scheduled retention pass runs"),
                 "{refusal:?} must state what the operator will observe: {message}"
             );
             assert!(
@@ -2951,6 +2957,46 @@ mod tests {
                 .build_unreported()
                 .is_some(),
             "a complete policy must still build when the caller owns the reporting"
+        );
+    }
+
+    #[test]
+    fn test_no_refusal_claims_the_table_is_unbounded() {
+        // `create_accelerated_table` installs `retention_sql` on the Arrow refresh write
+        // path before building this, and caching mode derives a policy after it, so both
+        // `Unscheduled` and `TimeColumnUnset` are reachable while something still evicts.
+        // Measured on a running spiced: the refusal printed 64ms before
+        // "[retention] Evicted 7 records for events". See #13804.
+        for refusal in [
+            RetentionRefusal::NothingToDelete,
+            RetentionRefusal::TimeColumnUnset,
+            RetentionRefusal::Unscheduled,
+        ] {
+            let message = refusal.message("events");
+            for overclaim in [
+                "no data is ever evicted",
+                "grows without limit",
+                "never deleted",
+                "is unbounded",
+            ] {
+                assert!(
+                    !message.contains(overclaim),
+                    "{refusal:?} must not claim {overclaim:?} — the builder only knows that no scheduled pass runs: {message}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_a_refusal_blames_the_value_not_the_key_where_a_bad_value_collapses_to_none() {
+        // `Dataset::retention_period` warns on an unparseable value and returns `None`, so
+        // this arm is reached with the key set. Saying it "is not set" told the operator to
+        // set a key they had already set. Measured: `retention_period: 7dd` logs
+        // "Unable to parse retention period" and then this refusal. See #13804.
+        let message = RetentionRefusal::NothingToDelete.message("events");
+        assert!(
+            message.contains("is set to a valid value"),
+            "the cause must fault the value, since an invalid one arrives here as absent: {message}"
         );
     }
 

--- a/crates/runtime-table/src/accelerated/retention.rs
+++ b/crates/runtime-table/src/accelerated/retention.rs
@@ -429,7 +429,7 @@ mod tests {
             .delete_expr
         });
 
-        let retention = Retention::builder()
+        let retention = Retention::builder("test")
             .time_column(time_column.map(String::from))
             .time_format(Some(runtime_component::dataset::TimeFormat::UnixSeconds))
             .time_period(retention_period)

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -3119,7 +3119,7 @@ impl DataFusion {
             accelerated_table_builder.user_facing_schema(Arc::clone(&refresh_schema));
         }
 
-        let retention = Retention::builder(dataset.name.to_string())
+        let retention_builder = Retention::builder(dataset.name.to_string())
             .time_column(dataset.time_column.clone())
             .time_format(dataset.time_format)
             .time_partition_column(dataset.time_partition_column.clone())
@@ -3127,8 +3127,18 @@ impl DataFusion {
             .time_period(dataset.retention_period())
             .check_interval(dataset.retention_check_interval())
             .enabled(acceleration_settings.retention_check_enabled)
-            .delete_expr(retention_delete_expr)
-            .build();
+            .delete_expr(retention_delete_expr);
+
+        // Caching mode decides what bounds the accelerator in the block below, and
+        // can install a policy derived from the caching parameters over this one — so
+        // a refusal reported here would say nothing evicts while something does.
+        // `caching_retention` reports that case instead, keyed on the
+        // `declared_retention_runs` this produces.
+        let retention = if matches!(refresh_mode, RefreshMode::Caching) {
+            retention_builder.build_unreported()
+        } else {
+            retention_builder.build()
+        };
 
         // Whether a retention task will actually run, which is not the same as
         // the dataset having configured one: the builder returns `None` for a

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -3119,7 +3119,7 @@ impl DataFusion {
             accelerated_table_builder.user_facing_schema(Arc::clone(&refresh_schema));
         }
 
-        let retention = Retention::builder()
+        let retention = Retention::builder(dataset.name.to_string())
             .time_column(dataset.time_column.clone())
             .time_format(dataset.time_format)
             .time_partition_column(dataset.time_partition_column.clone())
@@ -3201,7 +3201,7 @@ impl DataFusion {
                         );
                     }
 
-                    let cache_retention = Retention::builder()
+                    let cache_retention = Retention::builder(dataset.name.to_string())
                         .time_column(Some(crate::accelerated::caching::CACHE_REFRESHED_AT_COLUMN))
                         .time_period(Some(period))
                         .check_interval(Some(check_interval))

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -98,7 +98,7 @@ pub async fn register_metrics_table(
 ) -> Result<(), Error> {
     let metrics_table_reference = get_metrics_table_reference();
 
-    let retention = Retention::builder()
+    let retention = Retention::builder(metrics_table_reference.to_string())
         .time_column(Some("time_unix_nano"))
         .time_format(Some(TimeFormat::Timestamptz))
         .time_period(Some(Duration::from_mins(30))) // delete metrics older than 30 minutes

--- a/crates/runtime/src/task_history/mod.rs
+++ b/crates/runtime/src/task_history/mod.rs
@@ -104,13 +104,15 @@ impl TaskSpan {
             "Task history retention check interval: {retention_check_interval_secs} seconds"
         );
 
-        let retention = Retention::builder()
-            .time_column(time_column.clone())
-            .time_format(time_format)
-            .time_period(Some(Duration::from_secs(retention_period_secs)))
-            .check_interval(Some(Duration::from_secs(retention_check_interval_secs)))
-            .enabled(true)
-            .build();
+        let retention = Retention::builder(
+            TableReference::partial(SPICE_RUNTIME_SCHEMA, DEFAULT_TASK_HISTORY_TABLE).to_string(),
+        )
+        .time_column(time_column.clone())
+        .time_format(time_format)
+        .time_period(Some(Duration::from_secs(retention_period_secs)))
+        .check_interval(Some(Duration::from_secs(retention_check_interval_secs)))
+        .enabled(true)
+        .build();
 
         let tbl_reference =
             TableReference::partial(SPICE_RUNTIME_SCHEMA, DEFAULT_TASK_HISTORY_TABLE);

--- a/crates/runtime/tests/acceleration/retention_arrow.rs
+++ b/crates/runtime/tests/acceleration/retention_arrow.rs
@@ -153,7 +153,7 @@ async fn test_partitioned_arrow_retention_sql_applies_on_refresh_without_retenti
 
 /// The retention period for the tests below. Rows older than this are what a retention
 /// pass is supposed to delete.
-const RETENTION_PERIOD: std::time::Duration = std::time::Duration::from_mins(60);
+const RETENTION_PERIOD: std::time::Duration = std::time::Duration::from_hours(1);
 
 /// Rows this many minutes old, so they sit well outside [`RETENTION_PERIOD`] but well
 /// inside the refresh window the dataset declares.
@@ -174,11 +174,12 @@ fn write_straddling_source(path: &std::path::Path) -> Result<(), anyhow::Error> 
     let now = chrono::Utc::now();
     let mut csv = String::from("id,ts\n");
     for i in 0..STALE_ROWS {
-        let ts = now - chrono::Duration::minutes(STALE_AGE_MINUTES + i as i64);
+        let offset = i64::try_from(i)?;
+        let ts = now - chrono::Duration::minutes(STALE_AGE_MINUTES + offset);
         writeln!(csv, "{},{}", i, ts.format("%Y-%m-%dT%H:%M:%S%.6fZ"))?;
     }
     for i in 0..FRESH_ROWS {
-        let ts = now - chrono::Duration::seconds(i as i64);
+        let ts = now - chrono::Duration::seconds(i64::try_from(i)?);
         writeln!(
             csv,
             "{},{}",
@@ -274,7 +275,7 @@ async fn test_arrow_time_retention_with_a_check_interval_evicts_the_stale_rows()
                     .await?;
 
             let fresh = i64::try_from(FRESH_ROWS)?;
-            let evicted = wait_until_true(std::time::Duration::from_secs(60), || async {
+            let evicted = wait_until_true(std::time::Duration::from_mins(1), || async {
                 crate::acceleration::row_count(&rt, name)
                     .await
                     .is_ok_and(|c| c == fresh)

--- a/crates/runtime/tests/acceleration/retention_arrow.rs
+++ b/crates/runtime/tests/acceleration/retention_arrow.rs
@@ -27,7 +27,7 @@ use spicepod::{
 };
 use std::sync::Arc;
 
-use crate::utils::{runtime_ready_check, test_request_context};
+use crate::utils::{runtime_ready_check, test_request_context, wait_until_true};
 
 async fn run_query(rt: &Arc<Runtime>, sql: &str) -> Result<Vec<RecordBatch>, anyhow::Error> {
     rt.datafusion()
@@ -149,4 +149,203 @@ async fn test_partitioned_arrow_retention_sql_applies_on_refresh_without_retenti
         }],
     )
     .await
+}
+
+/// The retention period for the tests below. Rows older than this are what a retention
+/// pass is supposed to delete.
+const RETENTION_PERIOD: std::time::Duration = std::time::Duration::from_mins(60);
+
+/// Rows this many minutes old, so they sit well outside [`RETENTION_PERIOD`] but well
+/// inside the refresh window the dataset declares.
+const STALE_AGE_MINUTES: i64 = 180;
+
+/// How many of the source's rows are stale, and how many are fresh.
+const STALE_ROWS: usize = 5;
+const FRESH_ROWS: usize = 5;
+
+/// Write a source whose `ts` column straddles [`RETENTION_PERIOD`]: [`STALE_ROWS`] rows
+/// old enough for a retention pass to delete, and [`FRESH_ROWS`] it must keep.
+///
+/// The window is expressed against the process clock rather than fixed instants so the
+/// same file means the same thing whenever the test runs.
+fn write_straddling_source(path: &std::path::Path) -> Result<(), anyhow::Error> {
+    use std::fmt::Write as _;
+
+    let now = chrono::Utc::now();
+    let mut csv = String::from("id,ts\n");
+    for i in 0..STALE_ROWS {
+        let ts = now - chrono::Duration::minutes(STALE_AGE_MINUTES + i as i64);
+        writeln!(csv, "{},{}", i, ts.format("%Y-%m-%dT%H:%M:%S%.6fZ"))?;
+    }
+    for i in 0..FRESH_ROWS {
+        let ts = now - chrono::Duration::seconds(i as i64);
+        writeln!(
+            csv,
+            "{},{}",
+            STALE_ROWS + i,
+            ts.format("%Y-%m-%dT%H:%M:%S%.6fZ")
+        )?;
+    }
+    std::fs::write(path, csv)?;
+    Ok(())
+}
+
+/// A time-based retention policy, complete except for `retention_check_interval` when
+/// `check_interval` is `None` — the one setting with no default, and the configuration
+/// #13804 is about.
+///
+/// `refresh_data_window` is declared wider than `retention_period` on purpose: the
+/// refresh window otherwise falls back to `retention_period`
+/// (`DataFusion::create_accelerated_table`), which would filter the stale rows out at
+/// load and leave nothing for a retention pass to be observed deleting. No
+/// `refresh_check_interval` is set either, so the source loads once and a later refresh
+/// cannot put back what retention removed.
+fn make_time_retention_dataset(
+    source: &std::path::Path,
+    name: &str,
+    check_interval: Option<&str>,
+) -> Dataset {
+    let mut dataset = Dataset::new(format!("file://{}", source.display()), name);
+    dataset.time_column = Some("ts".to_string());
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        engine: Some("arrow".to_string()),
+        mode: Mode::Memory,
+        refresh_mode: Some(RefreshMode::Full),
+        refresh_data_window: Some("24h".to_string()),
+        retention_period: Some(format!("{}s", RETENTION_PERIOD.as_secs())),
+        retention_check_enabled: true,
+        retention_check_interval: check_interval.map(ToString::to_string),
+        ..Acceleration::default()
+    });
+    dataset
+}
+
+/// Load `dataset` and return the runtime, with every row of the source in the
+/// acceleration.
+async fn load_with_all_rows(name: &str, dataset: Dataset) -> Result<Arc<Runtime>, anyhow::Error> {
+    let app = AppBuilder::new(name).with_dataset(dataset).build();
+    let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+    tokio::select! {
+        () = tokio::time::sleep(std::time::Duration::from_mins(1)) => {
+            return Err(anyhow::Error::msg("Timeout waiting for components to load"));
+        }
+        () = Arc::clone(&rt).load_components() => {}
+    }
+    runtime_ready_check(&rt).await;
+
+    let total = i64::try_from(STALE_ROWS + FRESH_ROWS)?;
+    let loaded = wait_until_true(std::time::Duration::from_secs(30), || async {
+        crate::acceleration::row_count(&rt, name)
+            .await
+            .is_ok_and(|c| c == total)
+    })
+    .await;
+    anyhow::ensure!(
+        loaded,
+        "the acceleration holds {} row(s) after load, expected all {total}: the refresh window did not admit the stale rows, so this test cannot observe retention",
+        crate::acceleration::row_count(&rt, name).await?
+    );
+    Ok(rt)
+}
+
+/// A complete time-based retention policy runs, and deletes exactly the stale rows.
+///
+/// The companion test below is the same configuration with `retention_check_interval`
+/// removed; together they are what asserts a policy actually starts for a given
+/// configuration, which nothing covered when #13804 was filed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_arrow_time_retention_with_a_check_interval_evicts_the_stale_rows()
+-> Result<(), anyhow::Error> {
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            crate::configure_test_datafusion();
+
+            let temp_dir = tempfile::tempdir()?;
+            let source = temp_dir.path().join("events.csv");
+            write_straddling_source(&source)?;
+
+            let name = "arrow_time_retention_with_interval";
+            let rt =
+                load_with_all_rows(name, make_time_retention_dataset(&source, name, Some("1s")))
+                    .await?;
+
+            let fresh = i64::try_from(FRESH_ROWS)?;
+            let evicted = wait_until_true(std::time::Duration::from_secs(60), || async {
+                crate::acceleration::row_count(&rt, name)
+                    .await
+                    .is_ok_and(|c| c == fresh)
+            })
+            .await;
+            assert!(
+                evicted,
+                "the acceleration holds {} row(s), expected the {fresh} inside the retention period: the retention pass did not run",
+                crate::acceleration::row_count(&rt, name).await?
+            );
+
+            let survivors = run_query(&rt, &format!("SELECT id FROM {name} ORDER BY id")).await?;
+            let expected = [
+                "+----+", "| id |", "+----+", "| 5  |", "| 6  |", "| 7  |", "| 8  |", "| 9  |",
+                "+----+",
+            ];
+            assert_batches_eq!(&expected, &survivors);
+
+            Ok(())
+        })
+        .await
+}
+
+/// The same policy with no `retention_check_interval` never evicts anything.
+///
+/// This is the state #13804 reports: the setting has no default, so an operator who
+/// configured everything else gets no retention. The assertion is that the rows stay,
+/// which is the observable half — that the runtime now *says* so is asserted on the
+/// refusal itself in `runtime-table`, where the message is a value rather than a log
+/// line a spawned task writes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_arrow_time_retention_without_a_check_interval_evicts_nothing()
+-> Result<(), anyhow::Error> {
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            crate::configure_test_datafusion();
+
+            let temp_dir = tempfile::tempdir()?;
+            let source = temp_dir.path().join("events.csv");
+            write_straddling_source(&source)?;
+
+            let name = "arrow_time_retention_without_interval";
+            let rt = load_with_all_rows(name, make_time_retention_dataset(&source, name, None))
+                .await?;
+
+            let total = i64::try_from(STALE_ROWS + FRESH_ROWS)?;
+            let fresh = i64::try_from(FRESH_ROWS)?;
+            // The companion test above converges in a second or two on the same rig, so
+            // a window this long is generous rather than tight: what is under test is
+            // that no pass is scheduled at all.
+            let evicted = wait_until_true(std::time::Duration::from_secs(20), || async {
+                crate::acceleration::row_count(&rt, name)
+                    .await
+                    .is_ok_and(|c| c < total)
+            })
+            .await;
+            assert!(
+                !evicted,
+                "the acceleration dropped to {} row(s) with no `retention_check_interval` set, so retention ran after all and this test no longer covers #13804",
+                crate::acceleration::row_count(&rt, name).await?
+            );
+            assert_eq!(
+                crate::acceleration::row_count(&rt, name).await?,
+                total,
+                "every row must survive, including the {} outside the retention period",
+                total - fresh
+            );
+
+            Ok(())
+        })
+        .await
 }

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -174,7 +174,7 @@ impl SpiceExtension {
         runtime: Arc<Runtime>,
         from: String,
     ) -> Result<()> {
-        let retention = Retention::builder()
+        let retention = Retention::builder(get_metrics_table_reference().to_string())
             .time_column(Some("timestamp".to_string()))
             .time_format(Some(TimeFormat::UnixSeconds))
             .time_period(Some(Duration::from_mins(30))) // delete metrics older than 30 minutes


### PR DESCRIPTION
## Summary

`RetentionBuilder::build` returned `None` at `let check_interval = self.check_interval?`, so a dataset that set `retention_check_enabled: true`, a `retention_period` and a `time_column` — everything an operator would think constitutes a retention policy — got no retention task and no diagnostic. `retention_check_interval` has no default, so that is one unset field away from any time-based retention policy, and the only signal is the absence of log lines nobody has reason to look for. The builder's other two refusals both reported themselves; the missing interval was the only silent one.

Root cause: the `?` on `self.check_interval` was the first thing `build` did, and `?` on an `Option` cannot carry a reason. The two refusals that *were* reported logged inline and returned `None`, so a third arm meant either a third inline log or making the refusal a value. It is now a value.

## Changes

- `RetentionBuilder::assemble` returns `Result<Retention, RetentionRefusal>` — the policy, or why there is none — and `build` is the one call site that reports it, so a refusal cannot be added without being reported.
- The missing `retention_check_interval` gets an arm of its own, checked **after** the filter arms so a configuration missing both keeps reporting the filter, exactly as it did before the interval had an arm at all.
- All three refusals now name the dataset, state that the accelerated table grows without limit, and link the accelerator docs. None named the dataset before — that is what the builder needed a dataset name for, and all six call sites now pass one.
- The dataset name is `escape_debug`-ed, matching `unbounded_caching_retention_warning`: a quoted Spicepod identifier may legally contain a newline and could otherwise forge a second log line.
- `retention_check_enabled: false` stays silent. An operator asking for no retention is not a policy that failed to assemble, and `declared_policy` holds that rule once so the two `build` entry points cannot come to disagree about it.
- `build_unreported` for caching mode, the one caller that decides the accelerator's bound itself — see the note below.
- The refusal variants are named `NothingToDelete` / `TimeColumnUnset` / `Unscheduled` rather than a shared-prefix `No*` triple, which `clippy::enum_variant_names` rejects.

### Why caching mode does not report

The refusal asserts that nothing evicts and the table grows without limit, and under `refresh_mode: caching` that would be false. `create_accelerated_table` builds the dataset's own policy first, then `caching_retention` returns `Derive` — which it does whenever `caching_stale_if_error` is disabled, the default — and installs a derived policy over it. Reporting there would print an error saying nothing evicts immediately before a policy that does was installed, contradicting the existing "User-specified retention_period is overridden by automatic cache retention" warning beside it. That path's `Unbounded` arm already carries a warning explaining a declared policy that started nothing, so the refusal is left to it.

## Test plan

- `make lint`
- `make test`

### Reproduction on `trunk`, and its absence after

Two `spiced` runs against the same CSV source, differing only in whether `retention_check_interval` is set, then the same pair on this branch. `trunk` is `2f9a874a97`; the branch build is `dc4b4ff863`. Every cell loaded the same 6 rows, so the config and the build are the only variables.

| build | `retention_check_interval` | rows loaded | `[retention]` log lines |
|---|---|---|---|
| `2f9a874a97` (trunk) | unset | 6 | **0** |
| `2f9a874a97` (trunk) | `1s` | 6 | 81 (40 eviction lines, 6 real deletions) |
| `dc4b4ff863` (this branch) | unset | 6 | **1** — the new error |
| `dc4b4ff863` (this branch) | `1s` | 6 | 81 (40 eviction lines, 6 real deletions) |

On `trunk` with no interval, nothing runs and nothing is said — the run is otherwise clean, and the only line in it mentioning `retention_check_interval` is the unrelated `task_history` startup line. The same configuration on this branch:

```
ERROR runtime_table::accelerated: [retention] Retention is enabled for dataset 'events' but no
retention pass runs, so no data is ever evicted and the accelerated table grows without limit.
Cause: `retention_check_interval` is missing or is not a valid duration, and it has no default.
Set it, for example `retention_check_interval: 1h`. See: https://spiceai.org/docs/components/data-accelerators
```

The fourth row is the control that matters for regression: with the interval set, this branch still logs the identical 81 lines and performs the same 6 deletions, so the diagnostic is added without changing what retention does.

### Tests

`crates/runtime-table/src/accelerated/mod.rs` — 8 unit tests over the refusal decision and its wording (the dataset name, the impact clause, the docs link, one-line-ness, the newline-escaping, and the filter-before-interval precedence). Neuter-verified four ways: swapping `NoCheckInterval` for `NoFilter`, and dropping the dataset name, the docs link, or the impact clause, each fails them.

`crates/runtime/tests/acceleration/retention_arrow.rs` — the end-to-end coverage the issue asked for, which did not exist: a complete time-based policy evicts exactly the stale rows, and the same policy with only `retention_check_interval` removed evicts nothing. `refresh_data_window` is declared wider than `retention_period` on purpose, since the refresh window otherwise falls back to `retention_period` and would filter the stale rows out at load, leaving nothing for a retention pass to be observed deleting.

```
test acceleration::retention_arrow::test_arrow_time_retention_with_a_check_interval_evicts_the_stale_rows ... ok
test acceleration::retention_arrow::test_arrow_time_retention_without_a_check_interval_evicts_nothing ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 314 filtered out; finished in 20.32s
```

Every existing configuration in the repo that sets `retention_check_enabled: true` also sets an interval, so the new error does not fire in any existing test or benchmark spicepod.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` not installed
- `/security-review`: no findings
- `/simplify`: applied — `declared_policy` extracted so the "disabled is not a refusal" rule is stated once; unit tests re-run green

Because no second model was available, the diff was re-read against its callers instead, which is what found the caching-mode falsehood and the un-escaped dataset name recorded above. Both are fixed here rather than filed.

Re-run on `c135b75813`, the shipping head, with the same result. The security review was not re-run for the two follow-up commits: they rename enum variants, replace two `as i64` casts with `i64::try_from`, and reword log text — no input-handling, auth, filesystem, or secret-bearing surface.

**Copilot's review found two more instances of the same over-claim, both real and both since reproduced** — see the threads. The impact clause asserted that nothing is ever evicted, which is false wherever another caller installs something that evicts: `retention_sql` on the Arrow refresh write path, and caching's derived policy. Measured on a running `spiced`, the refusal printed **64 ms before** `[retention] Evicted 7 records for events`, with the table holding only the rows the predicate keeps. Separately, `retention_period: 7dd` logged `Unable to parse retention period` and then told the operator the key "is not set". Both are fixed here: the impact now stops at "no scheduled retention pass runs", and the cause faults the value rather than the key. Two tests guard the regression.

Counting the caching-mode case I found before opening this PR, the same wording error was reachable in **three** places. That is a design fault in the original message rather than three coincidences, which is why the fix weakens the claim to what the builder can prove instead of patching each site.

Fixes #13804

## A note on sign-off

The sign-off for this branch was blocked once by `runtime_launcher::tests::child_process::a_termination_signal_reaches_the_runtime` in `bin/spice`, which this diff does not touch. That is #13669, already open: the test's retry group either passes in ~0.6s or burns its full ~10s budget six times, depending on host load. Re-run in isolation on the same tree it came back `FLAKY 5/6 … passed in 0.640s`, and `12529 of 12530` tests passed in the sign-off itself. Measurement added to that issue rather than filing a duplicate.

## Checklist

- [x] Reproduced the reported failure on `trunk` and its absence on this branch, with the same command
- [x] Regression tests that fail on the old code (neuter-verified)
- [x] End-to-end coverage that a retention policy actually starts for a given configuration
- [x] User-facing messages name the dataset, state the impact, and link the docs
- [x] `make lint` / `make test`