### PR TITLE
fix(query): surface a panicking query as an error, never an empty success (fixes #13876)

### DIFF
--- a/crates/runtime-datafusion/src/managed_runtime.rs
+++ b/crates/runtime-datafusion/src/managed_runtime.rs
@@ -330,28 +330,42 @@ mod tests {
 
     /// A driver that panics *after* the stream has started must surface an error.
     ///
-    /// The sender is dropped as the panicking task's future unwinds, which closes
-    /// the batch channel before the runtime publishes the task's outcome. Sleeping
-    /// between the two makes that window wide enough to hit on every run instead of
-    /// roughly a third of them: the stream is woken by the channel close while the
-    /// join handle is still pending, which is exactly the ordering that used to end
-    /// the stream as an empty success.
+    /// The sender is dropped as the panicking task's future unwinds, which closes the
+    /// batch channel before the runtime publishes the task's outcome. Two one-shot
+    /// barriers pin that ordering exactly rather than racing it: the driver closes the
+    /// channel and signals, and only after the stream has been polled once does it get
+    /// released to panic. So at the first poll the channel is provably closed and the
+    /// handle is provably pending — the ordering that used to end the stream as an empty
+    /// success, and the one a sleep only reaches by luck.
     ///
     /// Regression test for #13876.
     #[tokio::test]
     async fn driver_panic_after_stream_start_is_an_error_not_an_empty_success() {
         let runtime = test_runtime();
         let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, DataFusionError>>(2);
+        let (closed_tx, closed_rx) = oneshot::channel::<()>();
+        let (release_tx, release_rx) = oneshot::channel::<()>();
 
         let driver_handle = runtime.spawn(async move {
             drop(batch_tx);
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let _ = closed_tx.send(());
+            let _ = release_rx.await;
             panic!("driver task panic after stream start");
         });
 
-        let results: Vec<_> = RuntimeDriverStream::new(batch_rx, driver_handle)
-            .collect()
-            .await;
+        closed_rx.await.expect("driver signalled the channel close");
+
+        let mut stream = RuntimeDriverStream::new(batch_rx, driver_handle);
+        assert!(
+            matches!(futures::poll!(stream.next()), Poll::Pending),
+            "the stream ended while the driver's outcome was still unknown — \
+             a panicking query would be reported to the client as an empty success"
+        );
+
+        release_tx
+            .send(())
+            .expect("release the driver into its panic");
+        let results: Vec<_> = stream.collect().await;
 
         let [Err(err)] = results.as_slice() else {
             panic!("expected exactly one error item, got {results:?}");
@@ -370,24 +384,42 @@ mod tests {
         let runtime = test_runtime();
         let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, DataFusionError>>(2);
 
+        let (closed_tx, closed_rx) = oneshot::channel::<()>();
+        let (release_tx, release_rx) = oneshot::channel::<()>();
+
         let driver_handle = runtime.spawn(async move {
             batch_tx
                 .send(Ok(test_batch(vec![1, 2, 3])))
                 .await
                 .expect("send batch");
             drop(batch_tx);
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let _ = closed_tx.send(());
+            let _ = release_rx.await;
             panic!("driver task panic after one batch");
         });
 
-        let results: Vec<_> = RuntimeDriverStream::new(batch_rx, driver_handle)
-            .collect()
-            .await;
+        closed_rx.await.expect("driver signalled the channel close");
 
-        let [Ok(batch), Err(err)] = results.as_slice() else {
-            panic!("expected one batch then one error, got {results:?}");
+        let mut stream = RuntimeDriverStream::new(batch_rx, driver_handle);
+        let first = futures::poll!(stream.next());
+        assert!(
+            matches!(first, Poll::Ready(Some(Ok(_)))),
+            "the buffered batch should be drained before the driver's outcome is known, got {first:?}"
+        );
+        assert!(
+            matches!(futures::poll!(stream.next()), Poll::Pending),
+            "the stream ended after its last buffered batch while the driver's outcome was \
+             still unknown — a panicking query would be truncated into a short success"
+        );
+
+        release_tx
+            .send(())
+            .expect("release the driver into its panic");
+        let results: Vec<_> = stream.collect().await;
+
+        let [Err(err)] = results.as_slice() else {
+            panic!("expected exactly one error item after the batch, got {results:?}");
         };
-        assert_eq!(batch.num_rows(), 3);
         assert!(
             err.to_string().contains("Query driver task panicked"),
             "unexpected error: {err}"

--- a/crates/runtime-datafusion/src/managed_runtime.rs
+++ b/crates/runtime-datafusion/src/managed_runtime.rs
@@ -208,6 +208,16 @@ mod tests {
         Arc::new(RequestContext::builder(Protocol::Internal).build())
     }
 
+    fn test_batch(values: Vec<i64>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int64,
+            false,
+        )]));
+        let columns: Vec<ArrayRef> = vec![Arc::new(Int64Array::from(values))];
+        RecordBatch::try_new(schema, columns).expect("create record batch")
+    }
+
     fn test_runtime() -> tokio::runtime::Runtime {
         Builder::new_multi_thread()
             .worker_threads(1)
@@ -361,14 +371,10 @@ mod tests {
         let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, DataFusionError>>(2);
 
         let driver_handle = runtime.spawn(async move {
-            let schema = Arc::new(Schema::new(vec![Field::new(
-                "value",
-                DataType::Int64,
-                false,
-            )]));
-            let columns: Vec<ArrayRef> = vec![Arc::new(Int64Array::from(vec![1, 2, 3]))];
-            let batch = RecordBatch::try_new(schema, columns).expect("create record batch");
-            batch_tx.send(Ok(batch)).await.expect("send batch");
+            batch_tx
+                .send(Ok(test_batch(vec![1, 2, 3])))
+                .await
+                .expect("send batch");
             drop(batch_tx);
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             panic!("driver task panic after one batch");
@@ -425,14 +431,10 @@ mod tests {
         let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, DataFusionError>>(2);
 
         let driver_handle = runtime.spawn(async move {
-            let schema = Arc::new(Schema::new(vec![Field::new(
-                "value",
-                DataType::Int64,
-                false,
-            )]));
-            let columns: Vec<ArrayRef> = vec![Arc::new(Int64Array::from(vec![7]))];
-            let batch = RecordBatch::try_new(schema, columns).expect("create record batch");
-            batch_tx.send(Ok(batch)).await.expect("send batch");
+            batch_tx
+                .send(Ok(test_batch(vec![7])))
+                .await
+                .expect("send batch");
         });
 
         let results: Vec<_> = RuntimeDriverStream::new(batch_rx, driver_handle)

--- a/crates/runtime-datafusion/src/managed_runtime.rs
+++ b/crates/runtime-datafusion/src/managed_runtime.rs
@@ -121,10 +121,15 @@ where
     Ok(ManagedRecordBatchStream::new(metadata, stream))
 }
 
+/// Response stream for the offloaded query driver. Wraps the receiver of batches
+/// produced on the managed runtime and owns the driver task's [`JoinHandle`] so
+/// that buffered batches are drained first, then a panic — or an unexpected
+/// cancellation (e.g. runtime shutdown) — of the driver task surfaces as a stream
+/// error instead of a silent end-of-stream, which the caller cannot tell apart
+/// from a query that legitimately matched no rows.
 struct RuntimeDriverStream {
     receiver: ReceiverStream<Result<RecordBatch, DataFusionError>>,
     driver_handle: Option<JoinHandle<()>>,
-    driver_error: Option<DataFusionError>,
 }
 
 impl RuntimeDriverStream {
@@ -135,7 +140,6 @@ impl RuntimeDriverStream {
         Self {
             receiver: ReceiverStream::new(receiver),
             driver_handle: Some(driver_handle),
-            driver_error: None,
         }
     }
 }
@@ -146,32 +150,32 @@ impl Stream for RuntimeDriverStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
-        if let Some(handle) = this.driver_handle.as_mut() {
-            match Future::poll(Pin::new(handle), cx) {
-                Poll::Ready(Ok(())) => {
-                    this.driver_handle = None;
-                }
-                Poll::Ready(Err(err)) => {
-                    this.driver_handle = None;
-                    if err.is_panic() {
-                        this.driver_error = Some(DataFusionError::Execution(format!(
-                            "Query driver task panicked: {err}"
-                        )));
-                    } else if !err.is_cancelled() {
-                        this.driver_error = Some(DataFusionError::Execution(format!(
-                            "Query driver task failed: {err}"
-                        )));
-                    }
-                }
-                Poll::Pending => {}
-            }
+        // Drain already-produced batches first, so a driver failure surfaces only
+        // after the caller has received everything the driver actually sent.
+        if let Some(batch) = std::task::ready!(Pin::new(&mut this.receiver).poll_next(cx)) {
+            return Poll::Ready(Some(batch));
         }
 
-        if let Some(err) = this.driver_error.take() {
-            return Poll::Ready(Some(Err(err)));
+        // The channel is closed, so the driver task has ended. Its sender is dropped
+        // as the task's future is dropped, which during a panic unwind happens before
+        // the runtime publishes the task's outcome — so the handle can still be
+        // pending here. Ending the stream at this point would turn a panicking query
+        // into an empty success that no client can tell apart from "no rows matched",
+        // so `ready!` yields `Pending` until the outcome is known.
+        let Some(handle) = this.driver_handle.as_mut() else {
+            return Poll::Ready(None);
+        };
+        let result = std::task::ready!(Future::poll(Pin::new(handle), cx));
+        this.driver_handle = None;
+        match result {
+            Ok(()) => Poll::Ready(None),
+            Err(err) if err.is_panic() => Poll::Ready(Some(Err(DataFusionError::Execution(
+                format!("Query driver task panicked: {err}"),
+            )))),
+            Err(err) => Poll::Ready(Some(Err(DataFusionError::Execution(format!(
+                "Query driver task ended before completing: {err}"
+            ))))),
         }
-
-        Pin::new(&mut this.receiver).poll_next(cx)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -311,6 +315,134 @@ mod tests {
                 panic!("expected driver termination error, got future error")
             }
         }
+        runtime.shutdown_background();
+    }
+
+    /// A driver that panics *after* the stream has started must surface an error.
+    ///
+    /// The sender is dropped as the panicking task's future unwinds, which closes
+    /// the batch channel before the runtime publishes the task's outcome. Sleeping
+    /// between the two makes that window wide enough to hit on every run instead of
+    /// roughly a third of them: the stream is woken by the channel close while the
+    /// join handle is still pending, which is exactly the ordering that used to end
+    /// the stream as an empty success.
+    ///
+    /// Regression test for #13876.
+    #[tokio::test]
+    async fn driver_panic_after_stream_start_is_an_error_not_an_empty_success() {
+        let runtime = test_runtime();
+        let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, DataFusionError>>(2);
+
+        let driver_handle = runtime.spawn(async move {
+            drop(batch_tx);
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            panic!("driver task panic after stream start");
+        });
+
+        let results: Vec<_> = RuntimeDriverStream::new(batch_rx, driver_handle)
+            .collect()
+            .await;
+
+        let [Err(err)] = results.as_slice() else {
+            panic!("expected exactly one error item, got {results:?}");
+        };
+        assert!(
+            err.to_string().contains("Query driver task panicked"),
+            "unexpected error: {err}"
+        );
+        runtime.shutdown_background();
+    }
+
+    /// Batches the driver did produce are delivered before its panic surfaces, so
+    /// the failure never silently truncates a partial result into a short success.
+    #[tokio::test]
+    async fn driver_panic_after_a_batch_yields_the_batch_then_the_error() {
+        let runtime = test_runtime();
+        let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, DataFusionError>>(2);
+
+        let driver_handle = runtime.spawn(async move {
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "value",
+                DataType::Int64,
+                false,
+            )]));
+            let columns: Vec<ArrayRef> = vec![Arc::new(Int64Array::from(vec![1, 2, 3]))];
+            let batch = RecordBatch::try_new(schema, columns).expect("create record batch");
+            batch_tx.send(Ok(batch)).await.expect("send batch");
+            drop(batch_tx);
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            panic!("driver task panic after one batch");
+        });
+
+        let results: Vec<_> = RuntimeDriverStream::new(batch_rx, driver_handle)
+            .collect()
+            .await;
+
+        let [Ok(batch), Err(err)] = results.as_slice() else {
+            panic!("expected one batch then one error, got {results:?}");
+        };
+        assert_eq!(batch.num_rows(), 3);
+        assert!(
+            err.to_string().contains("Query driver task panicked"),
+            "unexpected error: {err}"
+        );
+        runtime.shutdown_background();
+    }
+
+    /// A driver cancelled out from under the stream (e.g. runtime shutdown) is the
+    /// same silent-truncation hazard as a panic and must also surface as an error.
+    #[tokio::test]
+    async fn driver_cancelled_after_stream_start_is_an_error() {
+        let runtime = test_runtime();
+        let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, DataFusionError>>(2);
+
+        let driver_handle = runtime.spawn(async move {
+            drop(batch_tx);
+            std::future::pending::<()>().await;
+        });
+        driver_handle.abort();
+
+        let results: Vec<_> = RuntimeDriverStream::new(batch_rx, driver_handle)
+            .collect()
+            .await;
+
+        let [Err(err)] = results.as_slice() else {
+            panic!("expected exactly one error item, got {results:?}");
+        };
+        assert!(
+            err.to_string()
+                .contains("Query driver task ended before completing"),
+            "unexpected error: {err}"
+        );
+        runtime.shutdown_background();
+    }
+
+    /// The preserved direction: a driver that finishes cleanly still ends the stream
+    /// as a success once its batches are drained.
+    #[tokio::test]
+    async fn driver_completing_cleanly_still_ends_the_stream() {
+        let runtime = test_runtime();
+        let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, DataFusionError>>(2);
+
+        let driver_handle = runtime.spawn(async move {
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "value",
+                DataType::Int64,
+                false,
+            )]));
+            let columns: Vec<ArrayRef> = vec![Arc::new(Int64Array::from(vec![7]))];
+            let batch = RecordBatch::try_new(schema, columns).expect("create record batch");
+            batch_tx.send(Ok(batch)).await.expect("send batch");
+        });
+
+        let results: Vec<_> = RuntimeDriverStream::new(batch_rx, driver_handle)
+            .collect()
+            .await;
+
+        let [Ok(batch)] = results.as_slice() else {
+            panic!("expected exactly one batch and no error, got {results:?}");
+        };
+        assert_eq!(batch.num_rows(), 1);
         runtime.shutdown_background();
     }
 }

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -515,9 +515,8 @@ fn flight_data_size(flight_data: &FlightData) -> usize {
 ///   2. dropping the response stream (client disconnect) aborts the encode task,
 ///      which in turn drops the upstream execution stream.
 ///
-/// Uses the same join-handle-backed approach as `RuntimeDriverStream` (execution
-/// offload); unlike that stream it polls drain-first (point 1 above) rather than
-/// observing the handle first.
+/// Uses the same join-handle-backed, drain-first approach as `RuntimeDriverStream`
+/// (execution offload).
 struct FlightEncodeStream {
     receiver: ReceiverStream<Result<FlightData, Status>>,
     encode_handle: Option<JoinHandle<()>>,

--- a/crates/runtime/tests/query_panic_is_an_error.rs
+++ b/crates/runtime/tests/query_panic_is_an_error.rs
@@ -1,0 +1,140 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! A query whose execution panics must reach the caller as an error, never as a
+//! successful empty result — which is what a client cannot tell apart from "no rows
+//! matched", and what a pipeline would record as fact.
+//!
+//! The unit tests beside `RuntimeDriverStream` pin the channel/handle ordering that
+//! produced the empty success. This one covers the other half: that no layer between
+//! the driver stream and the caller — `run_with_managed_runtime`, `QueryResult`, the
+//! stream adapters — converts that error back into a success. It drives the real
+//! `Query::run` path, so it fails if any of them ever does.
+//!
+//! Regression test for <https://github.com/spiceai/spiceai/issues/13876>.
+//!
+//! This lives in its own test binary because it registers a deliberately panicking
+//! UDF on the session context, which must not be visible to any other test.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::DataType;
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use futures::StreamExt;
+use runtime::Runtime;
+use runtime_async::ManagedTokioRuntime;
+
+/// A UDF that panics when it is executed. Planning succeeds — the panic happens on the
+/// execution thread, which is the shape this test needs and the shape a kernel hitting
+/// an `unreachable!()` produces.
+///
+/// A real panicking expression was available (`concat` over an untyped NULL literal, the
+/// one #13876 was found through) but is deliberately not used: it is a bug in its own
+/// right, tracked as #13877, so a test built on it would break the moment it is fixed.
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct PanickingUdf {
+    signature: Signature,
+}
+
+impl PanickingUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Volatile),
+        }
+    }
+}
+
+impl ScalarUDFImpl for PanickingUdf {
+    fn name(&self) -> &'static str {
+        "spice_test_panic"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType, DataFusionError> {
+        Ok(DataType::Int64)
+    }
+
+    fn invoke_with_args(
+        &self,
+        _args: ScalarFunctionArgs,
+    ) -> Result<ColumnarValue, DataFusionError> {
+        panic!("spice_test_panic: deliberate panic from a scalar UDF");
+    }
+}
+
+#[tokio::test]
+async fn a_panicking_query_is_an_error_not_an_empty_success() {
+    let rt = Arc::new(Runtime::builder().build().await);
+
+    // `Query::run` only takes the offloaded driver path when a CPU runtime is set, which
+    // is what `spiced` does at startup. Without this the query runs inline and never
+    // reaches `RuntimeDriverStream` at all — the test would pass while covering nothing.
+    rt.datafusion().set_cpu_runtime(
+        ManagedTokioRuntime::try_new().expect("create a CPU runtime for the query driver"),
+    );
+    rt.datafusion()
+        .ctx
+        .register_udf(ScalarUDF::from(PanickingUdf::new()));
+
+    // Several rows over several partitions, which is the shape the empty success was
+    // measured on: most partitions finish empty and only one carries the panicking row.
+    const SQL: &str =
+        "SELECT spice_test_panic(x) AS z FROM (VALUES (1),(2),(3),(4),(5),(6),(7),(8)) t(x)";
+
+    // Repeated because the failure this guards is an ordering race: on the pre-fix code
+    // roughly a third of runs returned the empty success and the rest returned the error,
+    // so a single run could pass by luck.
+    for attempt in 1..=20 {
+        let outcome: Result<Vec<_>, DataFusionError> =
+            match rt.datafusion().query_builder(SQL).build().run().await {
+                // A planning failure would mean the UDF never executed, so this test would
+                // be asserting nothing at all — the failure mode it is most likely to rot
+                // into. Refuse it rather than counting it as the correct outcome.
+                Err(err) => {
+                    let msg = err.to_string();
+                    assert!(
+                        !msg.contains("Error during planning"),
+                        "attempt {attempt}: the query failed to plan, so execution was never \
+                         reached and this test covers nothing: {msg}"
+                    );
+                    continue;
+                }
+                Ok(result) => result.data.collect::<Vec<_>>().await.into_iter().collect(),
+            };
+
+        match outcome {
+            Err(_) => {}
+            Ok(batches) => {
+                let rows: usize = batches
+                    .iter()
+                    .map(arrow::array::RecordBatch::num_rows)
+                    .sum();
+                panic!(
+                    "attempt {attempt}: a query whose execution panicked returned success with \
+                     {} batch(es) and {rows} row(s); a client cannot tell this apart from a query \
+                     that legitimately matched no rows",
+                    batches.len()
+                );
+            }
+        }
+    }
+}

--- a/crates/runtime/tests/query_panic_is_an_error.rs
+++ b/crates/runtime/tests/query_panic_is_an_error.rs
@@ -81,6 +81,11 @@ impl ScalarUDFImpl for PanickingUdf {
     }
 }
 
+/// Several rows over several partitions, which is the shape the empty success was measured
+/// on: most partitions finish empty and only one carries the panicking row.
+const SQL: &str =
+    "SELECT spice_test_panic(x) AS z FROM (VALUES (1),(2),(3),(4),(5),(6),(7),(8)) t(x)";
+
 #[tokio::test]
 async fn a_panicking_query_is_an_error_not_an_empty_success() {
     let rt = Arc::new(Runtime::builder().build().await);
@@ -94,11 +99,6 @@ async fn a_panicking_query_is_an_error_not_an_empty_success() {
     rt.datafusion()
         .ctx
         .register_udf(ScalarUDF::from(PanickingUdf::new()));
-
-    // Several rows over several partitions, which is the shape the empty success was
-    // measured on: most partitions finish empty and only one carries the panicking row.
-    const SQL: &str =
-        "SELECT spice_test_panic(x) AS z FROM (VALUES (1),(2),(3),(4),(5),(6),(7),(8)) t(x)";
 
     // Repeated because the failure this guards is an ordering race: on the pre-fix code
     // roughly a third of runs returned the empty success and the rest returned the error,


### PR DESCRIPTION
## Summary

A query whose execution panicked was sometimes returned to the client as an **empty
HTTP 200 success** instead of an error — a silently wrong answer that no client can tell
apart from "no rows matched". Measured at 20 of 60 identical runs on `trunk`.

`RuntimeDriverStream` observed the driver task's `JoinHandle` first and then polled the
batch channel:

```rust
if let Some(handle) = this.driver_handle.as_mut() { /* poll handle, record error */ }
if let Some(err) = this.driver_error.take() { return Poll::Ready(Some(Err(err))); }
Pin::new(&mut this.receiver).poll_next(cx)
```

The driver's `batch_tx` is dropped as the driver task's future is dropped, which during a
panic unwind happens **before** the runtime publishes the task's outcome. So the channel
close and the handle's completion are two separate wakeups, and the close can arrive first.
In that ordering the handle poll returns `Pending`, the receiver returns `Ready(None)`, and
the stream ends as a clean end-of-stream. The client gets `[]` with HTTP 200.

The fix polls drain-first and, once the channel is closed, waits for the handle before
deciding — `ready!` yields `Pending` until the outcome is known, so a panic or an unexpected
cancellation surfaces as a stream error. **This is the shape `FlightEncodeStream` already
uses for the same hazard**, and whose doc comment already spells it out: *"While the channel
is closed but the handle has not resolved yet, `ready!` yields `Pending` so a panic is still
reported instead of ending silently."* That comment named `RuntimeDriverStream` as its model
while `RuntimeDriverStream` was the one still getting it wrong; it is updated here.

Cancellation is folded in deliberately rather than left as-is: the old code ignored
`is_cancelled()` and fell through to the receiver, which is the same silent-truncation
outcome. The only code that aborts this handle is `RuntimeDriverStream::Drop`, after which
the stream is never polled again, so the branch is reachable only by runtime shutdown — where
truncating a result into a short success is exactly what must not happen. Query *timeouts* go
through a `CancellationToken` and produce their own error, and are unaffected.

## Changes

- `crates/runtime-datafusion/src/managed_runtime.rs` — `RuntimeDriverStream::poll_next` polls
  drain-first, then awaits the driver handle before ending the stream; a panic or unexpected
  cancellation becomes a stream error. The now-redundant `driver_error` field is removed.
- `crates/runtime/src/flight/mod.rs` — doc comment updated: the two streams now share one
  shape, so the sentence contrasting them was stale.
- `crates/runtime-datafusion/src/managed_runtime.rs` tests — four guards, three
  failure-direction plus one preserved-direction. The two panic guards coordinate with
  one-shot barriers rather than a sleep, so the failing ordering is pinned rather than raced.
- `crates/runtime/tests/query_panic_is_an_error.rs` — a new end-to-end guard that drives a
  panicking scalar UDF through `Query::run` and asserts a non-success, covering the layers
  between the driver stream and the caller that the unit guards cannot reach.

## Test plan

```bash
make lint
make nextest
```

**The failure, on `trunk`, before the fix.** A real `spiced`, one local CSV dataset, no
acceleration, four rows. Sixty runs of the same statement, differing only in the output alias
so the results cache cannot serve any of them:

```
$ for i in $(seq 1 60); do
    curl -s -XPOST localhost:18190/v1/sql -d "SELECT concat(name, NULL) AS z$i FROM t_local"
  done | sort | uniq -c

  20  []
  40  Execution error: Query driver task panicked: task N panicked with message
      "internal error: entered unreachable code: concat"
```

The `[]` responses are HTTP 200 — indistinguishable from a real empty answer:

```
HTTP 200  body=[]  <-- EMPTY SUCCESS
HTTP 400  body=Execution error: Query driver task panicked: task ...
HTTP 200  body=[]  <-- EMPTY SUCCESS
...
```

**The same command on this branch**, same rig, same rows:

```
=== classified (fixed build, 60 runs) ===
  60 PANIC_ERROR
=== HTTP codes, 20 runs ===
400 400 400 400 400 400 400 400 400 400 400 400 400 400 400 400 400 400 400 400
```

Zero empty successes in 60 runs, every response HTTP 400.

**Preserved directions, same running build.** A query that legitimately matches no rows is
still an empty success, and normal streaming is unaffected:

```
$ curl -s -XPOST .../v1/sql -d "SELECT name FROM t_local WHERE id = 999"
run 1: HTTP 200 body []      (5 of 5 runs)

$ ... -d "SELECT count(*) AS n, min(name) AS mn FROM t_local"
[{"n":4,"mn":"first"}]

$ ... -d "SELECT count(*) AS n FROM (t_local a CROSS JOIN b CROSS JOIN c CROSS JOIN d)"
[{"n":256}]
```

**Unit tests** (`cargo test -p runtime-datafusion --lib managed_runtime`) — 7 passed,
0 failed.

**Neuter-verified.** With only the production `poll_next` reverted to the pre-fix shape and
the tests left untouched, exactly the three failure-direction guards fail and the
preserved-direction guard plus all three pre-existing tests stay green:

```
---- driver_panic_after_stream_start_is_an_error_not_an_empty_success stdout ----
expected exactly one error item, got []

---- driver_panic_after_a_batch_yields_the_batch_then_the_error stdout ----
expected one batch then one error, got [Ok(RecordBatch { ... row_count: 3 })]

failures:
    driver_cancelled_after_stream_start_is_an_error
    driver_panic_after_a_batch_yields_the_batch_then_the_error
    driver_panic_after_stream_start_is_an_error_not_an_empty_success

test result: FAILED. 4 passed; 3 failed
```

Since making the guards barrier-based they fail on the barrier assertion itself rather than
on a scheduling race — **5 of 5 neutered runs FAILED, 5 of 5 fixed runs passed**:

```
the stream ended while the driver's outcome was still unknown —
a panicking query would be reported to the client as an empty success
```

**The end-to-end guard is neuter-verified too**, and reproduces the empty success through the
real query path on the first attempt:

```
$ cargo test -p runtime --test query_panic_is_an_error     # production code neutered
attempt 1: a query whose execution panicked returned success with 0 batch(es) and 0 row(s);
a client cannot tell this apart from a query that legitimately matched no rows
test result: FAILED. 0 passed; 1 failed

$ cargo test -p runtime --test query_panic_is_an_error     # with the fix, 5 runs
test result: ok. 1 passed; 0 failed          (x5)
```

## Performance impact

The common path gets slightly cheaper: every batch previously polled the `JoinHandle` before
the receiver, and now polls the receiver first. No extra work is added on the streaming path;
the handle is polled only after the channel closes.

## Review gate

- Adversarial review: **skipped** — no engine available. `codex` was attempted and failed;
  its own reason, from the receipt log: `Codex error: Your workspace is out of credits. Ask
  your workspace owner to refill in order to continue.` `grok` is `result=not-installed`.
  Receipt: `engine=none exit=1 verdict=unparsed job=none`.
  In its place the diff was re-read against all three call sites of
  `run_record_batch_stream_on_runtime`, which resolved three questions:
  (1) no hang is possible — `batch_tx` is dropped only as the driver task ends, so a closed
  channel guarantees the handle resolves; (2) no caller depends on a cancelled driver
  producing a clean EOF — the only `abort()` of this handle is in `Drop`; (3) the
  `refresh_task.rs` call site benefits, since a truncated refresh would previously have
  written partial data as a success.
- `/security-review`: no findings. The diff parses no input and touches no route, authz
  check, path, or credential. The one new message formats a `tokio::task::JoinError`, the same
  class and source as the pre-existing line beside it.
- Adversarial review, second iteration (the review-comment fixes): **skipped** — same
  engine state, `codex` `exit=1` with `Your workspace is out of credits`, `grok`
  `not-installed`. Receipt `engine=none exit=1`.
- `/security-review`, second iteration: that iteration's diff is entirely test code — a new
  test binary plus changes inside `mod tests` — which carries no production attack surface.
- `/simplify`: one fix applied, one skipped. Applied: extracted a shared `test_batch`
  helper from two new tests that built the same batch inline. Skipped as out of scope:
  `FlightEncodeStream` and `RuntimeDriverStream` are now structurally identical and could
  share a generic, but that would rewrite an untouched file whose drain branch is interleaved
  with egress accounting.

## Review round

Both of Copilot's findings were valid and are fixed rather than deferred:

1. *The guards instantiate the private `RuntimeDriverStream` directly, so they cannot catch a
   later layer converting the stream error back into a successful empty response.* Correct —
   added `crates/runtime/tests/query_panic_is_an_error.rs`, which drives a panicking scalar
   UDF through the real `Query::run` path. It uses a purpose-built UDF rather than the
   `concat` untyped-NULL panic this bug was found through, because that panic is itself
   being fixed under #13877 and a test built on it would break when it lands. It also
   **refuses a planning failure** instead of counting it as the correct outcome — the first
   version of the test asserted nothing at all, because the UDF signature rejected the call
   and a bare error check hid it; the neuter run is what caught that.
2. *The 50 ms sleep does not make the ordering deterministic — if the test task is
   descheduled past it, the driver finishes first and the pre-fix code passes the guard.*
   Correct, and the guards now use two one-shot barriers as suggested: the driver closes the
   channel, signals, and is released only after the stream has been polled once, so the first
   poll provably sees a closed channel and a pending handle. Neutered, they now fail on that
   assertion on 5 of 5 runs.

## Follow-up filed

The panic itself is a separate defect and is **not** fixed here: `concat` with an untyped
`NULL` literal reaches `_ => unreachable!("concat")` in the `concat` kernel
(`datafusion-functions`, patched to the `spiceai/datafusion` fork, branch `spiceai-54`).
#13876 flagged that as a separate concern in its acceptance criteria; filed as #13877 with the
measurement and the fork-patch requirements. This PR fixes the reporting half — a panicking
query never returns a success response — which is the acceptance criterion #13876 is titled
for.

Fixes #13876

## Checklist

- [x] Reproduced the reported failure on `trunk` before writing the fix
- [x] Demonstrated the failure's absence on this branch with the same command
- [x] Regression tests added, and neuter-verified against the pre-fix code
- [x] Preserved directions verified (legitimately-empty result, normal streaming)
- [x] Bug-class sweep: the one sibling with this shape (`FlightEncodeStream`) was already correct
- [x] `make signoff` green (12605 tests passed) and `Attestation` re-run
