### PR TITLE
fix(search): classify a partially non-finite embedding as unindexable on every backend (fixes #13872)

### DIFF
--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -328,21 +328,18 @@ fn build_documents(
             });
         }
 
-        if embedding.iter().all(|&x| x == 0.0 || x.is_nan()) {
-            zero_or_nan_skips += 1;
-            if zero_or_nan_samples.len() < SAMPLE_LIMIT {
-                zero_or_nan_samples.push(row);
-            }
-            if let Some(id) = primary_keys[row].as_ref() {
-                outcomes.push((id.as_str(), write_util::RowOutcome::Rejected));
-            }
-            continue;
-        }
-
-        if embedding.iter().any(|x| !x.is_finite()) {
-            non_finite_skips += 1;
-            if non_finite_samples.len() < SAMPLE_LIMIT {
-                non_finite_samples.push(row);
+        if let Some(rejection) = write_util::classify_vector(embedding) {
+            let (skips, samples) = match rejection {
+                write_util::VectorRejection::NoDirection => {
+                    (&mut zero_or_nan_skips, &mut zero_or_nan_samples)
+                }
+                write_util::VectorRejection::NonFinite => {
+                    (&mut non_finite_skips, &mut non_finite_samples)
+                }
+            };
+            *skips += 1;
+            if samples.len() < SAMPLE_LIMIT {
+                samples.push(row);
             }
             if let Some(id) = primary_keys[row].as_ref() {
                 outcomes.push((id.as_str(), write_util::RowOutcome::Rejected));
@@ -1010,6 +1007,7 @@ mod tests {
         use crate::index::elasticsearch::{
             ElasticsearchIndex, ElasticsearchIndexWriteMaintenance, unused_client,
         };
+        use crate::index::write_util;
         use crate::metadata::MetadataColumns;
 
         const DIMS: i32 = 2;
@@ -1127,6 +1125,45 @@ mod tests {
             assert_eq!(
                 evicted(&[1, 2], &[Some(vec![1.0, 2.0]), None]),
                 vec!["2".to_string()],
+            );
+        }
+
+        /// Regression test for #13872. Elasticsearch already rejected every shape, so this
+        /// is the guard that keeps it aligned with the other two backends rather than a
+        /// behaviour change — and it runs the same shared list they do, so a shape added
+        /// for one backend cannot quietly go uncovered here.
+        #[test]
+        fn every_unindexable_shape_evicts_its_document_and_indexes_nothing() {
+            let ids = [1, 2, 1];
+            for (name, deciding, _) in write_util::unindexable_shapes(2) {
+                let embeddings = [Some(vec![1.0, 2.0]), Some(vec![3.0, 4.0]), Some(deciding)];
+                assert_eq!(
+                    evicted(&ids, &embeddings),
+                    vec!["1".to_string()],
+                    "the deciding row for _id 1 carries a {name} vector, so the document \
+                     the earlier row stored answers a search from text it no longer has"
+                );
+                assert_eq!(
+                    indexed_ids(&ids, &embeddings),
+                    vec!["2".to_string()],
+                    "re-indexing the earlier row would restore the document just deleted"
+                );
+            }
+        }
+
+        /// The control: an ordinary vector in the same position is stored and evicts nothing.
+        #[test]
+        fn an_ordinary_deciding_vector_evicts_nothing() {
+            let ids = [1, 2, 1];
+            let embeddings = [
+                Some(vec![1.0, 2.0]),
+                Some(vec![3.0, 4.0]),
+                Some(write_util::indexable_shape(2)),
+            ];
+            assert!(evicted(&ids, &embeddings).is_empty());
+            assert_eq!(
+                indexed_ids(&ids, &embeddings),
+                vec!["1".to_string(), "2".to_string(), "1".to_string()],
             );
         }
 

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -209,11 +209,12 @@ impl MemoryVectorIndex {
         for (key, vector) in primary_keys.iter().zip(embedding_vectors.iter()) {
             rows.push(match (key, vector) {
                 (Some(key), Some(vector)) => {
-                    // All-zero / all-NaN vectors have no defined direction and
-                    // would corrupt similarity scores — skip them.
-                    if vector.iter().all(|&v| v == 0.0 || v.is_nan()) {
+                    // A vector with no defined direction would corrupt similarity scores —
+                    // skip it, and evict whatever the key already holds.
+                    if let Some(rejection) = write_util::classify_vector(vector) {
+                        let reason = rejection.reason();
                         tracing::warn!(
-                            "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes or contains only invalid values. Any vector already stored for this record is removed, so it is not returned at its previous value"
+                            "Skipping record '{key}' for memory vector index '{INDEX_NAME}': {reason}. Any vector already stored for this record is removed, so it is not returned at its previous value"
                         );
                         Some((key.as_str(), write_util::RowOutcome::Rejected))
                     } else {
@@ -528,6 +529,9 @@ mod tests {
     struct ByteEmbed;
 
     fn byte_vector(text: &str) -> Vec<f32> {
+        if let Some(shape) = unindexable_shape(text) {
+            return shape;
+        }
         let dim = usize::try_from(DIM).expect("DIM is positive");
         let mut vector = vec![0.0_f32; dim];
         for (i, b) in text.bytes().enumerate() {
@@ -565,6 +569,23 @@ mod tests {
                 ))
             }),
         ))
+    }
+
+    /// Text that embeds to the `n`th shape of [`write_util::unindexable_shapes`], so a row
+    /// can carry one through the real embed -> classify -> store path.
+    fn unindexable_text(n: usize) -> String {
+        format!("\u{1}shape:{n}")
+    }
+
+    /// Resolve [`unindexable_text`] back to its vector, so the fixture cannot cover a
+    /// narrower set than the classifier's own test does.
+    fn unindexable_shape(text: &str) -> Option<Vec<f32>> {
+        let n: usize = text.strip_prefix("\u{1}shape:")?.parse().ok()?;
+        let dim = usize::try_from(DIM).expect("DIM is positive");
+        write_util::unindexable_shapes(dim)
+            .into_iter()
+            .nth(n)
+            .map(|(_, vector, _)| vector)
     }
 
     fn memory_index() -> MemoryVectorIndex {
@@ -1026,5 +1047,64 @@ mod tests {
             }
         }
         None
+    }
+
+    /// Regression test for #13872. One batch carries id=1 twice and the row that *decides*
+    /// it embeds to a vector the index cannot use. Before the shared classifier, only the
+    /// all-zero / all-NaN shapes were a rejection here, so a partially non-finite deciding
+    /// row evicted nothing: search kept answering id=1 at the vector its previous text
+    /// produced, and the unusable vector was stored beside it.
+    #[tokio::test]
+    async fn every_unindexable_shape_evicts_its_key_and_stores_nothing() {
+        let dim = usize::try_from(DIM).expect("DIM is positive");
+        for (n, (name, _, _)) in write_util::unindexable_shapes(dim).into_iter().enumerate() {
+            let index = memory_index();
+            let deciding = unindexable_text(n);
+            write_batch(
+                &index,
+                batch_with_contents(
+                    &[1, 2, 1],
+                    &[Some("first"), Some("other"), Some(deciding.as_str())],
+                ),
+            )
+            .await;
+
+            assert_eq!(
+                indexed_ids(&index),
+                vec![2],
+                "id=1's deciding row embeds to a {name} vector, so no vector for it may \
+                 remain searchable"
+            );
+            assert_eq!(
+                stored_vector(&index, 1),
+                None,
+                "the vector of the text the same batch replaced is exactly what must not \
+                 survive"
+            );
+        }
+    }
+
+    /// The fixture is only meaningful if the sentinel texts really embed to the shapes the
+    /// classifier rejects — otherwise the guard above passes for the wrong reason.
+    #[test]
+    fn the_unindexable_fixture_really_embeds_to_a_rejected_vector() {
+        let dim = usize::try_from(DIM).expect("DIM is positive");
+        for (n, (name, vector, expected)) in
+            write_util::unindexable_shapes(dim).into_iter().enumerate()
+        {
+            let embedded = byte_vector(&unindexable_text(n));
+            // `total_cmp` rather than `==`, so `NaN` compares equal to itself and the two
+            // vectors are held to the bit patterns they actually carry. Lengths first,
+            // because `zip` would otherwise pass a prefix off as the whole shape.
+            assert_eq!(embedded.len(), vector.len());
+            assert!(
+                embedded
+                    .iter()
+                    .zip(vector.iter())
+                    .all(|(a, b)| a.total_cmp(b) == std::cmp::Ordering::Equal),
+                "the sentinel text for {name} must embed to that shape"
+            );
+            assert_eq!(write_util::classify_vector(&embedded), Some(expected));
+        }
     }
 }

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -331,15 +331,17 @@ fn filter_zero_vectors(
         .zip(primary_keys.iter())
         .map(|(embedding, key)| {
             let outcome = match embedding {
-                // Single pass: check if all values are zero or NaN (both are invalid embeddings)
-                Some(embedding) if embedding.iter().all(|&x| x == 0.0 || x.is_nan()) => {
-                    let key_str = key.as_deref().unwrap_or("unknown");
-                    tracing::warn!(
-                        "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values. Any vector already stored for this record is removed, so it is not returned at its previous value"
-                    );
-                    write_util::RowOutcome::Rejected
-                }
-                Some(_) => write_util::RowOutcome::Indexed,
+                Some(embedding) => match write_util::classify_vector(embedding) {
+                    Some(rejection) => {
+                        let key_str = key.as_deref().unwrap_or("unknown");
+                        let reason = rejection.reason();
+                        tracing::warn!(
+                            "Skipping record '{key_str}' for S3 Vector index '{index_name}': {reason}. Any vector already stored for this record is removed, so it is not returned at its previous value"
+                        );
+                        write_util::RowOutcome::Rejected
+                    }
+                    None => write_util::RowOutcome::Indexed,
+                },
                 // `write_data` skips a row whose embedding is `None` (a NULL or empty search
                 // text), so those keys keep whatever vector an earlier text stored.
                 None => write_util::RowOutcome::Rejected,
@@ -392,6 +394,64 @@ mod tests {
     use super::*;
     use arrow::array::{Int32Array, UnionArray};
     use arrow_schema::{DataType, Schema, UnionFields, UnionMode};
+
+    /// Regression test for #13872. The batch carries one key twice and the row that
+    /// *decides* it carries a vector the index cannot use. Before the shared classifier,
+    /// only the all-zero / all-NaN shapes were a rejection here, so a partially non-finite
+    /// deciding row evicted nothing and the stale vector stayed searchable — while the
+    /// unusable vector was itself put alongside it.
+    #[test]
+    fn every_unindexable_shape_evicts_its_key_and_is_not_put() {
+        for (name, deciding, _) in write_util::unindexable_shapes(2) {
+            let embeddings = vec![
+                Some(vec![1.0_f32, 2.0]),
+                Some(vec![3.0_f32, 4.0]),
+                Some(deciding),
+            ];
+            let keys = vec![
+                Some("same".to_string()),
+                Some("other".to_string()),
+                Some("same".to_string()),
+            ];
+            let (kept, kept_keys, _metadata, evicted) =
+                filter_zero_vectors(embeddings, keys, HashMap::new(), "test_index");
+
+            assert_eq!(
+                evicted,
+                vec!["same".to_string()],
+                "the deciding row for 'same' is a {name} vector, so whatever S3 Vectors \
+                 already holds under that key must be removed"
+            );
+            assert_eq!(
+                kept_keys.into_iter().flatten().collect::<Vec<_>>(),
+                vec!["other".to_string()],
+                "the delete runs before the put, so putting the earlier row would restore \
+                 the entry the eviction exists to remove"
+            );
+            assert_eq!(kept.len(), 1);
+        }
+    }
+
+    /// The control: an ordinary deciding vector leaves both rows in the put and evicts
+    /// nothing, so the guard above is measuring the shapes and not the repeated key.
+    #[test]
+    fn an_ordinary_deciding_vector_evicts_nothing_and_puts_every_row() {
+        let embeddings = vec![
+            Some(vec![1.0_f32, 2.0]),
+            Some(vec![3.0_f32, 4.0]),
+            Some(write_util::indexable_shape(2)),
+        ];
+        let keys = vec![
+            Some("same".to_string()),
+            Some("other".to_string()),
+            Some("same".to_string()),
+        ];
+        let (kept, _kept_keys, _metadata, evicted) =
+            filter_zero_vectors(embeddings, keys, HashMap::new(), "test_index");
+
+        assert!(evicted.is_empty());
+        assert_eq!(kept.len(), 3);
+    }
 
     #[test]
     fn test_filter_zero_vectors() {

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -294,14 +294,15 @@ pub fn extract_and_format_metadata(
 
 /// Filter out the rows this batch will not store a vector for.
 ///
-/// A vector is dropped when it consists entirely of invalid values (zeros and/or NaNs).
-/// A vector with any valid non-zero, non-NaN value is kept.
-/// For example:
-/// - `[0.0, 0.0]` -> filtered (all zeros)
-/// - `[NaN, NaN]` -> filtered (all NaN)
-/// - `[0.0, NaN]` -> filtered (all values are either zero or NaN)
-/// - `[1.0, 0.0]` -> kept (has a valid non-zero value)
-/// - `[1.0, NaN]` -> kept (has a valid non-NaN value)
+/// A vector is dropped when it has no defined direction under any metric the index offers,
+/// which [`write_util::classify_vector`] decides: every component zero or `NaN`, or any
+/// component non-finite. For example:
+/// - `[0.0, 0.0]` -> filtered (no direction: all zero)
+/// - `[NaN, NaN]` -> filtered (no direction: all NaN)
+/// - `[0.0, NaN]` -> filtered (no direction: every component is zero or NaN)
+/// - `[1.0, NaN]` -> filtered (non-finite: every distance to it is `NaN`)
+/// - `[0.0, Inf]` -> filtered (non-finite, and note the all-zero test does not catch it)
+/// - `[1.0, 0.0]` -> kept (a finite, non-zero direction)
 ///
 /// The fourth element is the keys this batch will not store a vector for and so must
 /// delete, per [`write_util::keys_to_evict`]. It covers the rows filtered here and the

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -344,6 +344,122 @@ pub fn create_embedding_array(
     Ok(Arc::new(builder.finish()))
 }
 
+/// Why a write cannot index a vector.
+///
+/// The variants are the two shapes [`keys_to_evict`] names, kept apart because each has
+/// its own diagnostic on the paths that count them separately, not because they call for
+/// different handling: both are [`RowOutcome::Rejected`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VectorRejection {
+    /// No component carries a direction — every one is zero or `NaN`, so the vector points
+    /// nowhere and a cosine distance to it is undefined.
+    NoDirection,
+    /// At least one component is `NaN` or `±Inf`, so every metric the index offers answers
+    /// `NaN`/`Inf` for this vector whatever it is compared against.
+    NonFinite,
+}
+
+impl VectorRejection {
+    /// The cause clause for the user-facing line the caller logs, worded to sit after the
+    /// name of the record being skipped.
+    #[must_use]
+    pub fn reason(self) -> &'static str {
+        match self {
+            Self::NoDirection => "its embedding has no direction — every component is zero or NaN",
+            Self::NonFinite => {
+                "its embedding has a NaN or infinite component, so every distance to it is undefined"
+            }
+        }
+    }
+}
+
+/// Whether a vector can be indexed, by the one criterion [`keys_to_evict`] states: it must
+/// have a defined direction under the metrics the index offers.
+///
+/// Every vector write path classifies through this rather than spelling the test itself.
+/// The three paths did spell it separately, and two of the three carried only the
+/// [`VectorRejection::NoDirection`] limb — so a *partially* non-finite vector (`[1.0, NaN]`,
+/// `[0.0, Inf]`) was stored as if it were indexable and, being no rejection, evicted
+/// nothing (#13872). `Inf` is neither `== 0.0` nor `is_nan()`, so it does not merely escape
+/// the narrow limb, it actively prevents it from matching.
+///
+/// `NoDirection` is tested first so that a vector which is both — `[NaN, NaN]` — is
+/// reported under the more specific of the two, which is what the paths counting the
+/// two separately have always reported it as.
+#[must_use]
+pub fn classify_vector(vector: &[f32]) -> Option<VectorRejection> {
+    if vector.iter().all(|&x| x == 0.0 || x.is_nan()) {
+        return Some(VectorRejection::NoDirection);
+    }
+    if vector.iter().any(|x| !x.is_finite()) {
+        return Some(VectorRejection::NonFinite);
+    }
+    None
+}
+
+/// The vector shapes no index may store, as `dims`-component vectors paired with the
+/// rejection each must classify as.
+///
+/// Shared by the classifier's own test and by every backend's guard, so a backend cannot
+/// come to cover a narrower set than the criterion does — which is the shape of #13872,
+/// where two of three backends carried only the [`VectorRejection::NoDirection`] limb.
+/// `dims` must be at least 2, since the partially non-finite shapes need a finite
+/// component to sit beside the non-finite one.
+#[cfg(test)]
+pub(crate) fn unindexable_shapes(dims: usize) -> Vec<(&'static str, Vec<f32>, VectorRejection)> {
+    assert!(
+        dims >= 2,
+        "a partially non-finite shape needs two components"
+    );
+    let last = dims - 1;
+    let with_last = |fill: f32, last_value: f32| {
+        let mut vector = vec![fill; dims];
+        vector[last] = last_value;
+        vector
+    };
+    vec![
+        ("all zero", vec![0.0; dims], VectorRejection::NoDirection),
+        (
+            "all NaN",
+            vec![f32::NAN; dims],
+            VectorRejection::NoDirection,
+        ),
+        (
+            "finite, one NaN",
+            with_last(1.0, f32::NAN),
+            VectorRejection::NonFinite,
+        ),
+        (
+            "finite, one +Inf",
+            with_last(1.0, f32::INFINITY),
+            VectorRejection::NonFinite,
+        ),
+        (
+            "finite, one -Inf",
+            with_last(1.0, f32::NEG_INFINITY),
+            VectorRejection::NonFinite,
+        ),
+        (
+            "all +Inf",
+            vec![f32::INFINITY; dims],
+            VectorRejection::NonFinite,
+        ),
+        (
+            "zero, one +Inf",
+            with_last(0.0, f32::INFINITY),
+            VectorRejection::NonFinite,
+        ),
+    ]
+}
+
+/// A vector every backend must store, as the control the shapes above are measured
+/// against. Deliberately the `1.0`-filled base of the partially non-finite shapes, so the
+/// only difference between this and a rejection is the one component under test.
+#[cfg(test)]
+pub(crate) fn indexable_shape(dims: usize) -> Vec<f32> {
+    vec![1.0; dims]
+}
+
 /// What a write did with one row, for the row's primary key.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RowOutcome {
@@ -779,5 +895,33 @@ mod tests {
         assert_eq!(keys[0].as_deref(), Some("{\"id\":1,\"tenant\":\"a\"}"));
         assert_eq!(keys[1].as_deref(), Some("{\"tenant\":\"b\"}"));
         assert_eq!(keys[2], None);
+    }
+
+    /// Regression test for #13872. The criterion [`keys_to_evict`] states covers every
+    /// vector with no usable direction, and the classifier is the one place it is spelled.
+    #[test]
+    fn classify_vector_rejects_every_unindexable_shape() {
+        for (name, vector, expected) in unindexable_shapes(3) {
+            assert_eq!(
+                classify_vector(&vector),
+                Some(expected),
+                "{name} has no defined direction under any metric an index offers"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_vector_accepts_an_ordinary_vector() {
+        assert_eq!(classify_vector(&indexable_shape(3)), None);
+    }
+
+    /// A vector that is both all-NaN and non-finite is reported as the more specific of
+    /// the two, which is what the paths counting them separately have always logged it as.
+    #[test]
+    fn an_all_nan_vector_is_reported_as_having_no_direction() {
+        assert_eq!(
+            classify_vector(&[f32::NAN, f32::NAN]),
+            Some(VectorRejection::NoDirection)
+        );
     }
 }

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -376,12 +376,17 @@ impl VectorRejection {
 /// Whether a vector can be indexed, by the one criterion [`keys_to_evict`] states: it must
 /// have a defined direction under the metrics the index offers.
 ///
-/// Every vector write path classifies through this rather than spelling the test itself.
-/// The three paths did spell it separately, and two of the three carried only the
+/// The three write paths that participate in [`keys_to_evict`] — Elasticsearch, the
+/// in-memory index, and S3 Vectors — classify through this rather than spelling the test
+/// themselves. They did spell it separately, and two of the three carried only the
 /// [`VectorRejection::NoDirection`] limb — so a *partially* non-finite vector (`[1.0, NaN]`,
 /// `[0.0, Inf]`) was stored as if it were indexable and, being no rejection, evicted
 /// nothing (#13872). `Inf` is neither `== 0.0` nor `is_nan()`, so it does not merely escape
 /// the narrow limb, it actively prevents it from matching.
+///
+/// **Not every vector write reaches this.** The DuckDB vector index applies no criterion at
+/// all, and `PutVectors`' DataFusion sink spells its own — see #13901. Do not read a call to
+/// this as a guarantee that some other path enforced it.
 ///
 /// `NoDirection` is tested first so that a vector which is both — `[NaN, NaN]` — is
 /// reported under the more specific of the two, which is what the paths counting the
@@ -400,9 +405,10 @@ pub fn classify_vector(vector: &[f32]) -> Option<VectorRejection> {
 /// The vector shapes no index may store, as `dims`-component vectors paired with the
 /// rejection each must classify as.
 ///
-/// Shared by the classifier's own test and by every backend's guard, so a backend cannot
-/// come to cover a narrower set than the criterion does — which is the shape of #13872,
-/// where two of three backends carried only the [`VectorRejection::NoDirection`] limb.
+/// Shared by the classifier's own test and by the guard of each backend that classifies
+/// through it, so one of them cannot come to cover a narrower set than the criterion does —
+/// which is the shape of #13872, where two of the three carried only the
+/// [`VectorRejection::NoDirection`] limb.
 /// `dims` must be at least 2, since the partially non-finite shapes need a finite
 /// component to sit beside the non-finite one.
 #[cfg(test)]


### PR DESCRIPTION
## Summary

The three vector-index write paths share one criterion for a vector they cannot index —
[`write_util::keys_to_evict`](https://github.com/spiceai/spiceai/blob/trunk/crates/search/src/index/write_util.rs)
states it as *"a vector with no defined direction under any metric the index offers"* — but
each path spelled the test itself, and only Elasticsearch spelled it fully:

```rust
// elasticsearch/write.rs — both limbs
if embedding.iter().all(|&x| x == 0.0 || x.is_nan()) { /* rejected */ }
if embedding.iter().any(|x| !x.is_finite())          { /* rejected */ }

// s3_vectors/write.rs and memory/mod.rs — the second limb is absent
embedding.iter().all(|&x| x == 0.0 || x.is_nan())
```

`Inf` is neither `== 0.0` nor `is_nan()`, so on the two narrow paths it does not merely
escape the limb — it actively prevents the `all(...)` from matching. A **partially**
non-finite vector (`[1.0, NaN]`, `[0.0, Inf]`) was therefore classified indexable and stored.

Because that is not a rejection, a **repeated primary key whose deciding (last) row carries
such a vector evicted nothing**: search kept answering the key at the vector its previous
text produced, while the unusable vector was stored beside it. That is the exact shape #13848
exists to remove, surviving because the classifier disagreed with the criterion.

## Changes

- **`write_util`**: new `classify_vector` returning `Option<VectorRejection>` — the one place
  the criterion is spelled. `VectorRejection::{NoDirection, NonFinite}` keeps the two
  diagnostics the Elasticsearch path counts separately, and `reason()` supplies each one's
  wording for the user-facing skip warning.
- **The three write paths** classify through it. Elasticsearch's behaviour is unchanged
  (it already tested both limbs); the in-memory index and S3 Vectors now reject the
  partially non-finite shapes and evict the key.
- **The skip warning** now names which of the two reasons applied, instead of the single
  `"Embedding vector is all zeroes or contains only invalid values"` line that named neither
  and was wrong for a `[1.0, Inf]` vector in both halves.
- **One shared shape list**, `write_util::unindexable_shapes`, drives the classifier's own
  test *and* all three backend guards — so a backend cannot come to cover a narrower set
  than the criterion again, which is how this bug arose.

## Test plan

Feature set held constant across every command: `--features elasticsearch` on top of the
crate's defaults (`s3_vectors`, `text_search`), since the Elasticsearch path is not a default
feature and is one of the three under test.

### Before — the divergence, on this PR's base

Probes driving each backend's real builder (`build_documents`, `filter_zero_vectors`,
`MemoryVectorIndex::batch_for_store`) with one primary key carried twice: an indexable
`[1.0, 2.0]` first, then the row that *decides* the key.

```
PROBE es     deciding=[1,NaN]      evicted=["1"] indexed=["2"]
PROBE es     deciding=[1,Inf]      evicted=["1"] indexed=["2"]
PROBE es     deciding=[1,-Inf]     evicted=["1"] indexed=["2"]
PROBE es     deciding=[Inf,Inf]    evicted=["1"] indexed=["2"]
PROBE es     deciding=[0,Inf]      evicted=["1"] indexed=["2"]
PROBE es     deciding=[NaN,NaN]    evicted=["1"] indexed=["2"]
PROBE es     deciding=[0,0]        evicted=["1"] indexed=["2"]
PROBE es     deciding=[3,4]        evicted=[]    indexed=["1", "2", "1"]

PROBE s3     deciding=[1,NaN]      evicted=[]        rows_put=3 put_keys=["same", "other", "same"]
PROBE s3     deciding=[1,Inf]      evicted=[]        rows_put=3 put_keys=["same", "other", "same"]
PROBE s3     deciding=[1,-Inf]     evicted=[]        rows_put=3 put_keys=["same", "other", "same"]
PROBE s3     deciding=[Inf,Inf]    evicted=[]        rows_put=3 put_keys=["same", "other", "same"]
PROBE s3     deciding=[0,Inf]      evicted=[]        rows_put=3 put_keys=["same", "other", "same"]
PROBE s3     deciding=[NaN,NaN]    evicted=["same"]  rows_put=1 put_keys=["other"]
PROBE s3     deciding=[0,0]        evicted=["same"]  rows_put=1 put_keys=["other"]

PROBE memory deciding=[1,NaN,1]    indexed=[1, 1, 2] stored_vector_1=Some([0.8509804, 0.8666667, 0.44705883])
PROBE memory deciding=[1,Inf,1]    indexed=[1, 1, 2] stored_vector_1=Some([0.8509804, 0.8666667, 0.44705883])
PROBE memory deciding=[1,-Inf,1]   indexed=[1, 1, 2] stored_vector_1=Some([0.8509804, 0.8666667, 0.44705883])
PROBE memory deciding=[Inf;3]      indexed=[1, 1, 2] stored_vector_1=Some([0.8509804, 0.8666667, 0.44705883])
PROBE memory deciding=[0,Inf,0]    indexed=[1, 1, 2] stored_vector_1=Some([0.8509804, 0.8666667, 0.44705883])
PROBE memory deciding=[NaN;3]      indexed=[2]       stored_vector_1=None
PROBE memory deciding=[0;3]        indexed=[2]       stored_vector_1=None
```

`stored_vector_1 = [0.8509804, 0.8666667, 0.44705883]` is the embedding of the row's
**earlier** text — the stale vector a search would go on returning.

### After — the same probes on this branch

```
PROBE es     deciding=<all 7 shapes>  evicted=["1"]     indexed=["2"]
PROBE es     deciding=[3,4]           evicted=[]        indexed=["1", "2", "1"]
PROBE s3     deciding=<all 7 shapes>  evicted=["same"]  rows_put=1 put_keys=["other"]
PROBE s3     deciding=[3,4]           evicted=[]        rows_put=3 put_keys=["same", "other", "same"]
PROBE memory deciding=<all 7 shapes>  indexed=[2]       stored_vector_1=None
```

All three agree on all seven shapes, and the ordinary-vector control is untouched.

### The guards fail on the old predicate

The probes were replaced by permanent guards. To show they discriminate, the two narrow
predicates were temporarily restored underneath the new tests:

```
test index::s3_vectors::write::tests::every_unindexable_shape_evicts_its_key_and_is_not_put ... FAILED
  assertion `left == right` failed: the deciding row for 'same' is a finite, one NaN vector,
  so whatever S3 Vectors already holds under that key must be removed
  left: []   right: ["same"]

test index::memory::tests::every_unindexable_shape_evicts_its_key_and_stores_nothing ... FAILED
  assertion `left == right` failed: id=1's deciding row embeds to a finite, one NaN vector,
  so no vector for it may remain searchable
  left: [1, 1, 2]   right: [2]

test result: FAILED. 7 passed; 2 failed
```

The Elasticsearch guard passes both ways — that backend was already correct, so its guard is
an alignment guard, not a regression guard, and this PR claims no behaviour change there.

### Green on the fix

```
$ cargo test -p search --lib --features elasticsearch
test result: ok. 272 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo clippy -p search --features elasticsearch --tests --no-deps
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 32s
```

The repo gate — `make lint` and `make nextest` — runs via `make signoff` on the pushed head;
its result is recorded on the PR by the `Attestation` check.

**One unattributed failure, reported rather than glossed:** an early run of the suite
returned `271 passed; 1 failed` and the harness output was filtered down to the summary line,
so the test name was lost. It did not recur in **14** subsequent full runs (6 at the default
thread count, 8 at `--test-threads=16`), on a host that had a peer `make signoff`, a
`cargo test` and a `cargo-nextest` in flight throughout. I could not identify it and so
cannot attribute it to this diff or exclude it; recording it here rather than treating 14
green runs as proof it never happened.

## Review gate

- Adversarial review: **skipped** — engine `codex` ran and failed, on both the original
  diff and again on the current head `a71d11649c`. Each receipt records
  `attempt=codex result=exit-1`, `engine=none`, `exit=1`, `job=none`, and the engine's own
  reason verbatim: *"Codex error: Your workspace is out of credits. Ask your workspace owner
  to refill in order to continue."* The `grok` fallback is not installed on this host
  (`attempt=grok result=not-installed`; only `openai-codex` is present under
  `~/.claude/plugins/cache/`). Not substituted with `rescue`.
- `/security-review`: ran, **no findings**. The diff adds a numeric predicate, a closed
  two-variant enum whose `reason()` returns one of two `&'static str` literals, and
  `#[cfg(test)]` fixtures. No query, command, path, or deserialization surface is added; the
  only interpolated user value in the two reworded `tracing::warn!` lines (`key` / `key_str`)
  was already present and is unchanged; no new dependency and no `unsafe`.
- `/simplify`: ran — **two cleanups applied, one finding rejected**.
  - `indexable_shape` built its control with `1.0 + f32::from(u8::try_from(i).unwrap_or(0))`,
    which silently collapses above 256 dimensions; replaced with `vec![1.0; dims]`, which is
    also the exact base of the partially non-finite shapes, so the control now differs from a
    rejection in precisely the component under test.
  - The fixture assertion compared floats with `==` plus a NaN special case. `clippy::float_cmp`
    caught it, and the fix exposed a second defect the lint did not: `zip` would have passed a
    length-mismatched prefix off as the whole shape. Now `assert_eq!` on the lengths, then
    `total_cmp`, which also makes the NaN special case unnecessary.
  - **Rejected:** folding `classify_vector`'s two passes into one loop. The `all(...)` limb
    short-circuits on the first ordinary component, so the common case is already ~one pass,
    and a fused loop cannot short-circuit the non-finite limb either — no win, at the cost of
    a form that no longer auto-vectorizes as obviously.

### Second iteration — Copilot review

Both findings valid, both fixed in `a71d11649c`; the change is rustdoc only, no behaviour.

- **`filter_zero_vectors`' doc still said `[1.0, NaN] -> kept`**, which this PR makes false.
  Rewritten to state the criterion the function now applies, with `[0.0, Inf]` given its own
  line since the all-zero test failing to catch it is the whole shape of the bug.
- **`classify_vector`'s doc claimed "every vector write path classifies through this."**
  That is wrong, and wrong against an issue in this same PR body: #13901 exists precisely
  because the DuckDB index and the `PutVectors` sink do not. Narrowed to the three paths
  that participate in `keys_to_evict`, plus an explicit note that a call here guarantees
  nothing about the others. `unindexable_shapes`' "every backend's guard" narrowed likewise.

Adversarial review re-run on the new head — same declared skip, same reason, recorded above.
`/security-review` not re-run: the iteration changed doc comments only and touched no input
handling, auth, filesystem, network, or secret surface.

## Scope

Two vector write paths outside this issue's three still decide indexability on their own —
the DuckDB vector index applies no criterion at all, and `PutVectors`' DataFusion sink omits
the all-zero limb. Both are outside the three paths #13872 names (one is a fourth backend,
the other a different write path in another crate) and are tracked in #13901 rather than
grown into this PR. That issue labels its own impact claim *unverified, code inspection only*.

Fixes #13872

## Checklist

- [x] Reproduced the reported failure before writing the fix, and re-ran the same probe after
- [x] Regression guards demonstrated failing on the old predicate and passing on the new one
- [x] The whole bug-class fixed together — all three paths the criterion covers, in one change
- [x] Test plan carries the artifact, not a summary of it
- [x] Review gate run and recorded above, including the declared skip and its reason