### PR TITLE
ci: stop scheduled search benchmarks

### DIFF
--- a/.github/workflows/testoperator_dispatch_search.yml
+++ b/.github/workflows/testoperator_dispatch_search.yml
@@ -1,9 +1,6 @@
 name: testoperator dispatch search
 
 on:
-  schedule:
-    - cron: '0 6 * * 2,5' # Every Monday and Thursday at 8pm PST (6am UTC next day)
-
   workflow_dispatch:
     inputs:
       spiced_commit:


### PR DESCRIPTION
## WHAT
Stop the full search benchmark matrix from running automatically while retaining manual dispatch.

## WHY
The search suite saturates the shared dev runner cluster for hours and blocks other GitHub Actions jobs.

## HOW
Remove the twice-weekly cron trigger from the search benchmark dispatcher and leave `workflow_dispatch` available for deliberate runs.