### PR TITLE
fix(duckdb): pin a connector's DuckDB session to UTC so a dataset's schema does not carry the host timezone (fixes #13899)

### DIFF
--- a/crates/data-connectors/connector-duckdb/src/lib.rs
+++ b/crates/data-connectors/connector-duckdb/src/lib.rs
@@ -25,6 +25,7 @@ limitations under the License.
 
 use async_trait::async_trait;
 use data_components::Read;
+use data_components::duckdb::with_utc_session_timezone;
 use data_connector_api::ConnectorContext;
 use data_connector_api::{
     AnyErrorResult, ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError,
@@ -97,7 +98,7 @@ impl DuckDB {
     ///
     /// Returns an error if the in-memory `DuckDB` connection cannot be established.
     pub fn create_in_memory(params: &ConnectorParams) -> AnyErrorResult<DuckDBTableFactory> {
-        let pool = Arc::new(
+        let pool = Arc::new(with_utc_session_timezone(
             DuckDbConnectionPool::new_memory()
                 .map_err(|source| DataConnectorError::UnableToConnectInternal {
                     dataconnector: "duckdb".to_string(),
@@ -109,7 +110,7 @@ impl DuckDB {
                         .unsupported_type_action
                         .unwrap_or(UnsupportedTypeAction::Error),
                 ),
-        );
+        ));
 
         Ok(Self::with_spice_deny_list(
             DuckDBTableFactory::new(pool).with_dialect(new_duckdb_dialect()),
@@ -122,7 +123,7 @@ impl DuckDB {
     ///
     /// Returns an error if the file-based `DuckDB` connection cannot be established.
     pub fn create_file(path: &str, params: &ConnectorParams) -> AnyErrorResult<DuckDBTableFactory> {
-        let pool = Arc::new(
+        let pool = Arc::new(with_utc_session_timezone(
             DuckDbConnectionPool::new_file(path, &AccessMode::ReadOnly)
                 .map_err(|source| DataConnectorError::UnableToConnectInternal {
                     dataconnector: "duckdb".to_string(),
@@ -134,7 +135,7 @@ impl DuckDB {
                         .unsupported_type_action
                         .unwrap_or(UnsupportedTypeAction::Error),
                 ),
-        );
+        ));
 
         Ok(Self::with_spice_deny_list(
             DuckDBTableFactory::new(pool).with_dialect(new_duckdb_dialect()),

--- a/crates/data-connectors/connector-ducklake/src/lib.rs
+++ b/crates/data-connectors/connector-ducklake/src/lib.rs
@@ -20,6 +20,7 @@ limitations under the License.
 
 use async_trait::async_trait;
 use data_components::Read;
+use data_components::duckdb::with_utc_session_timezone;
 use data_components::ducklake::writer::DuckDbFederatedTableWriter;
 use data_components::ducklake::{
     DuckLakeS3Params, build_ducklake_attach_sql, configure_duckdb_httpfs,
@@ -133,7 +134,7 @@ fn create_ducklake_factory(
     params: &ConnectorParams,
 ) -> AnyErrorResult<(DuckDBTableFactory, Arc<DuckDbConnectionPool>, String)> {
     let pool = if let Some(path) = open_path {
-        Arc::new(
+        Arc::new(with_utc_session_timezone(
             DuckDbConnectionPool::new_file(path, &AccessMode::ReadWrite)
                 .map_err(|source| DataConnectorError::UnableToConnectInternal {
                     dataconnector: "ducklake".to_string(),
@@ -145,9 +146,9 @@ fn create_ducklake_factory(
                         .unsupported_type_action
                         .unwrap_or(UnsupportedTypeAction::Error),
                 ),
-        )
+        ))
     } else {
-        Arc::new(
+        Arc::new(with_utc_session_timezone(
             DuckDbConnectionPool::new_memory()
                 .map_err(|source| DataConnectorError::UnableToConnectInternal {
                     dataconnector: "ducklake".to_string(),
@@ -159,7 +160,7 @@ fn create_ducklake_factory(
                         .unsupported_type_action
                         .unwrap_or(UnsupportedTypeAction::Error),
                 ),
-        )
+        ))
     };
 
     let conn = Arc::clone(&pool).connect_sync().map_err(|source| {

--- a/crates/data_components/src/duckdb.rs
+++ b/crates/data_components/src/duckdb.rs
@@ -110,7 +110,7 @@ mod tests {
     }
 
     /// `with_connection_setup_queries` replaces the whole list, so the pin has to append to
-    /// what a caller already set rather than dropping it — `search`'s DuckDB index relies on a
+    /// what a caller already set rather than dropping it — `search`'s `DuckDB` index relies on a
     /// `LOAD vss` setup query, and losing one would be silent.
     #[test]
     fn the_pin_keeps_the_setup_queries_already_on_the_pool() {

--- a/crates/data_components/src/duckdb.rs
+++ b/crates/data_components/src/duckdb.rs
@@ -18,6 +18,7 @@ use crate::{Read, ReadWrite};
 use async_trait::async_trait;
 use datafusion::{datasource::TableProvider, sql::TableReference};
 use datafusion_table_providers::duckdb::DuckDBTableFactory;
+use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 use std::sync::Arc;
 
 #[async_trait]
@@ -37,5 +38,92 @@ impl ReadWrite for DuckDBTableFactory {
         table_reference: TableReference,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         self.read_write_table_provider(table_reference).await
+    }
+}
+
+/// The statement [`with_utc_session_timezone`] applies.
+pub const SET_UTC_SESSION_TIMEZONE: &str = "SET TimeZone = 'UTC'";
+
+/// Pin a Spice-opened `DuckDB` connection to `UTC`.
+///
+/// `DuckDB` labels a `TIMESTAMPTZ` column it exports to Arrow with the connection's own
+/// `TimeZone`, so an unpinned session makes a dataset's *schema* depend on the host: the same
+/// table reads back as `Timestamp(us, "Asia/Tokyo")` on one machine and `Timestamp(us, "UTC")`
+/// on another. `DataFusion` coerces a naive timestamp literal into the column's zone, and
+/// Arrow reads that literal as wall-clock in it, so `WHERE ts > TIMESTAMP '2024-01-15 15:00:00'`
+/// selects a different set of rows on each host ([#13899](https://github.com/spiceai/spiceai/issues/13899)).
+///
+/// `TimeZone` is a session setting, so this is applied per connection — the same scope the
+/// accelerator uses for it (`accelerator-duckdb`'s `settings::TimeZone`,
+/// `DuckDBSettingScope::Local`). Existing setup queries are kept, and `connect_sync` runs them
+/// in order, so a caller that set its own zone is overridden rather than dropped.
+#[must_use]
+pub fn with_utc_session_timezone(pool: DuckDbConnectionPool) -> DuckDbConnectionPool {
+    let mut queries = pool.connection_setup_queries().to_vec();
+    queries.push(Arc::from(SET_UTC_SESSION_TIMEZONE));
+    pool.with_connection_setup_queries(queries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion_table_providers::sql::db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
+
+    /// Read `TimeZone` back off a connection the pool hands out — the setup queries run on
+    /// `connect_sync`, so a live connection is the only place their effect is observable.
+    fn session_timezone(pool: DuckDbConnectionPool) -> String {
+        let mut conn = Arc::new(pool).connect_sync().expect("connect to DuckDB");
+        conn.as_any_mut()
+            .downcast_mut::<DuckDbConnection>()
+            .expect("DuckDB hands out a DuckDB connection")
+            .get_underlying_conn_mut()
+            .query_row("SELECT current_setting('TimeZone')", [], |row| {
+                row.get::<_, String>(0)
+            })
+            .expect("read the session TimeZone")
+    }
+
+    fn seeded_with(query: &str) -> DuckDbConnectionPool {
+        DuckDbConnectionPool::new_memory()
+            .expect("in-memory DuckDB pool")
+            .with_connection_setup_queries(vec![Arc::from(query)])
+    }
+
+    /// The pool is seeded with a non-UTC zone on purpose: a CI host already running UTC would
+    /// satisfy the second assertion with or without the pin, so the seed is what makes this
+    /// measure something. Without [`with_utc_session_timezone`] the connection stays on
+    /// `Asia/Tokyo`, and a `TIMESTAMPTZ` column then reaches Arrow labelled with it (#13899).
+    #[test]
+    fn the_pin_overrides_a_zone_the_session_already_carries() {
+        assert_eq!(
+            session_timezone(seeded_with("SET TimeZone = 'Asia/Tokyo'")),
+            "Asia/Tokyo",
+            "the seed has to take effect, or the pinned case below proves nothing"
+        );
+
+        assert_eq!(
+            session_timezone(with_utc_session_timezone(seeded_with(
+                "SET TimeZone = 'Asia/Tokyo'"
+            ))),
+            "UTC"
+        );
+    }
+
+    /// `with_connection_setup_queries` replaces the whole list, so the pin has to append to
+    /// what a caller already set rather than dropping it — `search`'s DuckDB index relies on a
+    /// `LOAD vss` setup query, and losing one would be silent.
+    #[test]
+    fn the_pin_keeps_the_setup_queries_already_on_the_pool() {
+        let pinned = with_utc_session_timezone(seeded_with("SET memory_limit = '123MB'"));
+        let queries: Vec<&str> = pinned
+            .connection_setup_queries()
+            .iter()
+            .map(AsRef::as_ref)
+            .collect();
+
+        assert_eq!(
+            queries,
+            vec!["SET memory_limit = '123MB'", SET_UTC_SESSION_TIMEZONE]
+        );
     }
 }

--- a/crates/runtime/src/catalogconnector/ducklake.rs
+++ b/crates/runtime/src/catalogconnector/ducklake.rs
@@ -28,6 +28,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use data_components::RefreshableCatalogProvider;
+use data_components::duckdb::with_utc_session_timezone;
 use data_components::ducklake::provider::{DuckLakeCatalogProvider, DuckLakeFederation};
 use data_components::ducklake::{
     DuckLakeS3Params, build_ducklake_attach_sql, configure_duckdb_httpfs,
@@ -228,7 +229,7 @@ impl CatalogConnector for DuckLakeCatalog {
         let pool =
             tokio::task::spawn_blocking(move || -> super::Result<Arc<DuckDbConnectionPool>> {
                 let pool = if let Some(path) = open_path.as_deref() {
-                    Arc::new(
+                    Arc::new(with_utc_session_timezone(
                         DuckDbConnectionPool::new_file(path, &duckdb_access_mode).map_err(|e| {
                             super::Error::UnableToGetCatalogProvider {
                                 connector: PREFIX.to_string(),
@@ -236,15 +237,17 @@ impl CatalogConnector for DuckLakeCatalog {
                                 source: e,
                             }
                         })?,
-                    )
+                    ))
                 } else {
-                    Arc::new(DuckDbConnectionPool::new_memory().map_err(|e| {
-                        super::Error::UnableToGetCatalogProvider {
-                            connector: PREFIX.to_string(),
-                            connector_component: connector_component_for_pool.clone(),
-                            source: e,
-                        }
-                    })?)
+                    Arc::new(with_utc_session_timezone(
+                        DuckDbConnectionPool::new_memory().map_err(|e| {
+                            super::Error::UnableToGetCatalogProvider {
+                                connector: PREFIX.to_string(),
+                                connector_component: connector_component_for_pool.clone(),
+                                source: e,
+                            }
+                        })?,
+                    ))
                 };
 
                 let conn = Arc::clone(&pool).connect_sync().map_err(|e| {


### PR DESCRIPTION
## Summary

A `duckdb` connector dataset's Arrow schema carried **the host's timezone**, so the same query
over the same database file returned **different rows on different machines**.

`DuckDB` labels a `TIMESTAMPTZ` column it exports to Arrow with the connection's own `TimeZone`
setting. The accelerator pins that to `UTC`
(`accelerator-duckdb`'s `settings::TimeZone`, `DuckDBSettingScope::Local`), but the connector
built its pool directly — `DuckDbConnectionPool::new_file` / `new_memory` — with no setup query,
so its session timezone was whatever `DuckDB` derived from the host.

`DataFusion` then coerces a naive timestamp literal into the column's zone
(`temporal_coercion_nonstrict_timezone`: `(Some(lhs_tz), None) => Some(lhs_tz)`), and Arrow's
naive->aware cast reads that literal as wall-clock *in* that zone. So the literal in
`WHERE ts > TIMESTAMP '...'` denoted a different instant on every host.

## Changes

- `data_components::duckdb::with_utc_session_timezone` pins a pool's session to `UTC`, appending
  to any setup queries the caller already set rather than replacing them.
- Applied to every `DuckDB` pool Spice opens for user data that did not already have it: the
  `duckdb` connector (file + memory), the `ducklake` connector (file + memory), and the
  `ducklake` catalog connector (file + memory).

The accelerator is unchanged — it already pins the same setting through its settings registry.

## Test plan

`make lint` and `make nextest` (via `make signoff`).

Sign-off ran **remotely** (`signoff.yml` run `33965840241`) and passed; `signoff=success` and `Attestation` is green. Two local `make signoff` attempts
died on `No space left on device` (os error 28) — the first in `lint-rust`, the second while
building the nextest binaries — on a host whose volume is 96% full with sibling worktrees. Neither
posted a status, so the commit stayed eligible for a clean run. The first local attempt did catch a
real `clippy::doc_markdown` failure in a test doc comment, fixed in `ee05c737ad`; the second cleared
both full-workspace clippy passes before running out of disk.

### The bug, end to end

Four rows in a `DuckDB` file, one `TIMESTAMPTZ` column, registered as a `duckdb` connector
dataset. Only the `spiced` process `TZ` changes between runs — same file, same spicepod, same
queries:

```sql
SELECT id FROM conn WHERE aware_ts > TIMESTAMP '2024-01-15 09:00:00' ORDER BY id;
SELECT id FROM conn WHERE aware_ts > TIMESTAMP '2024-01-15 15:00:00' ORDER BY id;
```

**Before** (trunk `4735581da0`) — three host timezones, three distinct behaviours:

```
TZ=Asia/Tokyo        schema=Timestamp(us, "Asia/Tokyo")        >09:00 -> [1,2,3,4]   >15:00 -> [1,2,3,4]
TZ=UTC               schema=Timestamp(us, "UTC")               >09:00 -> [1,2,3,4]   >15:00 -> [2,3,4]
TZ=America/New_York  schema=Timestamp(us, "America/New_York")  >09:00 -> [2,3,4]     >15:00 -> [2,3,4]
```

**After** (this branch) — identical on every host, and identical to what `TZ=UTC` already returned:

```
TZ=Asia/Tokyo        schema=Timestamp(us, "UTC")               >09:00 -> [1,2,3,4]   >15:00 -> [2,3,4]
TZ=UTC               schema=Timestamp(us, "UTC")               >09:00 -> [1,2,3,4]   >15:00 -> [2,3,4]
TZ=America/New_York  schema=Timestamp(us, "UTC")               >09:00 -> [1,2,3,4]   >15:00 -> [2,3,4]
```

Row 1 is `2024-01-15T12:00:00Z`; before the fix, whether it satisfied `> 15:00` depended only on
which machine the runtime happened to be running on.

### Regression guards

```
$ cargo test -p data_components --features duckdb --lib duckdb::tests
running 2 tests
test duckdb::tests::the_pin_keeps_the_setup_queries_already_on_the_pool ... ok
test duckdb::tests::the_pin_overrides_a_zone_the_session_already_carries ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 589 filtered out; finished in 0.12s
```

Neuter-verified — with `with_utc_session_timezone` reduced to returning the pool unchanged, both
fail, so neither passes on the unfixed code:

```
test duckdb::tests::the_pin_keeps_the_setup_queries_already_on_the_pool ... FAILED
  left: ["SET memory_limit = '123MB'"]
 right: ["SET memory_limit = '123MB'", "SET TimeZone = 'UTC'"]
test duckdb::tests::the_pin_overrides_a_zone_the_session_already_carries ... FAILED
  left: "Asia/Tokyo"
 right: "UTC"
```

The first guard seeds the pool with `Asia/Tokyo` deliberately: on a CI host already running UTC
the assertion would otherwise hold with or without the pin and measure nothing.

### Scope of the evidence

The `duckdb` connector is reproduced end to end above. The `ducklake` connector and the
`ducklake` catalog connector are **fixed by inspection** — same pool type, same export
convention, same missing setup query — and are covered only by the unit guards, not by a
separate end-to-end run.

## Performance impact

None. One `SET TimeZone = 'UTC'` per connection, alongside the setup queries the pool already
runs, on a code path that opens a connection.

## Review gate

- **Adversarial review — declared skip.** `codex adversarial-review` (thread
  `01a0705c-fae0-7fd3-a7a4-0820567b8003`) failed with the engine's own reason: *"Your workspace is
  out of credits. Ask your workspace owner to refill in order to continue."* No `grok` engine is
  installed in the plugin cache, so no substitute was available.
- **`/security-review`: no findings.** The only new SQL is a `const &str` with no interpolation,
  so there is no injection vector; the change adds no route, deserialization, authz, secret, or
  path handling. The append-rather-than-replace semantics were checked specifically so the pin
  cannot silently drop an existing setup statement such as `search`'s `LOAD vss`.
- **Copilot: approval recommended, 0 comments.**
- **`/simplify`: applied.** The first draft restructured the `map_err` closures at each call site
  and cost 43 lines of reformatting churn per connector; wrapping the existing expression whole
  instead reduced that to 9 lines each, with the original lines untouched. No behaviour change.

Fixes #13899

## Checklist

- [x] Reproduced on `trunk` before the fix, and the same command re-run on the branch
- [x] Regression tests added, and verified to fail with the fix neutered
- [x] `make signoff` green and `Attestation` re-run
