### PR TITLE
fix(duckdb): decode a federated sha256 back to the digest's bytes (fixes #13850)

### DIFF
--- a/crates/runtime-datafusion/src/dialect/duckdb.rs
+++ b/crates/runtime-datafusion/src/dialect/duckdb.rs
@@ -43,6 +43,14 @@ const TO_HEX_NAME: &str = "to_hex";
 /// `DataFusion`'s lower-case hex digits.
 const LOWER_NAME: &str = "lower";
 
+/// The name both engines give the SHA-256 function. They disagree on what it
+/// returns — see [`sha256_to_digest_bytes`].
+const SHA256_NAME: &str = "sha256";
+
+/// `DuckDB`'s hex-text-to-`BLOB` decoder, applied over [`SHA256_NAME`] so a
+/// federated digest comes back as the same bytes the kernel produces.
+const UNHEX_NAME: &str = "unhex";
+
 /// Renders `args` as a call to `duckdb_fn`, in the order given.
 ///
 /// The caller is responsible for having already put `args` into the shape
@@ -167,6 +175,50 @@ pub(crate) fn to_hex_to_lowercase_hex(
         // the un-lowered `to_hex` back into the DuckDB SQL.
         _ => Err(DataFusionError::Plan(format!(
             "to_hex takes one argument, got {}; cannot render it as DuckDB SQL.",
+            args.len()
+        ))),
+    }
+}
+
+/// Decodes `DuckDB`'s `sha256`, which returns the digest's hex *text*, back
+/// into the 32 raw bytes `DataFusion` returns.
+///
+/// Both engines have a `sha256`, so nothing denied the call and nothing
+/// rewrote it: it was pushed into the accelerated store verbatim, and the two
+/// return different things. `DataFusion`'s `sha256` returns the 32-byte digest
+/// as `Binary`; `DuckDB`'s returns its 64-character hex rendering as
+/// `VARCHAR`. The scan then casts that text into the plan's `Binary` column,
+/// so the federated column held the *ASCII bytes of the hex string* — 64 bytes
+/// that are not the digest of anything — with no error and no warning (issue
+/// #13850). Every non-NULL row differed, in length as well as content, so
+/// anything comparing a stored digest against `sha256(col)`, deduplicating on
+/// it, or joining on it changed behaviour the moment a dataset was
+/// accelerated.
+///
+/// `unhex` reverses exactly that rendering: measured on `DuckDB` v1.4.4,
+/// `unhex(sha256(x))` is a 32-byte `BLOB` holding the same digest the kernel
+/// computes, for an ASCII string, the empty string, a non-ASCII one, and NULL
+/// (which stays NULL). It also holds for a `BLOB` argument, which is what an
+/// Arrow `Binary` column becomes: `DuckDB` hashes a `BLOB`'s raw bytes rather
+/// than a text rendering of them, so a column carrying bytes that are not
+/// valid UTF-8 hashes the same on both sides.
+///
+/// The sibling digests need no handler for the same reason they cannot produce
+/// wrong data: `md5` agrees with the kernel (both render lower-case hex text),
+/// and `DuckDB` has no `sha224`, `sha384` or `sha512` at all, so those fail
+/// loudly rather than silently — the unknown-function class tracked by #10583.
+pub(crate) fn sha256_to_digest_bytes(
+    unparser: &datafusion::sql::unparser::Unparser,
+    args: &[Expr],
+) -> Result<Option<ast::Expr>, DataFusionError> {
+    match args {
+        [_] => Ok(renamed_fn_to_sql(unparser, args, SHA256_NAME)?
+            .map(|hex_text| wrap_in_call(hex_text, UNHEX_NAME))),
+        // `sha256` is a single-argument function, so the planner cannot build
+        // this. Fail rather than fall through to `Ok(None)`, which would put
+        // the undecoded `sha256` back into the DuckDB SQL.
+        _ => Err(DataFusionError::Plan(format!(
+            "sha256 takes one argument, got {}; cannot render it as DuckDB SQL.",
             args.len()
         ))),
     }
@@ -826,6 +878,60 @@ mod tests {
             .expr_to_sql(&call)
             .expect("to_hex unparses for DuckDB");
         assert_eq!(rendered.to_string(), "lower(to_hex(255))");
+    }
+
+    /// Both engines have a `sha256`, so the call federated verbatim and came
+    /// back as the digest's hex *text* where the kernel returns the digest's
+    /// 32 bytes — a silently different column, not an error (regression test
+    /// for #13850).
+    #[test]
+    fn sha256_unparses_to_a_duckdb_sha256_decoded_back_to_bytes() {
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        let column = Expr::Column(Column {
+            relation: Some(TableReference::bare("t")),
+            name: "name".to_string(),
+            spans: Spans::new(),
+        });
+
+        let rendered = sha256_to_digest_bytes(&unparser, &[column])
+            .expect("should execute successfully")
+            .expect("should return expression");
+        assert_eq!(rendered.to_string(), r#"unhex(sha256("t"."name"))"#);
+    }
+
+    /// `sha256` takes exactly one argument, so this is a defensive arm — but it
+    /// must be an error, not `Ok(None)`, which would hand the undecoded
+    /// `sha256` straight back to `DuckDB`.
+    #[test]
+    fn sha256_with_an_impossible_arity_is_an_error_not_a_passthrough() {
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+
+        let error = sha256_to_digest_bytes(&unparser, &[lit("a"), lit("b")])
+            .expect_err("two arguments cannot be rendered");
+        assert!(
+            error.to_string().contains("sha256 takes one argument"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// The whole `sha256` call, planned from the `DataFusion` UDF and unparsed
+    /// through the dialect, so a handler that is written but never installed
+    /// fails here rather than in a federated query.
+    #[test]
+    fn duckdb_dialect_installs_the_sha256_override() {
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        let call = Expr::ScalarFunction(ScalarFunction::new_udf(
+            datafusion::functions::crypto::sha256(),
+            vec![lit("alpha")],
+        ));
+
+        let rendered = unparser
+            .expr_to_sql(&call)
+            .expect("sha256 unparses for DuckDB");
+        assert_eq!(rendered.to_string(), "unhex(sha256('alpha'))");
     }
 
     #[test]

--- a/crates/runtime-datafusion/src/dialect/mod.rs
+++ b/crates/runtime-datafusion/src/dialect/mod.rs
@@ -34,6 +34,7 @@ const REGEXP_COUNT_FLAGS_POSITION: usize = 3; // The position of the flags argum
 
 const BTRIM_NAME: &str = "btrim";
 const TO_HEX_NAME: &str = "to_hex";
+const SHA256_NAME: &str = "sha256";
 
 pub(crate) const REGEXP_LIKE_NAME: &str = "regexp_like";
 pub(crate) const REGEXP_MATCH_NAME: &str = "regexp_match";
@@ -114,8 +115,9 @@ fn duckdb_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
 /// would do nothing. What a built-in needs is the handler — without one the
 /// unparser emits the `DataFusion` call verbatim, and `DuckDB` either rejects
 /// the name (`btrim`) or accepts it and answers differently (`to_hex`, whose
-/// digits come back upper-case). The second is the worse of the two: it is a
-/// silently different result rather than a query error.
+/// digits come back upper-case; `sha256`, which returns the digest's hex text
+/// where the kernel returns its bytes). The second is the worse of the two: it
+/// is a silently different result rather than a query error.
 fn duckdb_builtin_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
     vec![
         (
@@ -129,6 +131,12 @@ fn duckdb_builtin_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)
             // DataFusion dialect: to_hex(int) — lower-case digits
             TO_HEX_NAME,
             Box::new(duckdb::to_hex_to_lowercase_hex) as ScalarFnToSqlHandler,
+        ),
+        (
+            // DuckDB dialect: sha256(x) — the digest's hex text, as VARCHAR
+            // DataFusion dialect: sha256(x) — the 32-byte digest, as Binary
+            SHA256_NAME,
+            Box::new(duckdb::sha256_to_digest_bytes) as ScalarFnToSqlHandler,
         ),
     ]
 }

--- a/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
+++ b/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
@@ -19,6 +19,7 @@ limitations under the License.
 //! local evaluation.
 
 use app::AppBuilder;
+use arrow::array::Array;
 use datafusion::assert_batches_eq;
 use runtime::Runtime;
 use spicepod::acceleration::{Acceleration, Mode, RefreshMode};
@@ -448,6 +449,27 @@ async fn duckdb_accelerated_sha256_agrees_with_local() -> Result<(), anyhow::Err
                 "+----+------------------------------------------------------------------+",
             ];
             assert_batches_eq!(expected, &accelerated);
+
+            // Row 4's blank cell above does not pin the NULL half of the
+            // contract on its own: `pretty_format_batches` renders a SQL NULL
+            // and a zero-length `Binary` value identically, so a rewrite that
+            // turned `unhex(sha256(NULL))` into the empty blob would print the
+            // same table. Only the null bitmap separates them. The query is
+            // `ORDER BY id` over four rows, so the last one is id=4.
+            let nulls: Vec<bool> = accelerated
+                .iter()
+                .flat_map(|batch| {
+                    let d = batch.column_by_name("d").expect("the digest column");
+                    (0..batch.num_rows())
+                        .map(|row| d.is_null(row))
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            assert_eq!(
+                nulls,
+                vec![false, false, false, true],
+                "only the NULL name may produce a NULL digest, and the empty blob prints alike"
+            );
 
             // The accelerator's answer is only right if it is the answer
             // DataFusion gives; the hex-text rendering shows up here as a

--- a/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
+++ b/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
@@ -86,6 +86,26 @@ fn write_hex_source(path: &Path) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Strings whose SHA-256 exercises the hex-text-vs-bytes divergence: ASCII, a
+/// mixed-case string with a space, a non-ASCII one (whose UTF-8 bytes are what
+/// gets hashed), and NULL.
+///
+/// The empty string is not a row here — the CSV reader reads a quoted empty
+/// field as NULL, so it cannot be expressed in the source. The test reaches it
+/// through `coalesce(name, '')` over the NULL row instead, which is still
+/// evaluated by `DuckDB`.
+fn write_digest_source(path: &Path) -> Result<(), anyhow::Error> {
+    std::fs::write(
+        path,
+        "id,name\n\
+         1,alpha\n\
+         2,BeTa gamma\n\
+         3,Ünïcödé\n\
+         4,\n",
+    )?;
+    Ok(())
+}
+
 /// The SQL each federated scan in `plan` sends to `DuckDB`, one per line.
 ///
 /// `base_sql` is the only part of an `EXPLAIN` that says what `DuckDB` is asked
@@ -354,6 +374,110 @@ async fn duckdb_accelerated_to_hex_agrees_with_local() -> Result<(), anyhow::Err
                 to_pretty_display(&accelerated)?.to_string(),
                 to_pretty_display(&local)?.to_string(),
                 "a predicate over to_hex must select the same rows accelerated and local"
+            );
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}
+
+/// `sha256` exists in both engines, so nothing denied the call and — before
+/// the dialect rewrote it — nothing changed it either: it was pushed into the
+/// accelerated store verbatim. `DataFusion` returns the 32-byte digest as
+/// `Binary`; `DuckDB` returns its 64-character hex rendering as `VARCHAR`,
+/// which the scan then cast into the plan's `Binary` column. The accelerated
+/// dataset therefore held 64 bytes of ASCII hex text where the unaccelerated
+/// one held the digest — every non-NULL row different in length as well as
+/// content, with no error and no warning (regression test for #13850).
+///
+/// The empty string and NULL are here because they are where a decode-based
+/// rewrite could go wrong in the other direction: `unhex('')` must stay the
+/// empty-input digest and `unhex(NULL)` must stay NULL, rather than either
+/// collapsing into the other.
+#[tokio::test]
+async fn duckdb_accelerated_sha256_agrees_with_local() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let dir = tempfile::tempdir()?;
+            let csv = dir.path().join("digest.csv");
+            write_digest_source(&csv)?;
+            let from = format!("file://{}", csv.display());
+
+            let app = AppBuilder::new("duckdb_builtin_pushdown_sha256")
+                .with_dataset(duckdb_accelerated(&from, "accelerated"))
+                .with_dataset(unaccelerated(&from, "local"))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            load_runtime_datasets(&rt, LOAD_TIMEOUT).await?;
+
+            // The call must reach DuckDB for this to be testing anything: an
+            // accelerated query that evaluated `sha256` locally would agree
+            // with the control even with the rewrite removed.
+            let plan = to_pretty_display(
+                &run_query(&rt, "EXPLAIN SELECT sha256(name) FROM accelerated").await?,
+            )?
+            .to_string();
+            let remote_sql = pushed_down_sql(&plan);
+            assert!(
+                remote_sql.contains("unhex(sha256("),
+                "the digest must be pushed down to DuckDB inside an `unhex(..)`; \
+                 plan was:\n{plan}"
+            );
+
+            let query = "SELECT id, sha256(name) AS d FROM {table} ORDER BY id";
+            let accelerated = run_query(&rt, &query.replace("{table}", "accelerated")).await?;
+            let local = run_query(&rt, &query.replace("{table}", "local")).await?;
+
+            // 64 hex characters is a 32-byte digest. Before the rewrite this
+            // column held 128 of them: the hex text's own ASCII bytes.
+            let expected = [
+                "+----+------------------------------------------------------------------+",
+                "| id | d                                                                |",
+                "+----+------------------------------------------------------------------+",
+                "| 1  | 8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8 |",
+                "| 2  | 5b771e77826caa5ec36e3fbf8f5b2c59b606253913fcfe10104a43410b7a380b |",
+                "| 3  | 39af95d07d82b5d68b6639fea9557192025b64fcc79d700c4cce10f94c16bfc8 |",
+                "| 4  |                                                                  |",
+                "+----+------------------------------------------------------------------+",
+            ];
+            assert_batches_eq!(expected, &accelerated);
+
+            // The accelerator's answer is only right if it is the answer
+            // DataFusion gives; the hex-text rendering shows up here as a
+            // divergence, not as a query error.
+            assert_eq!(
+                to_pretty_display(&accelerated)?.to_string(),
+                to_pretty_display(&local)?.to_string(),
+                "DuckDB-accelerated sha256 must agree with local evaluation"
+            );
+
+            // The empty string, reached over the NULL row. `unhex('')` is the
+            // empty BLOB, so a rewrite that confused "no bytes" with "no value"
+            // would answer NULL here while the kernel answers the empty-input
+            // digest.
+            let empty = "SELECT id, sha256(coalesce(name, '')) AS d FROM {table} WHERE id = 4";
+            let accelerated = run_query(&rt, &empty.replace("{table}", "accelerated")).await?;
+            let local = run_query(&rt, &empty.replace("{table}", "local")).await?;
+            assert_batches_eq!(
+                [
+                    "+----+------------------------------------------------------------------+",
+                    "| id | d                                                                |",
+                    "+----+------------------------------------------------------------------+",
+                    "| 4  | e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 |",
+                    "+----+------------------------------------------------------------------+",
+                ],
+                &accelerated
+            );
+            assert_eq!(
+                to_pretty_display(&accelerated)?.to_string(),
+                to_pretty_display(&local)?.to_string(),
+                "DuckDB-accelerated sha256 of the empty string must agree with local evaluation"
             );
 
             rt.shutdown().await;

--- a/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
+++ b/crates/runtime/tests/acceleration/duckdb_builtin_pushdown.rs
@@ -392,9 +392,10 @@ async fn duckdb_accelerated_to_hex_agrees_with_local() -> Result<(), anyhow::Err
 /// content, with no error and no warning (regression test for #13850).
 ///
 /// The empty string and NULL are here because they are where a decode-based
-/// rewrite could go wrong in the other direction: `unhex('')` must stay the
-/// empty-input digest and `unhex(NULL)` must stay NULL, rather than either
-/// collapsing into the other.
+/// rewrite could go wrong in the other direction. The pushed-down expression
+/// is `unhex(sha256(..))`, so those two cases are `unhex(sha256(''))`, which
+/// must stay the empty-input digest, and `unhex(sha256(NULL))`, which must
+/// stay NULL — rather than either collapsing into the other.
 #[tokio::test]
 async fn duckdb_accelerated_sha256_agrees_with_local() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
@@ -457,10 +458,11 @@ async fn duckdb_accelerated_sha256_agrees_with_local() -> Result<(), anyhow::Err
                 "DuckDB-accelerated sha256 must agree with local evaluation"
             );
 
-            // The empty string, reached over the NULL row. `unhex('')` is the
-            // empty BLOB, so a rewrite that confused "no bytes" with "no value"
-            // would answer NULL here while the kernel answers the empty-input
-            // digest.
+            // The empty string, reached over the NULL row. DuckDB's
+            // sha256('') is the empty-input digest's hex text, so the pushed
+            // unhex(sha256('')) decodes back to that digest; a rewrite that
+            // confused "no bytes" with "no value" would answer NULL here while
+            // the kernel answers the digest.
             let empty = "SELECT id, sha256(coalesce(name, '')) AS d FROM {table} WHERE id = 4";
             let accelerated = run_query(&rt, &empty.replace("{table}", "accelerated")).await?;
             let local = run_query(&rt, &empty.replace("{table}", "local")).await?;


### PR DESCRIPTION
## Summary

`sha256` exists in both engines, so the federation deny-list never withheld it and the
`DuckDB` dialect had no handler for it: the call was pushed into an accelerated `DuckDB`
store verbatim. The two engines return different things — `DataFusion`'s `sha256` returns
the **32-byte digest** as `Binary`, `DuckDB`'s returns the digest's **64-character hex
text** as `VARCHAR`. `SchemaCastScanExec` then cast that text into the plan's `Binary`
column, so the federated column held *the ASCII bytes of the hex string*: 64 bytes that
are not the digest of anything. No error, no warning.

Every non-NULL row differed, in length as well as content, so anything comparing a stored
digest against `sha256(col)`, deduplicating on it, or joining on it changed behaviour the
moment a dataset was accelerated.

This is the third instance of the same shape after `btrim` (#13794) and `to_hex` (#13818),
and the worst of the three: `btrim` failed loudly, `to_hex` differed only in the case of
the digits, and this one returns wholly different bytes.

## Changes

- `crates/runtime-datafusion/src/dialect/duckdb.rs` — `sha256_to_digest_bytes` renders the
  call as `unhex(sha256(x))`, which returns the same 32 bytes the kernel does. The
  impossible-arity arm is an `Err`, not `Ok(None)`, because falling through would put the
  *undecoded* `sha256` straight back into the `DuckDB` SQL — the defect itself.
- `crates/runtime-datafusion/src/dialect/mod.rs` — registers the handler in
  `duckdb_builtin_scalar_overrides`, which is where a `DataFusion` built-in `DuckDB`
  answers differently belongs (a built-in federates unless denied, so the deny-list
  carve-out would do nothing).

One handler covers every `DuckDB`-backed path, because all four build their unparser from
`new_duckdb_dialect()`: the `DuckDB` accelerator, the `DuckDB` connector, the `DuckLake`
connector, and the `DuckLake` catalog connector.

### The sibling digest functions

Measured through a live `spiced` against a `DuckDB` accelerator, so the scope is a
measurement rather than a reading:

| function | `DataFusion` | `DuckDB` v1.4.4 | federated result |
|---|---|---|---|
| `md5` | `Utf8View`, lower-case hex | `VARCHAR`, lower-case hex | **agrees** — no handler needed |
| `sha256` | `Binary`, 32-byte digest | `VARCHAR`, hex text | **silently wrong** — fixed here |
| `sha224` | `Binary` | absent | `Scalar Function with name sha224 does not exist!` |
| `sha384` | `Binary` | absent | `Scalar Function with name sha384 does not exist!` |
| `sha512` | `Binary` | absent | `Scalar Function with name sha512 does not exist!` |

`sha256` is the only one that can produce wrong data. The three absent ones fail the query
outright, which is the unknown-function class already tracked by #10583 and deliberately
left to it — fixing three of that class's many functions here would be a partial fix in the
wrong issue.

### Known consequence, stated rather than hidden

`CAST(sha256(x) AS VARCHAR)` over an accelerated dataset used to return readable hex and
now returns `DuckDB`'s escaped-`BLOB` rendering (`\x8E\xD3\xF6...`). Neither matches the
kernel, which **refuses that cast** (`Encountered non UTF-8 data`), so there is no correct
behaviour being changed — the readable hex was only ever available because the accelerated
path was returning the hex text, which is the defect. `encode(sha256(x), 'hex')` — the
correct way to get hex — fails remotely both before and after this change, because
`DuckDB`'s `encode` takes one argument; that is #10583's class, verified below.

## Test plan

Everything below was run; the outputs are the actual ones.

### 1. Reproduced on `trunk` through a real `spiced`

Two datasets over one CSV — `t_duckdb` with `acceleration.engine: duckdb`, `t_local`
unaccelerated:

```
$ curl -s -XPOST localhost:8199/v1/sql -d "SELECT id, sha256(name) AS s FROM t_duckdb ORDER BY id"
[{"id":1,"s":"38656433663661643638356239353965616437303232353138653161663736636438313666386538656337636364646131656434303138653866323232336638"}, ...]

$ curl -s -XPOST localhost:8199/v1/sql -d "SELECT id, sha256(name) AS s FROM t_local ORDER BY id"
[{"id":1,"s":"8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8"}, ...]
```

The federated value **decodes** to the local one, which is what identifies the defect
rather than merely showing two different strings — verified for all three non-NULL rows:

```
row 1: federated 64 bytes -> ascii '8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8'
        local     32 bytes -> hex   '8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8'
        MATCH(ascii(fed)==hex(local)) = True
```

`arrow_typeof(sha256(name))` is `Binary` locally, and `EXPLAIN` confirms the call really is
evaluated remotely:

```
VirtualExecutionPlan name=duckdb compute_context=:memory: \
  base_sql=SELECT sha256("t_duckdb"."name") AS "s" FROM "t_duckdb"
```

### 2. The candidate rewrite verified against the pinned `DuckDB` before writing it

The issue flagged `unhex(sha256(x))` as unverified. Probed against the bundled engine
(`DUCKDB_VERSION=v1.4.4`) — including a raw `BLOB` whose bytes are not valid UTF-8, since
an Arrow `Binary` column becomes a `BLOB`:

```
PROBE unhex_exists   = BLOB            PROBE unhex_len     = 32
PROBE unhex_hex      = 8ed3f6ad...f8   PROBE unhex_null    = <NULL>
PROBE unhex_empty    = e3b0c442...55   PROBE unhex_unicode = 39af95d0...c8
PROBE blob_ff00      = ea5dbf95...2f   (== python hashlib.sha256(b'\xff\x00'))
PROBE blob_allbytes  = 40aff2e9...80   (== python hashlib.sha256(bytes(range(256))))
```

`DuckDB` hashes a `BLOB`'s raw bytes, not a text rendering of them, so the rewrite holds
for non-UTF-8 binary input too.

### 3. The regression test fails on unfixed code and passes on the fix — same command

`cargo test -p runtime --test integration ... duckdb_accelerated_sha256`, with the two
dialect files reverted to `trunk` and the new test in place:

```
actual (trunk):
| 1  | 38656433663661643638356239353965616437303232353138653161663736636438313666386538656337636364646131656434303138653866323232336638 |
expected (kernel):
| 1  | 8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8 |
test result: FAILED. 0 passed; 1 failed
```

128 hex characters is 64 bytes of ASCII; 64 is the 32-byte digest. With the fix, same
command:

```
test acceleration::duckdb_builtin_pushdown::duckdb_accelerated_sha256_agrees_with_local ... ok
test acceleration::duckdb_builtin_pushdown::duckdb_accelerated_to_hex_agrees_with_local ... ok
test acceleration::duckdb_builtin_pushdown::duckdb_accelerator_answers_btrim_and_agrees_with_local ... ok
test acceleration::duckdb_builtin_pushdown::duckdb_accelerated_btrim_leaves_unicode_separators_alone ... ok
test result: ok. 4 passed; 0 failed
```

The unfixed run also pins *why*, before it ever reaches the values — the pushed SQL was
`base_sql=SELECT sha256("accelerated"."name") FROM "accelerated"`, with no `unhex`.

### 4. Unit tests

3 new tests in `crates/runtime-datafusion/src/dialect/duckdb.rs`, mirroring #13818's: the
rendering, the impossible-arity arm being an error rather than a passthrough, and the
whole call planned from the `DataFusion` UDF so a handler that is written but never
installed fails there instead of in a federated query. `16 passed; 0 failed`.

### 5. Gate

- `make lint` — via `make signoff` (which runs `make lint-rust` + `make build-cli nextest`)
- `make nextest` — same
- `cargo fmt --all --check` — clean

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits"; `grok` not installed
- `/security-review`: no findings — the remote SQL is built as a `sqlparser` AST with hardcoded function names, the argument goes through the pre-existing `unparser.expr_to_sql` path, and the only interpolated value in the new error is `args.len()`
- `/simplify`: reviewed for reuse, simplification, efficiency and altitude; one finding recorded and skipped — `sha256_to_digest_bytes` and the merged `to_hex_to_lowercase_hex` share a `match` shape that could be extracted into a helper, but the extraction would rewrite a function merged hours ago in #13852 for a ~10-line saving, and each site's `match` arms are where its distinct reasoning lives. Light checks re-run green.

Because the adversarial engine was unavailable, the design was challenged by measurement
instead: the two shapes most likely to regress (`CAST(... AS VARCHAR)` and
`encode(..., 'hex')`) were each run on both sides and are reported under *Known
consequence* above rather than assumed benign.

### Later iterations — `703bae2854`, `acf495988a` (two Copilot threads, `fix-failing-prs`)

Attesting these two commits only.

- **Both threads valid, both fixed.** The first: the doc comment named `unhex('')` and `unhex(NULL)`, but line 428 asserts the pushed SQL contains `unhex(sha256(`, so the cases are `unhex(sha256(''))` and `unhex(sha256(NULL))` — `unhex('')` is the empty blob and appears nowhere in this test. The second, and the more serious one: the blank cell for id=4 did **not** verify the NULL contract that reword had just made explicit.
- **The NULL finding is measured, against the `spiceai/arrow-rs` rev this branch pins** (`ccb268d61bd49a0a42ba229a2af397d78bce7beb`). Two four-row batches differing only in whether the last value is NULL or a zero-length `Binary` format **byte-identically** under `pretty_format_batches`, while the null bitmap gives `[false, false, false, true]` versus `[false, false, false, false]`. So `assert_batches_eq!` and the `to_pretty_display` comparison beside it would both have passed on a rewrite that turned `unhex(sha256(NULL))` into the empty blob. `acf495988a` asserts the bitmap instead.
- Adversarial review: **declared skip**, engine `codex`, exit 1, its own reason `Your workspace is out of credits. Ask your workspace owner to refill in order to continue.`; `grok` companion not installed. Same condition as above.
- `/security-review`: not re-run — both commits are comments and test assertions with no production change, so the audit above still describes the whole production surface.
- `/simplify`: the bitmap assertion was written twice. The first draft downcast the `id` column to `Int32Array`, which would have depended on the CSV reader's integer width; replaced with the batch-order sequence, since the query is `ORDER BY id` over four rows.
- Gates: `cargo fmt --all -- --check` rc=0, and `cargo check -p runtime --test integration` with the gate's feature set — `Finished dev profile in 21m 05s`, **0 errors**. Sign-off dispatched on `acf495988a`; the two runs attesting the superseded heads were cancelled rather than left to spend five hours each on a dead SHA.

Fixes #13850

## Checklist

- [x] Reproduced the reported failure on `trunk` before writing the fix
- [x] Regression test demonstrated failing on unfixed code and passing on the fix
- [x] Candidate rewrite verified against the pinned `DuckDB` rather than assumed
- [x] Sibling digest functions measured, not reasoned about
- [x] `cargo fmt --all` clean
- [ ] `make signoff` green and `Attestation` re-run

