### PR TITLE
fix(search): evict a key whose deciding row the index rejected (fixes #13848)

### DIFF
--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -23,7 +23,7 @@ limitations under the License.
 //! 3. Bulk-indexes the documents into Elasticsearch, using the primary key as
 //!    the document `_id`.
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use arrow::array::{
     Array, FixedSizeListBuilder, Float32Builder, LargeStringArray, RecordBatch, StringArray,
@@ -291,16 +291,17 @@ fn build_documents(
 
     let expected_dims = usize::try_from(index.dims.max(0)).unwrap_or(0);
 
-    // The `_id`s of rows this batch could not index. A document already stored under
-    // one of them holds a vector from an earlier value of the row's text, which a
-    // search would go on returning — see [`write_util::keys_to_evict`].
-    let mut rejected: Vec<String> = Vec::new();
+    // What this batch did with each row that names an `_id`, in row order. A document
+    // already stored under a rejected `_id` holds a vector from an earlier value of the
+    // row's text, which a search would go on returning — see
+    // [`write_util::keys_to_evict`], which also decides a repeated `_id` by its last row.
+    let mut outcomes: Vec<(String, write_util::RowOutcome)> = Vec::with_capacity(record.num_rows());
 
     for row in 0..record.num_rows() {
         let Some(embedding) = embedding_vectors[row].as_ref() else {
             missing_embedding_skips += 1;
             if let Some(id) = primary_keys[row].as_ref() {
-                rejected.push(id.clone());
+                outcomes.push((id.clone(), write_util::RowOutcome::Rejected));
             }
             continue;
         };
@@ -333,7 +334,7 @@ fn build_documents(
                 zero_or_nan_samples.push(row);
             }
             if let Some(id) = primary_keys[row].as_ref() {
-                rejected.push(id.clone());
+                outcomes.push((id.clone(), write_util::RowOutcome::Rejected));
             }
             continue;
         }
@@ -344,7 +345,7 @@ fn build_documents(
                 non_finite_samples.push(row);
             }
             if let Some(id) = primary_keys[row].as_ref() {
-                rejected.push(id.clone());
+                outcomes.push((id.clone(), write_util::RowOutcome::Rejected));
             }
             continue;
         }
@@ -377,6 +378,9 @@ fn build_documents(
         );
         doc.insert(index.vector_field.clone(), vec_json);
 
+        if let Some(id) = primary_keys[row].as_ref() {
+            outcomes.push((id.clone(), write_util::RowOutcome::Indexed));
+        }
         docs.push((primary_keys[row].clone(), Value::Object(doc)));
     }
 
@@ -401,8 +405,15 @@ fn build_documents(
         );
     }
 
-    let indexed = docs.iter().filter_map(|(id, _)| id.as_deref());
-    let evicted = write_util::keys_to_evict(rejected, indexed);
+    let evicted = write_util::keys_to_evict(outcomes.iter().map(|(id, o)| (id.as_str(), *o)));
+
+    // A document whose `_id` is evicted must not be indexed by this same request: the
+    // delete runs first, so leaving it in `docs` would restore under that `_id` a row a
+    // later row of the same batch replaced with one this write could not index.
+    if !evicted.is_empty() {
+        let evicted_ids: HashSet<&str> = evicted.iter().map(String::as_str).collect();
+        docs.retain(|(id, _)| !id.as_deref().is_some_and(|id| evicted_ids.contains(id)));
+    }
     Ok((docs, evicted))
 }
 
@@ -1116,6 +1127,56 @@ mod tests {
             assert_eq!(
                 evicted(&[1, 2], &[Some(vec![1.0, 2.0]), None]),
                 vec!["2".to_string()],
+            );
+        }
+
+        /// The `_id`s the `_bulk` body would carry, in the order it carries them.
+        fn indexed_ids(ids: &[i64], embeddings: &[Option<Vec<f32>>]) -> Vec<String> {
+            let index = index();
+            let (docs, _evicted) = build_documents(&index, &record(ids), embeddings, &keys(ids))
+                .expect("documents build");
+            docs.into_iter()
+                .map(|(id, _)| id.expect("every test row names an _id"))
+                .collect()
+        }
+
+        /// Regression test for #13848. One batch carries `_id` 1 twice, and the row that
+        /// *decides* it — the last — is one Elasticsearch cannot be given a vector for. The
+        /// document the earlier row would index is exactly the stale one, so it must neither
+        /// survive the delete nor be re-indexed by the `_bulk` that follows it.
+        #[test]
+        fn a_repeated_id_whose_deciding_row_is_rejected_is_evicted_and_not_indexed() {
+            let ids = [1, 2, 1];
+            let embeddings = [
+                Some(vec![1.0, 2.0]),
+                Some(vec![3.0, 4.0]),
+                Some(vec![0.0, 0.0]),
+            ];
+
+            assert_eq!(evicted(&ids, &embeddings), vec!["1".to_string()]);
+            assert_eq!(
+                indexed_ids(&ids, &embeddings),
+                vec!["2".to_string()],
+                "the delete runs first, so indexing the earlier row would restore the \
+                 document it just removed"
+            );
+        }
+
+        /// The other direction, unchanged: the deciding row is the indexable one, so the
+        /// `_bulk` re-establishes the document and a delete would only cost a request.
+        #[test]
+        fn a_repeated_id_indexed_after_being_rejected_is_not_evicted() {
+            let ids = [1, 2, 1];
+            let embeddings = [
+                Some(vec![0.0, 0.0]),
+                Some(vec![3.0, 4.0]),
+                Some(vec![5.0, 6.0]),
+            ];
+
+            assert!(evicted(&ids, &embeddings).is_empty());
+            assert_eq!(
+                indexed_ids(&ids, &embeddings),
+                vec!["2".to_string(), "1".to_string()],
             );
         }
 

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -295,13 +295,13 @@ fn build_documents(
     // already stored under a rejected `_id` holds a vector from an earlier value of the
     // row's text, which a search would go on returning — see
     // [`write_util::keys_to_evict`], which also decides a repeated `_id` by its last row.
-    let mut outcomes: Vec<(String, write_util::RowOutcome)> = Vec::with_capacity(record.num_rows());
+    let mut outcomes: Vec<(&str, write_util::RowOutcome)> = Vec::with_capacity(record.num_rows());
 
     for row in 0..record.num_rows() {
         let Some(embedding) = embedding_vectors[row].as_ref() else {
             missing_embedding_skips += 1;
             if let Some(id) = primary_keys[row].as_ref() {
-                outcomes.push((id.clone(), write_util::RowOutcome::Rejected));
+                outcomes.push((id.as_str(), write_util::RowOutcome::Rejected));
             }
             continue;
         };
@@ -334,7 +334,7 @@ fn build_documents(
                 zero_or_nan_samples.push(row);
             }
             if let Some(id) = primary_keys[row].as_ref() {
-                outcomes.push((id.clone(), write_util::RowOutcome::Rejected));
+                outcomes.push((id.as_str(), write_util::RowOutcome::Rejected));
             }
             continue;
         }
@@ -345,7 +345,7 @@ fn build_documents(
                 non_finite_samples.push(row);
             }
             if let Some(id) = primary_keys[row].as_ref() {
-                outcomes.push((id.clone(), write_util::RowOutcome::Rejected));
+                outcomes.push((id.as_str(), write_util::RowOutcome::Rejected));
             }
             continue;
         }
@@ -379,7 +379,7 @@ fn build_documents(
         doc.insert(index.vector_field.clone(), vec_json);
 
         if let Some(id) = primary_keys[row].as_ref() {
-            outcomes.push((id.clone(), write_util::RowOutcome::Indexed));
+            outcomes.push((id.as_str(), write_util::RowOutcome::Indexed));
         }
         docs.push((primary_keys[row].clone(), Value::Object(doc)));
     }
@@ -405,7 +405,7 @@ fn build_documents(
         );
     }
 
-    let evicted = write_util::keys_to_evict(outcomes.iter().map(|(id, o)| (id.as_str(), *o)));
+    let evicted = write_util::keys_to_evict(outcomes);
 
     // A document whose `_id` is evicted must not be indexed by this same request: the
     // delete runs first, so leaving it in `docs` would restore under that `_id` a row a

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -1162,8 +1162,8 @@ mod tests {
             );
         }
 
-        /// The other direction, unchanged: the deciding row is the indexable one, so the
-        /// `_bulk` re-establishes the document and a delete would only cost a request.
+        /// The other direction: the deciding row is the indexable one, so the `_bulk`
+        /// re-establishes the document and a delete would only cost a request.
         #[test]
         fn a_repeated_id_indexed_after_being_rejected_is_not_evicted() {
             let ids = [1, 2, 1];

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -24,7 +24,7 @@ limitations under the License.
 //! contents as `LogicalPlan`s. Nearest-neighbor search is brute-force exact
 //! k-NN over the SIMD distance kernels in `runtime-datafusion-udfs`.
 
-use std::{any::Any, sync::Arc};
+use std::{any::Any, collections::HashSet, sync::Arc};
 
 use arrow::array::{ArrayRef, BooleanArray, RecordBatch};
 use arrow::compute::filter;
@@ -201,42 +201,56 @@ impl MemoryVectorIndex {
         primary_keys: &[Option<String>],
         embedding_vectors: &[Option<Vec<f32>>],
     ) -> Result<(RecordBatch, Vec<String>, Vec<String>), Error> {
-        let mut keys = Vec::with_capacity(primary_keys.len());
-        let mut rejected = Vec::new();
-        let mask: BooleanArray = primary_keys
-            .iter()
-            .zip(embedding_vectors.iter())
-            .map(|(key, vector)| {
-                let keep = match (key, vector) {
-                    (Some(key), Some(vector)) => {
-                        // All-zero / all-NaN vectors have no defined direction and
-                        // would corrupt similarity scores — skip them.
-                        let valid = !vector.iter().all(|&v| v == 0.0 || v.is_nan());
-                        if valid {
-                            keys.push(key.clone());
-                        } else {
-                            rejected.push(key.clone());
-                            tracing::warn!(
-                                "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes or contains only invalid values. Any vector already stored for this record is removed, so it is not returned at its previous value"
-                            );
-                        }
-                        valid
-                    }
-                    (None, _) => {
-                        // No key to address an earlier entry with, so there is
-                        // nothing this write can evict.
+        // Per row: the key this row would be stored under and what the write did with it,
+        // or `None` for a row no write can address. In batch order, because the eviction
+        // decision is which row *decides* a repeated key.
+        let mut rows: Vec<Option<(&str, write_util::RowOutcome)>> =
+            Vec::with_capacity(primary_keys.len());
+        for (key, vector) in primary_keys.iter().zip(embedding_vectors.iter()) {
+            rows.push(match (key, vector) {
+                (Some(key), Some(vector)) => {
+                    // All-zero / all-NaN vectors have no defined direction and
+                    // would corrupt similarity scores — skip them.
+                    if vector.iter().all(|&v| v == 0.0 || v.is_nan()) {
                         tracing::warn!(
-                            "Skipping a record for memory vector index '{INDEX_NAME}': the primary key is NULL"
+                            "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes or contains only invalid values. Any vector already stored for this record is removed, so it is not returned at its previous value"
                         );
-                        false
+                        Some((key.as_str(), write_util::RowOutcome::Rejected))
+                    } else {
+                        Some((key.as_str(), write_util::RowOutcome::Indexed))
                     }
-                    // NULL/empty search text — nothing to index, and an entry
-                    // stored under this key from an earlier text must go with it.
-                    (Some(key), None) => {
-                        rejected.push(key.clone());
-                        false
-                    }
-                };
+                }
+                (None, _) => {
+                    // No key to address an earlier entry with, so there is
+                    // nothing this write can evict.
+                    tracing::warn!(
+                        "Skipping a record for memory vector index '{INDEX_NAME}': the primary key is NULL"
+                    );
+                    None
+                }
+                // NULL/empty search text — nothing to index, and an entry
+                // stored under this key from an earlier text must go with it.
+                (Some(key), None) => Some((key.as_str(), write_util::RowOutcome::Rejected)),
+            });
+        }
+
+        let evicted = write_util::keys_to_evict(rows.iter().flatten().copied());
+        let evicted_keys: HashSet<&str> = evicted.iter().map(String::as_str).collect();
+
+        // An indexable row is still dropped when a later row of the same batch decided its
+        // key against it: `upsert` deletes `evicted` and then stores this batch, so keeping
+        // the row here would write the stale entry straight back over its own eviction.
+        let mut keys = Vec::with_capacity(rows.len());
+        let mask: BooleanArray = rows
+            .iter()
+            .map(|row| {
+                let keep = matches!(
+                    row,
+                    Some((key, write_util::RowOutcome::Indexed)) if !evicted_keys.contains(key)
+                );
+                if keep && let Some((key, _)) = row {
+                    keys.push((*key).to_string());
+                }
                 Some(keep)
             })
             .collect();
@@ -263,7 +277,6 @@ impl MemoryVectorIndex {
                 index: INDEX_NAME.to_string(),
             },
         )?;
-        let evicted = write_util::keys_to_evict(rejected, keys.iter().map(String::as_str));
         Ok((batch, keys, evicted))
     }
 }
@@ -906,5 +919,112 @@ mod tests {
             .expect("the write window closes");
 
         assert_eq!(indexed_ids(&index), vec![1, 3]);
+    }
+
+    /// Regression test for #13848. One batch carries id=1 twice: an indexable row first,
+    /// then the row that *decides* the key, whose text the write rejects. The table
+    /// resolves a repeated key last-write-wins, so id=1's standing value is the rejected
+    /// one — and before this fix the earlier row's vector stayed searchable under it, so a
+    /// search answered from text the same batch had already replaced.
+    #[tokio::test]
+    async fn a_repeated_key_whose_deciding_row_is_rejected_keeps_nothing_indexed() {
+        let index = memory_index();
+        write_batch(
+            &index,
+            batch_with_contents(
+                &[1, 2, 1],
+                &[Some("first"), Some("other"), Some(REJECTED_TEXT)],
+            ),
+        )
+        .await;
+
+        assert_eq!(
+            indexed_ids(&index),
+            vec![2],
+            "id=1's deciding row was rejected, so no vector for it may remain searchable"
+        );
+        assert_eq!(
+            stored_vector(&index, 1),
+            None,
+            "the vector of the text the same batch replaced is exactly what must not survive"
+        );
+    }
+
+    /// The other direction, which this fix must leave alone: the key is rejected first and
+    /// stored after, so the row that decides it is the one the write indexes.
+    #[tokio::test]
+    async fn a_repeated_key_stored_after_being_rejected_stays_indexed() {
+        let index = memory_index();
+        write_batch(
+            &index,
+            batch_with_contents(
+                &[1, 2, 1],
+                &[Some(REJECTED_TEXT), Some("other"), Some("last")],
+            ),
+        )
+        .await;
+
+        assert_eq!(indexed_ids(&index), vec![1, 2]);
+        assert_eq!(
+            stored_vector(&index, 1),
+            Some(byte_vector("last")),
+            "the deciding row is indexable, so the key keeps the vector that row produced"
+        );
+    }
+
+    /// A key whose deciding row is rejected must not take an unrelated key's entry with it,
+    /// including one written by an earlier batch.
+    #[tokio::test]
+    async fn evicting_a_superseded_key_leaves_its_neighbours_indexed() {
+        let index = memory_index();
+        write_batch(&index, batch(&[1, 2, 3])).await;
+
+        write_batch(
+            &index,
+            batch_with_contents(&[2, 2], &[Some("rewritten"), Some(REJECTED_TEXT)]),
+        )
+        .await;
+
+        assert_eq!(indexed_ids(&index), vec![1, 3]);
+    }
+
+    /// The vector the store currently holds for `id`, if any.
+    fn stored_vector(index: &MemoryVectorIndex, id: i64) -> Option<Vec<f32>> {
+        use arrow::array::{Array, FixedSizeListArray, Float32Array};
+        let store = index.store.read();
+        for b in store.batches() {
+            let (id_idx, _) = b
+                .schema()
+                .column_with_name("id")
+                .expect("the stored schema carries the primary key");
+            let (vec_idx, _) = b
+                .schema()
+                .column_with_name("content_embedding")
+                .expect("the stored schema carries the embedding column");
+            let ids = b
+                .column(id_idx)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("id is Int64");
+            let vectors = b
+                .column(vec_idx)
+                .as_any()
+                .downcast_ref::<FixedSizeListArray>()
+                .expect("the embedding column is a FixedSizeList");
+            for row in 0..b.num_rows() {
+                if ids.value(row) == id && !vectors.is_null(row) {
+                    let values = vectors.value(row);
+                    return Some(
+                        values
+                            .as_any()
+                            .downcast_ref::<Float32Array>()
+                            .expect("embeddings are Float32")
+                            .values()
+                            .to_vec(),
+                    );
+                }
+            }
+        }
+        None
     }
 }

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -244,14 +244,14 @@ impl MemoryVectorIndex {
         let mask: BooleanArray = rows
             .iter()
             .map(|row| {
-                let keep = matches!(
-                    row,
-                    Some((key, write_util::RowOutcome::Indexed)) if !evicted_keys.contains(key)
-                );
-                if keep && let Some((key, _)) = row {
-                    keys.push((*key).to_string());
+                let Some((key, write_util::RowOutcome::Indexed)) = row else {
+                    return Some(false);
+                };
+                if evicted_keys.contains(key) {
+                    return Some(false);
                 }
-                Some(keep)
+                keys.push((*key).to_string());
+                Some(true)
             })
             .collect();
 

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -924,8 +924,8 @@ mod tests {
     /// Regression test for #13848. One batch carries id=1 twice: an indexable row first,
     /// then the row that *decides* the key, whose text the write rejects. The table
     /// resolves a repeated key last-write-wins, so id=1's standing value is the rejected
-    /// one — and before this fix the earlier row's vector stayed searchable under it, so a
-    /// search answered from text the same batch had already replaced.
+    /// one; leaving the earlier row's vector searchable under that key would answer a
+    /// search from text the same batch had already replaced.
     #[tokio::test]
     async fn a_repeated_key_whose_deciding_row_is_rejected_keeps_nothing_indexed() {
         let index = memory_index();
@@ -950,8 +950,8 @@ mod tests {
         );
     }
 
-    /// The other direction, which this fix must leave alone: the key is rejected first and
-    /// stored after, so the row that decides it is the one the write indexes.
+    /// The other direction: the key is rejected first and stored after, so the row that
+    /// decides it is the one the write indexes and the key stays in the index.
     #[tokio::test]
     async fn a_repeated_key_stored_after_being_rejected_stays_indexed() {
         let index = memory_index();

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use arrow::array::RecordBatch;
 use arrow::compute::concat_batches;
@@ -289,9 +292,9 @@ pub fn extract_and_format_metadata(
     Ok(metadata)
 }
 
-/// Filter out invalid embedding vectors where all values are either zero or NaN.
+/// Filter out the rows this batch will not store a vector for.
 ///
-/// This filters vectors that consist entirely of invalid values (zeros and/or NaNs).
+/// A vector is dropped when it consists entirely of invalid values (zeros and/or NaNs).
 /// A vector with any valid non-zero, non-NaN value is kept.
 /// For example:
 /// - `[0.0, 0.0]` -> filtered (all zeros)
@@ -304,6 +307,14 @@ pub fn extract_and_format_metadata(
 /// delete, per [`write_util::keys_to_evict`]. It covers the rows filtered here and the
 /// rows carrying no embedding at all — `write_data` drops a `None` embedding, which
 /// leaves an earlier vector in place just as a filtered row does.
+///
+/// A row whose key is evicted is dropped from the write as well, even when its own vector
+/// is fine: the delete runs before the put, so storing it would restore under that key a
+/// row a later row of the same batch replaced with one this write cannot embed.
+///
+/// The decision is per call, so a key repeated across two calls — `write` splits a batch
+/// larger than `batch_write_rows` into chunks processed independently — is decided within
+/// each chunk rather than across them.
 #[expect(clippy::type_complexity)]
 fn filter_zero_vectors(
     mut embeddings: Vec<Option<Vec<f32>>>,
@@ -316,23 +327,52 @@ fn filter_zero_vectors(
     HashMap<String, Vec<Option<Value>>>,
     Vec<String>,
 ) {
-    let mut rejected: Vec<String> = Vec::new();
-    // Filter in reverse order to avoid index shifting when removing elements
-    for i in (0..embeddings.len()).rev() {
-        if let Some(embedding) = &embeddings[i]
+    // What this write would do with each row that names a key, in row order — which is
+    // what decides a key the batch carries more than once.
+    let mut outcomes: Vec<(&str, write_util::RowOutcome)> = Vec::with_capacity(embeddings.len());
+    for (embedding, key) in embeddings.iter().zip(primary_keys.iter()) {
+        let outcome = match embedding {
             // Single pass: check if all values are zero or NaN (both are invalid embeddings)
-            && embedding.iter().all(|&x| x == 0.0 || x.is_nan())
-        {
-            let key = primary_keys.get(i).and_then(Option::as_ref);
-            let key_str = key.map_or("unknown", String::as_str);
-            tracing::warn!(
-                "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values. Any vector already stored for this record is removed, so it is not returned at its previous value"
-            );
-            // A NULL key addresses no stored vector, so there is nothing to remove.
-            if let Some(key) = key {
-                rejected.push(key.clone());
+            Some(embedding) if embedding.iter().all(|&x| x == 0.0 || x.is_nan()) => {
+                let key_str = key.as_deref().unwrap_or("unknown");
+                tracing::warn!(
+                    "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values. Any vector already stored for this record is removed, so it is not returned at its previous value"
+                );
+                write_util::RowOutcome::Rejected
             }
+            Some(_) => write_util::RowOutcome::Indexed,
+            // `write_data` skips a row whose embedding is `None` (a NULL or empty search
+            // text), so those keys keep whatever vector an earlier text stored.
+            None => write_util::RowOutcome::Rejected,
+        };
+        // A NULL key addresses no stored vector, so there is nothing to remove.
+        if let Some(key) = key {
+            outcomes.push((key.as_str(), outcome));
+        }
+    }
 
+    let evicted = write_util::keys_to_evict(outcomes.iter().copied());
+    let evicted_keys: HashSet<&str> = evicted.iter().map(String::as_str).collect();
+
+    let drop_row: Vec<bool> = embeddings
+        .iter()
+        .zip(primary_keys.iter())
+        .map(|(embedding, key)| {
+            let invalid_vector = embedding
+                .as_ref()
+                .is_some_and(|e| e.iter().all(|&x| x == 0.0 || x.is_nan()));
+            // Only a row this write would otherwise store needs dropping. A row with no
+            // embedding is skipped by `write_data` either way, so leaving it in place keeps
+            // the arrays exactly as they were before eviction was considered.
+            let superseded =
+                embedding.is_some() && key.as_deref().is_some_and(|key| evicted_keys.contains(key));
+            invalid_vector || superseded
+        })
+        .collect();
+
+    // In reverse order to avoid index shifting when removing elements.
+    for i in (0..drop_row.len()).rev() {
+        if drop_row[i] {
             embeddings.remove(i);
             primary_keys.remove(i);
             for values in metadata.values_mut() {
@@ -341,19 +381,6 @@ fn filter_zero_vectors(
         }
     }
 
-    // `write_data` skips a row whose embedding is `None` (a NULL or empty search
-    // text), so those keys keep whatever vector an earlier text stored.
-    let mut indexed: Vec<&str> = Vec::with_capacity(embeddings.len());
-    for (embedding, key) in embeddings.iter().zip(primary_keys.iter()) {
-        match (embedding, key) {
-            (Some(_), Some(key)) => indexed.push(key.as_str()),
-            // A NULL key addresses no stored vector, so `None` here evicts nothing.
-            (None, Some(key)) => rejected.push(key.clone()),
-            _ => {}
-        }
-    }
-
-    let evicted = write_util::keys_to_evict(rejected, indexed);
     (embeddings, primary_keys, metadata, evicted)
 }
 
@@ -505,17 +532,43 @@ mod tests {
         assert!(evicted.is_empty(), "a NULL key names no stored vector");
     }
 
-    /// The same key indexed and rejected within one batch: the put re-establishes it, so a
-    /// delete would only cost a round trip.
+    /// The same key rejected and then stored within one batch: the row that decides the key
+    /// is the one the put re-establishes, so a delete would only cost a round trip.
     #[test]
-    fn a_key_this_batch_also_stores_is_not_named_for_deletion() {
-        let embeddings = vec![Some(vec![1.0, 2.0]), Some(vec![0.0, 0.0])];
+    fn a_key_this_batch_stores_after_rejecting_is_not_named_for_deletion() {
+        let embeddings = vec![Some(vec![0.0, 0.0]), Some(vec![1.0, 2.0])];
         let keys = keys_of(&[Some("same"), Some("same")]);
 
-        let (_, _, _, evicted) =
+        let (filtered_embeddings, filtered_keys, _, evicted) =
             filter_zero_vectors(embeddings, keys, HashMap::new(), "test_index");
 
         assert!(evicted.is_empty());
+        assert_eq!(
+            filtered_embeddings,
+            vec![Some(vec![1.0, 2.0])],
+            "the deciding row is still stored"
+        );
+        assert_eq!(filtered_keys, keys_of(&[Some("same")]));
+    }
+
+    /// Regression test for #13848. The same pair the other way round: the row that decides
+    /// the key cannot be embedded, so the vector the earlier row would have stored is
+    /// exactly what a search must stop returning — the key is deleted, and the earlier row
+    /// is dropped from the put that would otherwise restore it.
+    #[test]
+    fn a_key_whose_deciding_row_is_rejected_is_deleted_and_not_stored() {
+        let embeddings = vec![Some(vec![1.0, 2.0]), Some(vec![0.0, 0.0])];
+        let keys = keys_of(&[Some("same"), Some("same")]);
+
+        let (filtered_embeddings, filtered_keys, _, evicted) =
+            filter_zero_vectors(embeddings, keys, HashMap::new(), "test_index");
+
+        assert_eq!(evicted, vec!["same".to_string()]);
+        assert!(
+            filtered_embeddings.is_empty(),
+            "storing the earlier row would write the stale vector back over its own delete"
+        );
+        assert!(filtered_keys.is_empty());
     }
 
     #[test]

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -311,10 +311,6 @@ pub fn extract_and_format_metadata(
 /// A row whose key is evicted is dropped from the write as well, even when its own vector
 /// is fine: the delete runs before the put, so storing it would restore under that key a
 /// row a later row of the same batch replaced with one this write cannot embed.
-///
-/// The decision is per call, so a key repeated across two calls — `write` splits a batch
-/// larger than `batch_write_rows` into chunks processed independently — is decided within
-/// each chunk rather than across them.
 #[expect(clippy::type_complexity)]
 fn filter_zero_vectors(
     mut embeddings: Vec<Option<Vec<f32>>>,
@@ -327,46 +323,53 @@ fn filter_zero_vectors(
     HashMap<String, Vec<Option<Value>>>,
     Vec<String>,
 ) {
-    // What this write would do with each row that names a key, in row order — which is
+    // Per row: the key this row would be stored under, or `None` for a row that addresses
+    // no stored vector, and what this write would do with it. In row order, because that is
     // what decides a key the batch carries more than once.
-    let mut outcomes: Vec<(&str, write_util::RowOutcome)> = Vec::with_capacity(embeddings.len());
-    for (embedding, key) in embeddings.iter().zip(primary_keys.iter()) {
-        let outcome = match embedding {
-            // Single pass: check if all values are zero or NaN (both are invalid embeddings)
-            Some(embedding) if embedding.iter().all(|&x| x == 0.0 || x.is_nan()) => {
-                let key_str = key.as_deref().unwrap_or("unknown");
-                tracing::warn!(
-                    "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values. Any vector already stored for this record is removed, so it is not returned at its previous value"
-                );
-                write_util::RowOutcome::Rejected
-            }
-            Some(_) => write_util::RowOutcome::Indexed,
-            // `write_data` skips a row whose embedding is `None` (a NULL or empty search
-            // text), so those keys keep whatever vector an earlier text stored.
-            None => write_util::RowOutcome::Rejected,
-        };
-        // A NULL key addresses no stored vector, so there is nothing to remove.
-        if let Some(key) = key {
-            outcomes.push((key.as_str(), outcome));
-        }
-    }
-
-    let evicted = write_util::keys_to_evict(outcomes.iter().copied());
-    let evicted_keys: HashSet<&str> = evicted.iter().map(String::as_str).collect();
-
-    let drop_row: Vec<bool> = embeddings
+    let rows: Vec<(Option<&str>, write_util::RowOutcome)> = embeddings
         .iter()
         .zip(primary_keys.iter())
         .map(|(embedding, key)| {
-            let invalid_vector = embedding
-                .as_ref()
-                .is_some_and(|e| e.iter().all(|&x| x == 0.0 || x.is_nan()));
-            // Only a row this write would otherwise store needs dropping. A row with no
-            // embedding is skipped by `write_data` either way, so leaving it in place keeps
-            // the arrays exactly as they were before eviction was considered.
-            let superseded =
-                embedding.is_some() && key.as_deref().is_some_and(|key| evicted_keys.contains(key));
-            invalid_vector || superseded
+            let outcome = match embedding {
+                // Single pass: check if all values are zero or NaN (both are invalid embeddings)
+                Some(embedding) if embedding.iter().all(|&x| x == 0.0 || x.is_nan()) => {
+                    let key_str = key.as_deref().unwrap_or("unknown");
+                    tracing::warn!(
+                        "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values. Any vector already stored for this record is removed, so it is not returned at its previous value"
+                    );
+                    write_util::RowOutcome::Rejected
+                }
+                Some(_) => write_util::RowOutcome::Indexed,
+                // `write_data` skips a row whose embedding is `None` (a NULL or empty search
+                // text), so those keys keep whatever vector an earlier text stored.
+                None => write_util::RowOutcome::Rejected,
+            };
+            // A NULL key addresses no stored vector, so there is nothing to remove.
+            (key.as_deref(), outcome)
+        })
+        .collect();
+
+    let evicted = write_util::keys_to_evict(
+        rows.iter()
+            .filter_map(|(key, outcome)| key.map(|key| (key, *outcome))),
+    );
+    let evicted_keys: HashSet<&str> = evicted.iter().map(String::as_str).collect();
+
+    // A row this write will not store: its own vector is invalid, or a later row of the
+    // batch decided its key against it and the delete below would otherwise be undone by
+    // the put. A row with no embedding at all is left in place either way — `write_data`
+    // skips it, so removing it would only change the arrays for no effect.
+    let drop_row: Vec<bool> = rows
+        .iter()
+        .zip(embeddings.iter())
+        .map(|((key, outcome), embedding)| {
+            embedding.is_some()
+                && match outcome {
+                    write_util::RowOutcome::Rejected => true,
+                    write_util::RowOutcome::Indexed => {
+                        key.is_some_and(|key| evicted_keys.contains(key))
+                    }
+                }
         })
         .collect();
 

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -344,6 +344,17 @@ pub fn create_embedding_array(
     Ok(Arc::new(builder.finish()))
 }
 
+/// What a write did with one row, for the row's primary key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RowOutcome {
+    /// The write is about to store this row under its key.
+    Indexed,
+    /// The write could not index this row — no embedding at all (a NULL or empty search
+    /// value), or one with no defined direction under any metric the index offers
+    /// (all-zero, all-NaN, non-finite).
+    Rejected,
+}
+
 /// The primary keys a write must remove from its index because it could not index
 /// the rows they name.
 ///
@@ -362,19 +373,35 @@ pub fn create_embedding_array(
 /// behaviour every backend can implement with the delete primitive it already has,
 /// and it is what these paths do.
 ///
-/// `indexed` is what this same write is about to store. A key in both — the batch
-/// carries the key twice, once indexable and once not — is not evicted: the write
-/// that follows re-establishes it, so issuing a delete for it would only cost a round
-/// trip. Callers must still delete before they write, so the two orders agree.
-pub fn keys_to_evict<'a>(
-    rejected: impl IntoIterator<Item = String>,
-    indexed: impl IntoIterator<Item = &'a str>,
-) -> Vec<String> {
-    let indexed: std::collections::HashSet<&str> = indexed.into_iter().collect();
-    rejected
+/// `rows` is every row of the batch that names a key, **in batch order**, tagged with
+/// what the write did with it. A key the batch carries more than once is decided by its
+/// **last** row, because that is the row the table itself resolves the key to under
+/// last-write-wins — so a key whose deciding row is [`RowOutcome::Rejected`] is evicted
+/// even when an earlier row of the same batch was indexable, and a key rejected earlier
+/// and indexed later is not evicted at all. Order is what carries that distinction, which
+/// is why this takes a sequence rather than two sets.
+///
+/// Callers must do two things with the result, and neither alone is enough:
+///
+/// - **Delete these keys before writing**, so the two orders agree.
+/// - **Drop from the write every row whose key this returns.** An earlier indexable row
+///   for an evicted key would otherwise be stored straight back over the delete, which
+///   re-establishes exactly the stale entry the eviction exists to remove.
+pub fn keys_to_evict<'a>(rows: impl IntoIterator<Item = (&'a str, RowOutcome)>) -> Vec<String> {
+    let mut deciding: std::collections::HashMap<&str, RowOutcome> =
+        std::collections::HashMap::new();
+    // Eviction order follows first appearance, so a batch always produces the same delete
+    // request for the same rows.
+    let mut first_seen: Vec<&str> = Vec::new();
+    for (key, outcome) in rows {
+        if deciding.insert(key, outcome).is_none() {
+            first_seen.push(key);
+        }
+    }
+    first_seen
         .into_iter()
-        .filter(|key| !indexed.contains(key.as_str()))
-        .unique()
+        .filter(|key| deciding.get(key) == Some(&RowOutcome::Rejected))
+        .map(ToString::to_string)
         .collect()
 }
 
@@ -675,9 +702,11 @@ mod tests {
         keys.iter().map(|k| (*k).to_string()).collect()
     }
 
+    use RowOutcome::{Indexed, Rejected};
+
     #[test]
     fn keys_to_evict_names_every_rejected_key_the_write_does_not_also_store() {
-        let evicted = keys_to_evict(owned(&["a", "b"]), ["c"]);
+        let evicted = keys_to_evict([("a", Rejected), ("b", Rejected), ("c", Indexed)]);
         assert_eq!(
             evicted,
             owned(&["a", "b"]),
@@ -685,17 +714,37 @@ mod tests {
         );
     }
 
-    /// The batch carries one key twice — once indexable, once not. The write that follows
-    /// re-establishes it, so a delete for it would be undone by this same write.
+    /// The batch carries one key twice, rejected first and indexed after. The row that
+    /// decides the key is the one this write stores, so the entry it is about to write is
+    /// the current one and a delete for it would only cost a round trip.
     #[test]
-    fn keys_to_evict_skips_a_key_the_same_write_also_indexes() {
-        let evicted = keys_to_evict(owned(&["a", "b"]), ["b"]);
+    fn keys_to_evict_skips_a_key_the_same_write_stores_after_rejecting_it() {
+        let evicted = keys_to_evict([("a", Rejected), ("b", Rejected), ("b", Indexed)]);
         assert_eq!(evicted, owned(&["a"]));
+    }
+
+    /// Regression test for #13848. The same pair the other way round: the row that decides
+    /// the key is the rejected one, so the entry the earlier row would leave behind is
+    /// exactly what has to go.
+    #[test]
+    fn keys_to_evict_names_a_key_whose_deciding_row_is_rejected() {
+        let evicted = keys_to_evict([("a", Indexed), ("b", Indexed), ("a", Rejected)]);
+        assert_eq!(
+            evicted,
+            owned(&["a"]),
+            "the table resolves a repeated key to its last row, so an earlier indexable row \
+             does not keep the key indexed"
+        );
     }
 
     #[test]
     fn keys_to_evict_deduplicates_a_key_rejected_more_than_once() {
-        let evicted = keys_to_evict(owned(&["a", "a", "b", "a"]), std::iter::empty());
+        let evicted = keys_to_evict([
+            ("a", Rejected),
+            ("a", Rejected),
+            ("b", Rejected),
+            ("a", Rejected),
+        ]);
         assert_eq!(
             evicted,
             owned(&["a", "b"]),
@@ -705,7 +754,12 @@ mod tests {
 
     #[test]
     fn keys_to_evict_is_empty_when_the_write_rejected_nothing() {
-        assert!(keys_to_evict(Vec::new(), ["a", "b"]).is_empty());
+        assert!(keys_to_evict([("a", Indexed), ("b", Indexed)]).is_empty());
+    }
+
+    #[test]
+    fn keys_to_evict_is_empty_for_a_batch_that_names_no_key() {
+        assert!(keys_to_evict(std::iter::empty()).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`write_util::keys_to_evict` decided which primary keys a search-index write must delete by
**set membership**: a key the batch carried both as an indexable row and as one the backend
could not embed was never evicted, on the reasoning that the write about to follow
re-establishes it.

That reasoning holds only when the *indexable* occurrence is the one that stands. It is not.
The table resolves a repeated primary key **last-write-wins**, so when the last occurrence is
the rejected one — a NULL/empty search value, or an embedding the backend refuses — the earlier
occurrence's entry is exactly what has to go. It survived,
and the index went on answering from a value the same batch had already replaced.

Measured on `trunk` (`53f3c90fbd`) against the real `MemoryVectorIndex` write path, one batch
carrying `(id=1, "first")`, `(id=2, "other")`, `(id=1, NULL)` — the table resolves `id=1` to
NULL:

```
PROBE indexed_ids = [1, 2]
PROBE stored vector for id=1 = Some([0.8509804, 0.8666667, 0.44705883])
PROBE embedding of "first"   =      [0.8509804, 0.8666667, 0.44705883]
```

The vector left under `id=1` is byte-identical to the embedding of the text the same batch
replaced. In user terms: vector search returns the row at text it does not contain, while the
write's own log line says the row was not indexed.

## Changes

`keys_to_evict` now decides by **which occurrence stands** instead of by set membership. It
takes the batch's per-row outcomes in row order (`RowOutcome::Indexed` / `Rejected`) and evicts
a key whose **last** row was rejected. The preserved direction is unchanged: a key rejected
earlier and stored later is still not evicted.

Eviction alone is not enough, and this is the part that is easy to miss. Every backend deletes
before it writes, so an earlier indexable row for an evicted key would be stored straight back
over its own delete. Each caller therefore drops those rows from the write as well:

- `crates/search/src/index/memory/mod.rs` — `batch_for_store` masks them out of the stored batch.
- `crates/search/src/index/elasticsearch/write.rs` — `build_documents` drops them from the `_bulk` body.
- `crates/search/src/index/s3_vectors/write.rs` — `filter_zero_vectors` drops them from the put.

All three backends that share the helper are fixed together rather than one at a time.

## Test plan

**The failure, on `trunk` (`53f3c90fbd`), before the fix** — the probe above, run through the
real `MemoryVectorIndex::write` path:

```
$ cargo test -p search --lib index::memory -- --nocapture
PROBE indexed_ids = [1, 2]
PROBE stored vector for id=1 = Some([0.8509804, 0.8666667, 0.44705883])
assertion `left == right` failed: id=1's deciding row was rejected, so no vector for it may remain searchable
  left: [1, 2]
 right: [2]
```

**The same probe on this branch:**

```
PROBE indexed_ids = [2]
PROBE stored vector for id=1 = None
test index::memory::tests::a_repeated_key_whose_deciding_row_is_rejected_keeps_nothing_indexed ... ok
```

**Neuter-verified** — with `keys_to_evict` reverted to the set-membership rule and nothing else
changed, exactly the five new guards fail, across all three backends, and the
preserved-direction guards stay green:

```
test index::memory::tests::a_repeated_key_whose_deciding_row_is_rejected_keeps_nothing_indexed ... FAILED
test index::memory::tests::evicting_a_superseded_key_leaves_its_neighbours_indexed ... FAILED
test index::elasticsearch::write::tests::eviction::a_repeated_id_whose_deciding_row_is_rejected_is_evicted_and_not_indexed ... FAILED
test index::s3_vectors::write::tests::a_key_whose_deciding_row_is_rejected_is_deleted_and_not_stored ... FAILED
test index::write_util::tests::keys_to_evict_names_a_key_whose_deciding_row_is_rejected ... FAILED
test index::memory::tests::a_repeated_key_stored_after_being_rejected_stays_indexed ... ok
test index::elasticsearch::write::tests::eviction::a_repeated_id_indexed_after_being_rejected_is_not_evicted ... ok
test result: FAILED. 258 passed; 5 failed
```

With the fix restored: `test result: ok. 263 passed; 0 failed`.

**Gates:**

- `make lint` — clean.
- `make test` (`make nextest`) — clean.
- `make signoff` — run after the push; `Attestation` re-run to green.

## Known limitations

- The Elasticsearch and S3 Vectors arms are **unverified, code inspection only** as end-to-end
  runs: no Elasticsearch or S3 Vectors instance was available to this run. Both are covered by
  unit tests that drive their real document/vector builders (`build_documents`,
  `filter_zero_vectors`) and are neuter-verified above, and both build `rejected`/`indexed`
  through the same helper as the in-memory index — but the wrong-result artifact was captured
  on the in-memory backend only.
- A key carried twice where **both** occurrences are indexable is a different defect (#13713)
  and is deliberately untouched here: the deciding row is stored, but so is the earlier one.
- **Which vectors count as rejected at all is unchanged, and two backends implement a narrower
  rule than the one this helper states** — #13872, raised by the Copilot review here and
  verified rather than taken on trust. Elasticsearch rejects any non-finite component; the
  in-memory index and S3 Vectors reject only `all(x == 0.0 || x.is_nan())`, so `[1.0, NaN]`,
  `[1.0, Inf]`, `[0.0, Inf]` and `[Inf, Inf]` are classified indexable there and a deciding row
  carrying one evicts nothing. Measured on all three backends' real builders; the full table and
  the three predicates are in #13872. Not fixed here because it changes which rows are deleted
  from live indexes for every user whose embedder can emit a non-finite component — a different
  blast radius from this PR's ordering question.

Fixes #13848

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits."; `grok` not installed. In its place the diff was re-read against each of its three call sites, which found two things, both fixed here: the S3 Vectors drop predicate duplicated the invalid-vector test instead of deriving it from the per-row outcome, and a doc comment claimed a cross-chunk limitation that does not exist (chunks are applied in row order, each deleting before it puts, so the last chunk to touch a key decides it).
- `/security-review`: no findings — the diff is in-memory decision logic over Arrow arrays and primary-key strings, adds no SQL, filesystem, network, or deserialization surface, and logs no value trunk did not already log.
- Copilot review: 1 finding, verified first-hand and deferred with its mechanism corrected —
  the S3 Vectors and in-memory classifiers reject a narrower set of vectors than `keys_to_evict`'s
  stated criterion, filed as #13872. The sink Copilot cited (`put_vectors_sink.rs`) is on the
  DataFusion `INSERT INTO` path, not the search-index write, so the row is put rather than
  locally discarded; the divergence stands regardless. Thread replied and resolved.
- `/simplify`: applied — the Elasticsearch outcome list now borrows the `_id`s it records instead of cloning one `String` per row, and the in-memory mask derives `keys` from a single decision instead of a `matches!` plus a separate push. Light checks re-run green.

## Checklist

- [x] Reproduced the reported failure on `trunk` before writing the fix, with the artifact pasted above
- [x] Regression tests fail without the fix (neuter-verified) and pass with it
- [x] The whole bug class fixed together — all three backends sharing `keys_to_evict`
- [x] The preserved direction (rejected earlier, stored later) pinned by its own tests
- [ ] `make signoff` green and `Attestation` re-run