### PR TITLE
fix(federation): refuse a user function the deny-list snapshot was built before (fixes #13726)

### DIFF
--- a/crates/runtime-datafusion/src/function_support.rs
+++ b/crates/runtime-datafusion/src/function_support.rs
@@ -81,8 +81,8 @@ pub fn deny_spice_functions_for_bigquery_table_providers() -> FunctionSupport {
     FunctionSupportBuilder::new()
         .native(&crate::dialect::bigquery_native_function_names())
         .deny_also([crate::dialect::REGEXP_MATCH_NAME.to_string()])
+        .scalar_call(Arc::new(crate::dialect::bigquery_can_translate))
         .build()
-        .with_scalar_call_support(Arc::new(crate::dialect::bigquery_can_translate))
 }
 
 /// `DataFusion`'s nested array/list/map functions that `PostgreSQL` cannot

--- a/crates/runtime-udfs-api/src/lib.rs
+++ b/crates/runtime-udfs-api/src/lib.rs
@@ -39,8 +39,11 @@ limitations under the License.
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
+use datafusion::logical_expr::expr::ScalarFunction;
 use datafusion::prelude::SessionContext;
-use datafusion_table_providers::util::supported_functions::{FunctionRestriction, FunctionSupport};
+use datafusion_table_providers::util::supported_functions::{
+    FunctionRestriction, FunctionSupport, ScalarCallSupport,
+};
 use linkme::distributed_slice;
 
 /// Re-exported so a crate invoking [`register_spice_function!`] can bring
@@ -140,6 +143,17 @@ pub fn user_function_names() -> Vec<String> {
     USER_FUNCTION_NAMES.read().clone()
 }
 
+/// Whether `name` is a user-registered function **right now**.
+///
+/// Read at the moment a plan is checked rather than when a provider was built,
+/// which is what [`FunctionSupportBuilder::build`] needs: the name list it
+/// freezes into a [`FunctionRestriction::Deny`] is a snapshot, and a function
+/// registered after that provider exists is absent from it.
+#[must_use]
+pub fn is_user_function(name: &str) -> bool {
+    USER_FUNCTION_NAMES.read().iter().any(|n| n == name)
+}
+
 /// The link-time set of Spice function names, plus the JSON functions
 /// `datafusion-functions-json` contributes.
 #[must_use]
@@ -219,6 +233,7 @@ fn excluding_native(names: impl IntoIterator<Item = String>, native: &[&str]) ->
 pub struct FunctionSupportBuilder<'a> {
     native: &'a [&'a str],
     deny_also: Vec<String>,
+    scalar_call: Option<ScalarCallSupport>,
 }
 
 impl<'a> FunctionSupportBuilder<'a> {
@@ -247,6 +262,20 @@ impl<'a> FunctionSupportBuilder<'a> {
         self
     }
 
+    /// A per-call check refusing the *call shapes* this backend's dialect cannot
+    /// translate, for a function whose name it carved out with [`Self::native`].
+    ///
+    /// Supply it here rather than through
+    /// `FunctionSupport::with_scalar_call_support` after [`Self::build`]: that
+    /// setter *replaces* the per-call check, and [`Self::build`] installs one of
+    /// its own for the live user-function registry. Both are consulted, and a
+    /// call has to satisfy both to federate.
+    #[must_use]
+    pub fn scalar_call(mut self, scalar_call: ScalarCallSupport) -> Self {
+        self.scalar_call = Some(scalar_call);
+        self
+    }
+
     /// The denied scalar-function names, in the order the deny-list is built:
     /// Spice functions minus the native carve-out, then user functions, then
     /// any backend-specific additions.
@@ -263,13 +292,35 @@ impl<'a> FunctionSupportBuilder<'a> {
 
     /// The [`FunctionSupport`] to hand a federated provider or table-provider
     /// factory.
+    ///
+    /// The denied *names* are a snapshot, so they cannot answer for a user
+    /// function registered after this call — and providers are built once while
+    /// [`add_user_function`] runs for the life of the process. Every accelerator
+    /// engine is constructed in `RuntimeBuilder::build` before that same `build`
+    /// registers the spicepod's `functions:` entries, so a SQL accelerator's
+    /// snapshot names no user function at all; a tool-backed SQL UDF registers
+    /// while datasets and catalogs load; and a hot reload applies its function
+    /// diff after the components, without rebuilding a component that did not
+    /// itself change. A name absent from the snapshot federates, so the remote
+    /// is asked to evaluate a function it does not have — or, where it happens
+    /// to have one of that name, answers from a different function.
+    ///
+    /// So the per-call check reads the registry live. It only ever narrows what
+    /// the name list allows, which is why the snapshot is left as it is rather
+    /// than removed: it already denies everything registered before this call,
+    /// and this closes the rest.
     #[must_use]
-    pub fn build(self) -> FunctionSupport {
+    pub fn build(mut self) -> FunctionSupport {
+        let backend_call = self.scalar_call.take();
         FunctionSupport::new(
             Some(FunctionRestriction::Deny(self.denied_names())),
             None,
             None,
         )
+        .with_scalar_call_support(std::sync::Arc::new(move |call: &ScalarFunction| {
+            !is_user_function(call.func.name())
+                && backend_call.as_ref().is_none_or(|supports| supports(call))
+        }))
     }
 }
 
@@ -306,4 +357,135 @@ pub fn deny_spice_specific_functions_excluding(native: &[&str]) -> std::sync::Ar
 #[must_use]
 pub fn deny_spice_functions_for_table_providers() -> FunctionSupport {
     FunctionSupportBuilder::new().build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::DataType;
+    use datafusion::logical_expr::{
+        ColumnarValue, Expr, ScalarUDF, Volatility, create_udf, expr::ScalarFunction,
+    };
+    use datafusion::scalar::ScalarValue;
+    use std::sync::Arc;
+
+    /// `USER_FUNCTION_NAMES` is process-global, so every test here uses a name
+    /// of its own and drops it again; the assertions never depend on the
+    /// registry being empty.
+    struct Registered(&'static str);
+
+    impl Registered {
+        fn new(name: &'static str) -> Self {
+            add_user_function(name);
+            Self(name)
+        }
+    }
+
+    impl Drop for Registered {
+        fn drop(&mut self) {
+            remove_user_function(self.0);
+        }
+    }
+
+    fn udf(name: &str, arity: usize) -> Arc<ScalarUDF> {
+        Arc::new(create_udf(
+            name,
+            vec![DataType::Utf8; arity],
+            DataType::Utf8,
+            Volatility::Immutable,
+            Arc::new(|args: &[ColumnarValue]| Ok(args[0].clone())),
+        ))
+    }
+
+    fn call(name: &str, arity: usize) -> Expr {
+        Expr::ScalarFunction(ScalarFunction::new_udf(
+            udf(name, arity),
+            vec![Expr::Literal(ScalarValue::from("v"), None); arity],
+        ))
+    }
+
+    /// The name list is a snapshot, so this is the case it already covered.
+    #[test]
+    fn a_user_function_registered_before_the_support_was_built_is_refused() {
+        let _registered = Registered::new("early_user_fn_udfs_api");
+
+        let support = FunctionSupportBuilder::new().build();
+
+        assert!(
+            !support.supports(&call("early_user_fn_udfs_api", 1)),
+            "a user function in the deny-list snapshot must not federate"
+        );
+    }
+
+    /// The case the snapshot cannot answer: every provider is built once, and
+    /// registrations keep arriving for the life of the process (#13726).
+    #[test]
+    fn a_user_function_registered_after_the_support_was_built_is_refused() {
+        let support = FunctionSupportBuilder::new().build();
+        let _registered = Registered::new("late_user_fn_udfs_api");
+
+        assert!(
+            !support.supports(&call("late_user_fn_udfs_api", 1)),
+            "a user function registered after the support was built must not federate"
+        );
+    }
+
+    /// Dropping a registration must not leave the name refused for ever: the
+    /// live read is the point, in both directions.
+    #[test]
+    fn a_name_that_is_no_longer_a_user_function_federates_again() {
+        let support = FunctionSupportBuilder::new().build();
+        drop(Registered::new("transient_user_fn_udfs_api"));
+
+        assert!(
+            support.supports(&call("transient_user_fn_udfs_api", 1)),
+            "an unregistered name is not a user function and has nothing to refuse it"
+        );
+    }
+
+    #[test]
+    fn a_function_nobody_registered_still_federates() {
+        let support = FunctionSupportBuilder::new().build();
+
+        assert!(
+            support.supports(&call("some_remote_fn_udfs_api", 1)),
+            "the deny-list must not refuse a name it has no reason to"
+        );
+    }
+
+    /// A backend's own per-call check and the live user-function check are both
+    /// consulted, so neither can mask the other. `build` installs the second,
+    /// which is why the first has to be supplied through the builder rather
+    /// than by `with_scalar_call_support` afterwards.
+    #[test]
+    fn a_backend_per_call_check_composes_with_the_live_user_function_check() {
+        let one_argument_only: ScalarCallSupport =
+            Arc::new(|call: &ScalarFunction| call.args.len() == 1);
+        let support = FunctionSupportBuilder::new()
+            .scalar_call(Arc::clone(&one_argument_only))
+            .build();
+        let _registered = Registered::new("composed_user_fn_udfs_api");
+
+        assert!(
+            support.supports(&call("translatable_fn_udfs_api", 1)),
+            "a call shape the backend declared it can translate must still federate"
+        );
+        assert!(
+            !support.supports(&call("translatable_fn_udfs_api", 2)),
+            "the backend's own per-call check must survive the one `build` installs"
+        );
+        assert!(
+            !support.supports(&call("composed_user_fn_udfs_api", 1)),
+            "a late-registered user function must be refused even in a shape the backend accepts"
+        );
+    }
+
+    #[test]
+    fn is_user_function_reads_the_registry_live() {
+        assert!(!is_user_function("probe_user_fn_udfs_api"));
+        let registered = Registered::new("probe_user_fn_udfs_api");
+        assert!(is_user_function("probe_user_fn_udfs_api"));
+        drop(registered);
+        assert!(!is_user_function("probe_user_fn_udfs_api"));
+    }
 }

--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -77,6 +77,8 @@ mod single_instance_duckdb;
 mod snapshot_lock_contention;
 #[cfg(feature = "snapshots")]
 mod snapshot_mutex;
+#[cfg(feature = "sqlite")]
+mod user_function_pushdown;
 
 /// Queue a refresh of `table`. Callers poll for the result rather than waiting on the
 /// returned notifier: completion signals with `notify_waiters`, which stores no permit,

--- a/crates/runtime/tests/acceleration/user_function_pushdown.rs
+++ b/crates/runtime/tests/acceleration/user_function_pushdown.rs
@@ -1,0 +1,280 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! A user-defined function must never be pushed into a remote backend: no
+//! source has an equivalent, so the SQL it receives names a function it cannot
+//! resolve — or, where it happens to have one of that name, answers from a
+//! different function. Both halves are measured here, because only the first
+//! one is loud.
+//!
+//! The deny-list that prevents this freezes its *names* when a table-provider
+//! factory is built, and every accelerator engine is constructed in
+//! `RuntimeBuilder::build` before that same `build` registers the spicepod's
+//! `functions:` entries. So the snapshot the `SQLite` accelerator carries names
+//! no user function at all, and the whole of `functions:` was pushdown-eligible
+//! against it (#13726 / #13810).
+
+use app::AppBuilder;
+use datafusion::assert_batches_eq;
+use runtime::Runtime;
+use spicepod::acceleration::{Acceleration, Mode, RefreshMode};
+use spicepod::component::dataset::Dataset;
+use spicepod::component::function::{
+    Function, FunctionArg, FunctionKind, FunctionReturns, Signature,
+    Volatility as FunctionVolatility,
+};
+use spicepod::component::runtime::{Functions, Runtime as SpicepodRuntime};
+use spicepod::param::Params;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::acceleration::load_runtime_datasets;
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{register_test_connectors, run_query, test_request_context, to_pretty_display},
+};
+
+const LOAD_TIMEOUT: Duration = Duration::from_mins(1);
+
+fn write_csv_source(path: &Path) -> Result<(), anyhow::Error> {
+    std::fs::write(
+        path,
+        "id,x\n\
+         1,10\n\
+         2,20\n\
+         3,30\n",
+    )?;
+    Ok(())
+}
+
+/// `double_it(x) = x * 2`, declared immutable so nothing but the deny-list
+/// decides whether the call federates — a volatile function is held back by the
+/// optimizer anyway, which would make this test pass with the fix removed.
+fn double_it() -> Function {
+    Function {
+        name: "double_it".to_string(),
+        from: "sql".to_string(),
+        enabled: true,
+        description: Some("Double a 64-bit integer.".to_string()),
+        kind: FunctionKind::Scalar,
+        volatility: FunctionVolatility::Immutable,
+        signature: Signature {
+            tables: vec![],
+            args: vec![FunctionArg {
+                name: "x".to_string(),
+                arrow_type: "int64".to_string(),
+            }],
+            returns: Some(FunctionReturns::Scalar("int64".to_string())),
+        },
+        body: Some("x * 2".to_string()),
+        body_ref: None,
+        metadata: HashMap::new(),
+        params: HashMap::new(),
+        depends_on: vec![],
+        metrics: None,
+        as_tool: false,
+    }
+}
+
+/// `unlikely(x) = x * 2`, under a name `SQLite` also has: its own
+/// `unlikely(X)` is an optimizer hint returning `X` unchanged, and it returns
+/// an integer, so a pushed-down call answers a *different number* of the right
+/// type rather than failing. This is the half of #13726 that returns wrong rows
+/// instead of an error.
+fn shadowing_unlikely() -> Function {
+    let mut function = double_it();
+    function.name = "unlikely".to_string();
+    function.description =
+        Some("SQLite has a function of this name that returns its argument unchanged.".to_string());
+    function
+}
+
+fn csv_params() -> Option<Params> {
+    Some(Params::from_string_map(
+        vec![("file_format".to_string(), "csv".to_string())]
+            .into_iter()
+            .collect(),
+    ))
+}
+
+fn sqlite_accelerated(from: &str, name: &str) -> Dataset {
+    let mut dataset = Dataset::new(from, name);
+    dataset.params = csv_params();
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        engine: Some("sqlite".to_string()),
+        mode: Mode::Memory,
+        refresh_mode: Some(RefreshMode::Full),
+        ..Acceleration::default()
+    });
+    dataset
+}
+
+fn unaccelerated(from: &str, name: &str) -> Dataset {
+    let mut dataset = Dataset::new(from, name);
+    dataset.params = csv_params();
+    dataset
+}
+
+/// A loaded runtime carrying `function`, an `accelerated` dataset over `csv` and
+/// an unaccelerated `local` control over the same file.
+///
+/// Built through `Runtime::builder().build()` rather than by registering the
+/// function afterwards, because the ordering *inside* that call is the defect:
+/// it constructs every accelerator engine — freezing each one's deny-list —
+/// before it registers the spicepod's `functions:` entries.
+async fn runtime_with(
+    app_name: &str,
+    function: Function,
+    csv: &Path,
+) -> Result<Arc<Runtime>, anyhow::Error> {
+    write_csv_source(csv)?;
+    let from = format!("file://{}", csv.display());
+
+    let app = AppBuilder::new(app_name)
+        .with_runtime(SpicepodRuntime {
+            functions: Functions::enabled(),
+            ..Default::default()
+        })
+        .with_function(function)
+        .with_dataset(sqlite_accelerated(&from, "accelerated"))
+        .with_dataset(unaccelerated(&from, "local"))
+        .build();
+
+    configure_test_datafusion();
+    let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+    load_runtime_datasets(&rt, LOAD_TIMEOUT).await?;
+    Ok(rt)
+}
+
+/// Regression test for #13726 / #13810.
+///
+/// Before the fix the `SQLite` accelerator was asked to evaluate `double_it`
+/// and answered `no such function: double_it`; the query failed rather than
+/// returning a row.
+#[tokio::test]
+async fn a_user_function_is_not_pushed_into_a_sqlite_accelerator() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let dir = tempfile::tempdir()?;
+            let rt = runtime_with(
+                "user_function_pushdown",
+                double_it(),
+                &dir.path().join("numbers.csv"),
+            )
+            .await?;
+
+            // `base_sql` is the SQL the federated scan sends, so it is the only
+            // part of the plan that says what SQLite is asked to evaluate — the
+            // logical plan above it names `double_it` either way.
+            let plan = to_pretty_display(
+                &run_query(
+                    &rt,
+                    "EXPLAIN SELECT id, double_it(x) AS doubled FROM accelerated",
+                )
+                .await?,
+            )?
+            .to_string();
+            let remote_sql: String = plan
+                .split("base_sql=")
+                .skip(1)
+                .map(|tail| tail.split('\n').next().unwrap_or_default().to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                !remote_sql.contains("double_it"),
+                "SQLite has no `double_it`; the user function must stay above the federated scan, \
+                 but the pushed-down SQL was:\n{remote_sql}\nfull plan:\n{plan}"
+            );
+
+            let query = "SELECT id, double_it(x) AS doubled FROM {table} ORDER BY id";
+            let accelerated = run_query(&rt, &query.replace("{table}", "accelerated")).await?;
+            let local = run_query(&rt, &query.replace("{table}", "local")).await?;
+
+            let expected = [
+                "+----+---------+",
+                "| id | doubled |",
+                "+----+---------+",
+                "| 1  | 20      |",
+                "| 2  | 40      |",
+                "| 3  | 60      |",
+                "+----+---------+",
+            ];
+            assert_batches_eq!(expected, &accelerated);
+
+            assert_eq!(
+                to_pretty_display(&accelerated)?.to_string(),
+                to_pretty_display(&local)?.to_string(),
+                "an accelerated user function must answer what local evaluation answers"
+            );
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}
+
+/// The wrong-rows half of #13726 / #13810.
+///
+/// `SQLite` has an `unlikely` of its own, so before the fix this query answered
+/// `10, 20, 30` from the accelerated dataset and `20, 40, 60` from the
+/// unaccelerated one — the same SQL over the same rows, two different answers,
+/// no error anywhere.
+#[tokio::test]
+async fn a_user_function_the_backend_also_has_is_not_pushed_down() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let dir = tempfile::tempdir()?;
+            let rt = runtime_with(
+                "user_function_pushdown_shadowing",
+                shadowing_unlikely(),
+                &dir.path().join("numbers.csv"),
+            )
+            .await?;
+
+            let query = "SELECT id, unlikely(x) AS v FROM {table} ORDER BY id";
+            let accelerated = run_query(&rt, &query.replace("{table}", "accelerated")).await?;
+            let local = run_query(&rt, &query.replace("{table}", "local")).await?;
+
+            // The user function's own body is `x * 2`; SQLite's `unlikely` would
+            // answer `x`. Asserting the values, not just that the two agree, so
+            // a future change that pushed the call down to *both* sides could
+            // not satisfy this test.
+            let expected = [
+                "+----+----+",
+                "| id | v  |",
+                "+----+----+",
+                "| 1  | 20 |",
+                "| 2  | 40 |",
+                "| 3  | 60 |",
+                "+----+----+",
+            ];
+            assert_batches_eq!(expected, &accelerated);
+            assert_batches_eq!(expected, &local);
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/acceleration/user_function_pushdown.rs
+++ b/crates/runtime/tests/acceleration/user_function_pushdown.rs
@@ -104,17 +104,17 @@ fn shadowing_unlikely() -> Function {
     function
 }
 
-fn csv_params() -> Option<Params> {
-    Some(Params::from_string_map(
+fn csv_params() -> Params {
+    Params::from_string_map(
         vec![("file_format".to_string(), "csv".to_string())]
             .into_iter()
             .collect(),
-    ))
+    )
 }
 
 fn sqlite_accelerated(from: &str, name: &str) -> Dataset {
     let mut dataset = Dataset::new(from, name);
-    dataset.params = csv_params();
+    dataset.params = Some(csv_params());
     dataset.acceleration = Some(Acceleration {
         enabled: true,
         engine: Some("sqlite".to_string()),
@@ -127,7 +127,7 @@ fn sqlite_accelerated(from: &str, name: &str) -> Dataset {
 
 fn unaccelerated(from: &str, name: &str) -> Dataset {
     let mut dataset = Dataset::new(from, name);
-    dataset.params = csv_params();
+    dataset.params = Some(csv_params());
     dataset
 }
 


### PR DESCRIPTION
## Summary

A user-defined function must never be pushed into a remote backend — no source
has an equivalent — and `FunctionSupportBuilder` denies them for exactly that
reason. But it denies them **by name, from a snapshot** taken when a
table-provider factory is built, and every factory is built once while
`add_user_function` keeps running for the life of the process. A function
registered after that factory exists is absent from the list it froze, so plans
using it stay pushdown-eligible against it.

The issues named hot reload and tool-backed SQL UDFs as the reachable orderings.
**A plain startup is one too, and it is much wider than that:** every accelerator
engine is constructed in `RuntimeBuilder::build` (`register_all`, builder.rs:355)
*before that same `build` registers the spicepod's `functions:` entries*
(`register_udfs`, builder.rs:870). So the snapshot every SQL accelerator carries
names no user function at all, and the whole of `functions:` was pushdown-eligible
against it from a cold start — no hot reload and no tool involved.

Both failure modes are measured in the test plan below, on `trunk` at `2f9a874a97`:
a `SQLite` accelerator answering `no such function: double_it`, and — under a name
`SQLite` also has — the accelerated dataset and the unaccelerated one returning
**different numbers for the same query, with no error**.

## Changes

- `runtime-udfs-api`: `FunctionSupportBuilder::build` now installs a per-call
  check that reads the user-function registry **live**, through a new
  `is_user_function`. The frozen name list is left alone: it already denies
  everything registered before the call, the per-call check only ever narrows
  what a name list allows, and together they cover both sides of the window.
  This is the shared builder both issues asked for — every connector,
  accelerator and catalog deny-list goes through it, so no call site changes.
- `runtime-udfs-api`: new `FunctionSupportBuilder::scalar_call`, because
  `FunctionSupport::with_scalar_call_support` *replaces* the per-call check
  rather than composing with it — a backend that installed its own after
  `build()` would silently drop the live check.
- `runtime-datafusion`: `BigQuery` is that backend; it now supplies
  `bigquery_can_translate` through the builder. Both checks are consulted and a
  call has to satisfy both, which is asserted directly in the unit tests.

Scope: user functions are only ever scalar or table UDFs, and a table function
cannot appear in a federated expression tree, so the scalar per-call check covers
the whole registry. Which names are denied is unchanged (a non-goal in #13726).

Cost: one `parking_lot` read lock plus a scan of a `Vec` that is empty in any
deployment without `functions:`, per scalar call, at plan time only — not per row.

## Test plan

`make lint` and `make test`/`make nextest` (via `make signoff`), plus the
end-to-end reproduction below.

**Repro.** One `spiced`, one CSV, two datasets over it — `t_lite` accelerated into
`SQLite`, `t_local` unaccelerated as the local control — and two `from: sql` user
functions, each `x * 2`. `double_it` is a name `SQLite` does not have; `unlikely`
is a name it *does* have, where its own `unlikely(X)` returns `X` unchanged and
returns an integer, so a pushed-down call answers a different number of the right
type instead of failing.

On `trunk` at `2f9a874a97` — the loud half:

```
$ curl -s -XPOST localhost:8590/v1/sql -d "select id, double_it(x) as v from t_lite order by id"
Execution error: Failed to execute query.
ConnectionError Error("no such function: double_it in SELECT `t_lite`.`id`, double_it(`t_lite`.`x`) AS `doubled` FROM `t_lite` ... at offset 22")

$ curl -s -XPOST localhost:8590/v1/sql -d "select id, double_it(x) as v from t_local order by id"
[{"id":1,"v":20},{"id":2,"v":40},{"id":3,"v":60}]
```

and the quiet half — same query, same rows, two answers, no error:

```
accelerated: [{"id":1,"v":10},{"id":2,"v":20},{"id":3,"v":30}]     <- SQLite's own unlikely()
local:       [{"id":1,"v":20},{"id":2,"v":40},{"id":3,"v":60}]     <- the function as declared
```

`EXPLAIN` says why, and is the artifact that separates "evaluated locally" from
"pushed down". On `trunk`:

```
VirtualExecutionPlan name=sqlite compute_context=memory
  base_sql=SELECT `t_lite`.`id`, double_it(`t_lite`.`x`) AS `doubled` FROM `t_lite` ORDER BY `t_lite`.`id` ASC NULLS LAST
```

On this branch, same binary flags and same spicepod — the call stays above the
federated scan and both datasets agree:

```
ProjectionExec: expr=[id@0 as id, double_it(x@1) as doubled]
  ...
      VirtualExecutionPlan name=sqlite compute_context=memory base_sql=SELECT `t_lite`.`id`, `t_lite`.`x` FROM `t_lite`

double_it accelerated: [{"id":1,"v":20},{"id":2,"v":40},{"id":3,"v":60}]
double_it local:       [{"id":1,"v":20},{"id":2,"v":40},{"id":3,"v":60}]
unlikely  accelerated: [{"id":1,"v":20},{"id":2,"v":40},{"id":3,"v":60}]
unlikely  local:       [{"id":1,"v":20},{"id":2,"v":40},{"id":3,"v":60}]
```

**Regression tests.**

- Two integration tests in `crates/runtime/tests/acceleration/user_function_pushdown.rs`
  drive the reproduction above through the real load path — the same
  `RuntimeBuilder::build` ordering that causes it — one asserting `base_sql` never
  names the function, one asserting the values (not merely that the two datasets
  agree, so a change that pushed the call to *both* sides could not satisfy it).
- Six unit tests in `runtime-udfs-api` covering registered-before (the case the
  snapshot already handled), registered-after, unregistered-again, a name nobody
  registered, and composition with a backend's own per-call check.
- Neuter-verified, both levels. With the live check removed from `build` and the
  backend check left in place, **both integration tests fail** — the first on
  a `base_sql` that still calls `double_it`, the second on the accelerated rows
  coming back as 10, 20, 30 instead of 20, 40, 60 — and exactly the
  two unit tests that guard the new behaviour fail
  (`a_user_function_registered_after_the_support_was_built_is_refused`,
  `a_backend_per_call_check_composes_with_the_live_user_function_check`), while
  the four pinning pre-existing behaviour still pass.

## Known residual — #13873

Copilot found a second, narrower window this change does **not** close, and it is real:
a cached `LogicalPlan` holds the `Arc<ScalarUDF>` itself, and `apply_function_diff`
removes a name from the registry without clearing the plan cache — so a plan cached
while a late-registered function existed can be reused after its removal, match neither
the snapshot nor the live check, and push the stale call down. Tracked in #13873 with
both candidate fixes and their tradeoff; not folded in here because it is a
*deregistration* window rather than the registration-ordering one this PR is about, and
because it is strictly narrower than the hole being closed (before this change such a
function federated on every query, not only inside that window). Read `build`'s
"this closes the rest" as scoped to the registration-ordering gap, which is what it
measures.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` not installed
- `/security-review`: no findings — the per-call check is ANDed with the name restriction upstream, so it can only refuse federation a name list already allowed, never widen it; no new untrusted input path, log line, or error text
- `/simplify`: applied — `build` now takes the backend handler out of the builder instead of cloning it, and the two integration tests share one `runtime_with` helper; light checks (`cargo clippy -p runtime-udfs-api --all-targets`, unit tests, integration tests) re-run green

Re-attested on `e0179b3d72`, which adds one lint fix: `clippy::unnecessary_wraps` fires on the test helper's always-`Some` return, and a package-scoped clippy never reaches `runtime`'s integration-test target, so the gate found it and the scoped run had not.

Fixes #13726
Fixes #13810

## Checklist

- [x] Reproduced on `trunk` before the fix, and the same reproduction re-run on this branch
- [x] Regression tests added, and verified to fail without the fix
- [x] `cargo fmt --all`
- [x] `make signoff` green (14055s: workspace clippy clean, 12525 tests passed) and `Attestation` green