### PR TITLE
fix(duckdb): keep a call the dialect cannot render out of the federated plan (fixes #13900)

### DIFF
--- a/crates/runtime-datafusion/src/dialect/mod.rs
+++ b/crates/runtime-datafusion/src/dialect/mod.rs
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use datafusion::logical_expr::expr::ScalarFunction;
+use datafusion::sql::unparser::Unparser;
 use datafusion::sql::unparser::dialect::{Dialect, DuckDBDialect, ScalarFnToSqlHandler};
 
 use runtime_datafusion_udfs::cosine_distance::COSINE_DISTANCE_UDF_NAME;
@@ -172,6 +173,43 @@ pub fn new_duckdb_dialect() -> Arc<dyn Dialect> {
     Arc::new(dialect) as Arc<dyn Dialect>
 }
 
+/// One `DuckDB` dialect, built once, for [`duckdb_can_translate`] to ask
+/// whether a call renders. It is consulted per scalar call during federation
+/// planning, and building the override table each time would be the expensive
+/// part of an otherwise trivial check.
+static DUCKDB_DIALECT: LazyLock<Arc<dyn Dialect>> = LazyLock::new(new_duckdb_dialect);
+
+/// Whether the `DuckDB` dialect can render this particular call.
+///
+/// A handler renders a *call*, not a name, and several of the `DuckDB`
+/// handlers refuse a call they cannot render faithfully — the regex family
+/// refuses the `U` and `R` flags, which `DuckDB` has no equivalent of, and
+/// `regexp_count` refuses a start position that is not an integer literal,
+/// because the rewrite has to turn it into a `substring` offset. Refusing is
+/// right; what was wrong is where the refusal landed. Federation asks for the
+/// SQL after it has already decided to federate the plan, so the refusal came
+/// back as a planning error and failed a query `DataFusion` can answer on its
+/// own (issue #13900).
+///
+/// The deny-list installs this so the decision is made while it is still a
+/// decision: a call the dialect cannot render is not federated, and evaluates
+/// locally above the federated scan instead. That costs the pushdown for those
+/// plans and returns the right rows, which is the trade the deny-list exists
+/// to make.
+///
+/// The answer comes from running the dialect's own handler rather than from a
+/// second table describing it, so the check cannot drift from what the dialect
+/// does: whatever [`new_duckdb_dialect`] installs is what is asked. A name the
+/// dialect has no handler for renders as `Ok(None)` and is deferred to, which
+/// is why an ordinary function is unaffected.
+#[must_use]
+pub fn duckdb_can_translate(call: &ScalarFunction) -> bool {
+    let unparser = Unparser::new(DUCKDB_DIALECT.as_ref());
+    DUCKDB_DIALECT
+        .scalar_function_to_sql_overrides(&unparser, call.func.name(), &call.args)
+        .is_ok()
+}
+
 /// Names of the functions [`new_bigquery_dialect`] rewrites to native
 /// `BigQuery` SQL. The federation deny-list derives its `BigQuery` carve-out
 /// from this list; see [`crate::function_support::deny_spice_functions_for_bigquery_table_providers`].
@@ -234,8 +272,138 @@ pub fn new_bigquery_dialect() -> Arc<dyn Dialect> {
 mod tests {
     use super::{
         bigquery, bigquery_native_function_names, duckdb_builtin_scalar_overrides,
-        duckdb_native_function_names,
+        duckdb_can_translate, duckdb_native_function_names, new_duckdb_dialect,
     };
+    use datafusion::functions::expr_fn::upper;
+    use datafusion::functions::regex::expr_fn::{regexp_count, regexp_like, regexp_replace};
+    use datafusion::logical_expr::expr::ScalarFunction;
+    use datafusion::prelude::{Expr, col, lit};
+    use datafusion::sql::unparser::Unparser;
+
+    /// The [`ScalarFunction`] inside a call built by `DataFusion`'s own
+    /// `expr_fn` helpers, so these guards run against the real UDFs rather
+    /// than a stub that only shares their name.
+    fn call_of(expr: Expr) -> ScalarFunction {
+        match expr {
+            Expr::ScalarFunction(call) => call,
+            other => panic!("expected a scalar function call, got {other:?}"),
+        }
+    }
+
+    /// Regression test for #13900: the `U` flag has no `DuckDB` equivalent, so
+    /// the dialect's regex handler refuses to render the call. Before this
+    /// check the refusal surfaced as a planning error for the whole query;
+    /// declining to federate leaves the call for `DataFusion` to evaluate.
+    #[test]
+    fn duckdb_declines_a_regex_flag_duckdb_has_no_equivalent_of() {
+        for flag in ["U", "R", "gU", "iR"] {
+            assert!(
+                !duckdb_can_translate(&call_of(regexp_replace(
+                    col("s"),
+                    lit("a"),
+                    lit("X"),
+                    Some(lit(flag)),
+                ))),
+                "regexp_replace with flags `{flag}` has no DuckDB rendering"
+            );
+            assert!(
+                !duckdb_can_translate(&call_of(regexp_like(col("s"), lit("a"), Some(lit(flag))))),
+                "regexp_like with flags `{flag}` has no DuckDB rendering"
+            );
+        }
+
+        // The flags DuckDB does have keep federating.
+        for flag in ["g", "i", "gi"] {
+            assert!(
+                duckdb_can_translate(&call_of(regexp_replace(
+                    col("s"),
+                    lit("a"),
+                    lit("X"),
+                    Some(lit(flag)),
+                ))),
+                "regexp_replace with flags `{flag}` renders as DuckDB SQL"
+            );
+        }
+
+        // No flags argument at all is the common shape and must federate.
+        assert!(duckdb_can_translate(&call_of(regexp_replace(
+            col("s"),
+            lit("a"),
+            lit("X"),
+            None,
+        ))));
+    }
+
+    /// Regression test for #13900: `regexp_count`'s start position becomes a
+    /// `substring` offset in the `DuckDB` rewrite, which needs the value at
+    /// unparse time. A column cannot supply one, and neither can a start
+    /// below 1.
+    #[test]
+    fn duckdb_declines_a_regexp_count_start_it_cannot_turn_into_an_offset() {
+        assert!(
+            !duckdb_can_translate(&call_of(regexp_count(
+                col("s"),
+                lit("a"),
+                Some(col("start")),
+                None,
+            ))),
+            "a column start position has no DuckDB rendering"
+        );
+        assert!(
+            !duckdb_can_translate(&call_of(regexp_count(
+                col("s"),
+                lit("a"),
+                Some(lit(0)),
+                None,
+            ))),
+            "a start position below 1 has no DuckDB rendering"
+        );
+        assert!(
+            duckdb_can_translate(&call_of(regexp_count(
+                col("s"),
+                lit("a"),
+                Some(lit(1)),
+                None,
+            ))),
+            "an integer start position renders as a DuckDB substring offset"
+        );
+    }
+
+    /// A function the dialect installs no handler for is deferred to, so an
+    /// ordinary call keeps federating.
+    #[test]
+    fn duckdb_defers_on_a_function_the_dialect_does_not_rewrite() {
+        assert!(duckdb_can_translate(&call_of(upper(col("s")))));
+    }
+
+    /// The check must answer exactly what the unparser does, or a call it
+    /// admits still fails the query and a call it refuses loses its pushdown
+    /// for nothing. Asking through `expr_to_sql` reaches the handler by the
+    /// unparser's own dispatch rather than by the accessor the check uses.
+    #[test]
+    fn duckdb_can_translate_agrees_with_what_the_unparser_renders() {
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+
+        for expr in [
+            regexp_replace(col("s"), lit("a"), lit("X"), Some(lit("U"))),
+            regexp_replace(col("s"), lit("a"), lit("X"), Some(lit("g"))),
+            regexp_replace(col("s"), lit("a"), lit("X"), None),
+            regexp_like(col("s"), lit("a"), Some(lit("R"))),
+            regexp_like(col("s"), lit("a"), None),
+            regexp_count(col("s"), lit("a"), Some(col("start")), None),
+            regexp_count(col("s"), lit("a"), Some(lit(0)), None),
+            regexp_count(col("s"), lit("a"), Some(lit(2)), None),
+            upper(col("s")),
+        ] {
+            let renders = unparser.expr_to_sql(&expr).is_ok();
+            assert_eq!(
+                duckdb_can_translate(&call_of(expr.clone())),
+                renders,
+                "the per-call check and the unparser disagree about {expr:?}"
+            );
+        }
+    }
 
     #[test]
     fn every_carved_out_bigquery_name_is_a_function_the_deny_list_knows() {

--- a/crates/runtime-datafusion/src/function_support.rs
+++ b/crates/runtime-datafusion/src/function_support.rs
@@ -170,25 +170,23 @@ pub fn deny_spice_functions_for_postgres_table_providers() -> FunctionSupport {
 #[cfg(test)]
 mod tests {
     use super::deny_spice_functions_for_duckdb_table_providers;
+    use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::functions::regex::expr_fn::{regexp_count, regexp_replace};
-    use datafusion::logical_expr::{LogicalPlan, LogicalPlanBuilder, Projection, table_scan};
+    use datafusion::logical_expr::{LogicalPlan, table_scan};
     use datafusion::prelude::{Expr, col, lit};
     use datafusion_table_providers::util::supported_functions::contains_unsupported_functions;
-    use std::sync::Arc;
 
     /// A scan of `t(s, start)` projecting `expr`, which is the shape federation
     /// is asked to decide about.
     fn plan_projecting(expr: Expr) -> LogicalPlan {
-        let schema = arrow::datatypes::Schema::new(vec![
-            arrow::datatypes::Field::new("s", arrow::datatypes::DataType::Utf8, true),
-            arrow::datatypes::Field::new("start", arrow::datatypes::DataType::Int64, true),
+        let schema = Schema::new(vec![
+            Field::new("s", DataType::Utf8, true),
+            Field::new("start", DataType::Int64, true),
         ]);
-        let scan = table_scan(Some("t"), &schema, None)
+        table_scan(Some("t"), &schema, None)
             .expect("scan t")
-            .build()
-            .expect("build scan");
-        let projection = Projection::try_new(vec![expr], Arc::new(scan)).expect("projection");
-        LogicalPlanBuilder::from(LogicalPlan::Projection(projection))
+            .project(vec![expr])
+            .expect("project")
             .build()
             .expect("build plan")
     }

--- a/crates/runtime-datafusion/src/function_support.rs
+++ b/crates/runtime-datafusion/src/function_support.rs
@@ -24,10 +24,7 @@ limitations under the License.
 use std::sync::Arc;
 
 use datafusion_table_providers::util::supported_functions::FunctionSupport;
-use runtime_udfs_api::{
-    FunctionSupportBuilder, datafusion_nested_function_names,
-    deny_spice_specific_functions_excluding,
-};
+use runtime_udfs_api::{FunctionSupportBuilder, datafusion_nested_function_names};
 
 /// The [`FunctionSupport`] for `DuckDB` connectors and accelerators: allows
 /// every function the `DuckDB` dialect can rewrite into native SQL (e.g.
@@ -35,16 +32,30 @@ use runtime_udfs_api::{
 /// from the dialect so it tracks it automatically.
 #[must_use]
 pub fn deny_spice_functions_for_duckdb() -> Arc<FunctionSupport> {
-    deny_spice_specific_functions_excluding(&crate::dialect::duckdb_native_function_names())
+    Arc::new(deny_spice_functions_for_duckdb_table_providers())
 }
 
 /// `DuckDB` deny-list as a value, for
 /// `DuckDBTableFactory::with_function_support`. See issue #10703.
+///
+/// Two layers, both derived from [`crate::dialect`] so they cannot drift from
+/// what the dialect can actually render:
+///
+/// 1. the name carve-out, so the Spice functions the `DuckDB` dialect rewrites
+///    into native SQL federate instead of being denied;
+/// 2. a per-call check, because a *name* the dialect handles is not a *call*
+///    the dialect can render. `regexp_replace(s, p, r, 'U')` has no `DuckDB`
+///    rendering — `DuckDB` has no `U` flag — and without this check the
+///    refusal reaches the user as a planning error for a query `DataFusion`
+///    can answer locally (issue #13900). The check also gates the
+///    `DataFusion` built-ins the dialect rewrites, whose untranslatable shapes
+///    must stay local the same way.
 #[must_use]
 pub fn deny_spice_functions_for_duckdb_table_providers() -> FunctionSupport {
     FunctionSupportBuilder::new()
         .native(&crate::dialect::duckdb_native_function_names())
         .build()
+        .with_scalar_call_support(Arc::new(crate::dialect::duckdb_can_translate))
 }
 
 /// The [`FunctionSupport`] for `BigQuery` over ADBC, as a value for
@@ -154,4 +165,72 @@ pub fn deny_spice_functions_for_postgres_table_providers() -> FunctionSupport {
     FunctionSupportBuilder::new()
         .deny_also(unsupported_arrays)
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deny_spice_functions_for_duckdb_table_providers;
+    use datafusion::functions::regex::expr_fn::{regexp_count, regexp_replace};
+    use datafusion::logical_expr::{LogicalPlan, LogicalPlanBuilder, Projection, table_scan};
+    use datafusion::prelude::{Expr, col, lit};
+    use datafusion_table_providers::util::supported_functions::contains_unsupported_functions;
+    use std::sync::Arc;
+
+    /// A scan of `t(s, start)` projecting `expr`, which is the shape federation
+    /// is asked to decide about.
+    fn plan_projecting(expr: Expr) -> LogicalPlan {
+        let schema = arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("s", arrow::datatypes::DataType::Utf8, true),
+            arrow::datatypes::Field::new("start", arrow::datatypes::DataType::Int64, true),
+        ]);
+        let scan = table_scan(Some("t"), &schema, None)
+            .expect("scan t")
+            .build()
+            .expect("build scan");
+        let projection = Projection::try_new(vec![expr], Arc::new(scan)).expect("projection");
+        LogicalPlanBuilder::from(LogicalPlan::Projection(projection))
+            .build()
+            .expect("build plan")
+    }
+
+    /// Whether federation would push this plan into `DuckDB`, which is what
+    /// `SqlTable::can_execute_plan` asks of the deny-list.
+    fn federates(expr: Expr) -> bool {
+        let support = deny_spice_functions_for_duckdb_table_providers();
+        !contains_unsupported_functions(&plan_projecting(expr), &support)
+            .expect("the support check must not error")
+    }
+
+    /// Regression test for #13900. Federation is an optimization: a call the
+    /// `DuckDB` dialect cannot render must not be federated, so `DataFusion`
+    /// evaluates it locally instead of the query failing at planning.
+    #[test]
+    fn a_duckdb_untranslatable_call_is_not_federated() {
+        assert!(
+            !federates(regexp_replace(col("s"), lit("a"), lit("X"), Some(lit("U")),)),
+            "the `U` flag has no DuckDB rendering, so this plan must stay local"
+        );
+        assert!(
+            !federates(regexp_count(col("s"), lit("a"), Some(col("start")), None)),
+            "a column start position has no DuckDB rendering, so this plan must stay local"
+        );
+    }
+
+    /// The complement: the per-call check must not cost a pushdown that works.
+    #[test]
+    fn a_duckdb_renderable_call_still_federates() {
+        assert!(federates(regexp_replace(
+            col("s"),
+            lit("a"),
+            lit("X"),
+            Some(lit("g")),
+        )));
+        assert!(federates(regexp_count(
+            col("s"),
+            lit("a"),
+            Some(lit(1)),
+            None,
+        )));
+        assert!(federates(col("s")));
+    }
 }

--- a/crates/runtime/src/catalogconnector/ducklake.rs
+++ b/crates/runtime/src/catalogconnector/ducklake.rs
@@ -35,7 +35,7 @@ use data_components::ducklake::{
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 use duckdb::AccessMode;
-use runtime_datafusion::dialect::new_duckdb_dialect;
+use runtime_datafusion::dialect::{duckdb_can_translate, new_duckdb_dialect};
 use runtime_udfs_api::deny_spice_functions_for_table_providers;
 use snafu::prelude::*;
 use std::any::Any;
@@ -357,10 +357,19 @@ impl CatalogConnector for DuckLakeCatalog {
 /// answers twice the local one. Carving it out here would turn today's
 /// unknown-function error into a silently wrong number, so these are denied and
 /// evaluated locally instead. The divergence itself is #13728.
+///
+/// The per-call gate is a separate layer from the name carve-out, so it composes
+/// with the plain list rather than replacing it: these names are denied, *and* of
+/// the names that are allowed, only the calls the dialect can actually render may
+/// be federated. Without it this route keeps the defect #13900 reports — the
+/// dialect refuses a call it has no rendering for (`regexp_replace(s, p, r, 'U')`),
+/// and because federation has already committed by then, the refusal fails the
+/// whole query instead of leaving the call for `DataFusion`.
 fn ducklake_federation() -> DuckLakeFederation {
     DuckLakeFederation {
         dialect: new_duckdb_dialect(),
-        function_support: deny_spice_functions_for_table_providers(),
+        function_support: deny_spice_functions_for_table_providers()
+            .with_scalar_call_support(Arc::new(duckdb_can_translate)),
     }
 }
 
@@ -404,8 +413,8 @@ mod tests {
 #[cfg(test)]
 mod federation_tests {
     use super::*;
-    use crate::catalogconnector::stub_udf;
-    use datafusion::prelude::col;
+    use crate::catalogconnector::{stub_udf, stub_udf_called_with};
+    use datafusion::prelude::{col, lit};
     use datafusion::sql::unparser::Unparser;
 
     /// A `DuckLake` catalog must deny the Spice-only UDFs `DuckDB` cannot run, so
@@ -480,5 +489,34 @@ mod federation_tests {
                  translate it -- the stock DuckDB dialect does not"
             );
         }
+    }
+
+    /// Regression guard for #13900 on the *catalog* route. Translating a name is
+    /// not the same as translating a call: `regexp_replace` is handled, but the
+    /// handler has no rendering for the `U` flag and refuses. Federation asks for
+    /// the SQL only after it has committed, so an ungated route turns that refusal
+    /// into a planning error for a query `DataFusion` can answer.
+    ///
+    /// This route pairs the `DuckDB` dialect with the *plain* deny-list, which
+    /// carries no per-call gate of its own -- so it has to be attached here, and
+    /// nothing else in this file would notice if it went missing.
+    #[test]
+    fn an_untranslatable_call_is_not_federated_by_the_catalog_route() {
+        let support = ducklake_federation().function_support;
+
+        assert!(
+            !support.supports(&stub_udf_called_with(
+                "regexp_replace",
+                vec![col("s"), lit("a"), lit("X"), lit("U")],
+            )),
+            "the `U` flag has no DuckDB rendering, so this call must stay local"
+        );
+        assert!(
+            support.supports(&stub_udf_called_with(
+                "regexp_replace",
+                vec![col("s"), lit("a"), lit("X"), lit("g")],
+            )),
+            "a renderable call must keep its pushdown"
+        );
     }
 }

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -147,7 +147,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// A named scalar UDF expression, for asserting what a connector's federation
 /// deny-list does and does not allow. The deny-list matches on the function's
 /// name, so the body and the argument types are irrelevant -- only the name and
-/// the argument count are.
+/// the argument count are. A backend that also answers per *call* is the
+/// exception: reach for [`stub_udf_called_with`] there, since the arguments are
+/// then part of the question.
 #[cfg(test)]
 pub(crate) fn stub_udf(name: &str, arity: usize) -> datafusion::logical_expr::Expr {
     use datafusion::arrow::datatypes::DataType;
@@ -164,6 +166,30 @@ pub(crate) fn stub_udf(name: &str, arity: usize) -> datafusion::logical_expr::Ex
     Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
         udf,
         (0..arity).map(|i| col(format!("c{i}"))).collect(),
+    ))
+}
+
+/// The same stub called with `args` instead of bare columns, for a backend whose
+/// [`FunctionSupport`](datafusion_table_providers::util::supported_functions::FunctionSupport)
+/// answers per *call* — where a literal argument is what decides whether the
+/// dialect can render it.
+#[cfg(test)]
+pub(crate) fn stub_udf_called_with(
+    name: &str,
+    args: Vec<datafusion::logical_expr::Expr>,
+) -> datafusion::logical_expr::Expr {
+    use datafusion::arrow::datatypes::DataType;
+    use datafusion::logical_expr::{ColumnarValue, Expr, Volatility, create_udf};
+
+    let udf = std::sync::Arc::new(create_udf(
+        name,
+        vec![DataType::Utf8; args.len()],
+        DataType::Utf8,
+        Volatility::Immutable,
+        std::sync::Arc::new(|args: &[ColumnarValue]| Ok(args[0].clone())),
+    ));
+    Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
+        udf, args,
     ))
 }
 

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -152,21 +152,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// then part of the question.
 #[cfg(test)]
 pub(crate) fn stub_udf(name: &str, arity: usize) -> datafusion::logical_expr::Expr {
-    use datafusion::arrow::datatypes::DataType;
-    use datafusion::logical_expr::{ColumnarValue, Expr, Volatility, create_udf};
     use datafusion::prelude::col;
 
-    let udf = std::sync::Arc::new(create_udf(
-        name,
-        vec![DataType::Utf8; arity],
-        DataType::Utf8,
-        Volatility::Immutable,
-        std::sync::Arc::new(|args: &[ColumnarValue]| Ok(args[0].clone())),
-    ));
-    Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
-        udf,
-        (0..arity).map(|i| col(format!("c{i}"))).collect(),
-    ))
+    stub_udf_called_with(name, (0..arity).map(|i| col(format!("c{i}"))).collect())
 }
 
 /// The same stub called with `args` instead of bare columns, for a backend whose

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -964,7 +964,7 @@ mod tests {
     fn make_named_expr_of_one_arg(name: &str) -> Expr {
         Expr::ScalarFunction(ScalarFunction::new_udf(
             Arc::new(stub_scalar_udf(name)),
-            vec![col("s")],
+            vec![lit("  padded  ")],
         ))
     }
 

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -956,6 +956,18 @@ mod tests {
         ))
     }
 
+    /// The same probe with one argument, for a name whose backend answers
+    /// per-call as well as per-name: a `FunctionSupport` carrying a
+    /// [`ScalarCallSupport`](datafusion_table_providers::util::supported_functions::ScalarCallSupport)
+    /// asks its dialect to render the call, and the no-arg probe is a call the
+    /// planner cannot build and the dialect refuses on arity alone.
+    fn make_named_expr_of_one_arg(name: &str) -> Expr {
+        Expr::ScalarFunction(ScalarFunction::new_udf(
+            Arc::new(stub_scalar_udf(name)),
+            vec![col("s")],
+        ))
+    }
+
     #[test]
     fn table_providers_default_deny_list_denies_spice_functions() {
         // The default table-providers-typed deny-list (wired into the ADBC
@@ -1092,7 +1104,7 @@ mod tests {
             ),
         ] {
             assert_eq!(
-                support.supports(&make_named_expr("btrim")),
+                support.supports(&make_named_expr_of_one_arg("btrim")),
                 !denied,
                 "btrim pushdown for {backend} is wrong: expected denied={denied}"
             );


### PR DESCRIPTION
## Summary

A `DuckDB` unparser-dialect handler renders a **call**, not a name, and several of the
handlers refuse a call they cannot render faithfully:

- the regex family refuses the `U` and `R` flags, which `DuckDB` has no equivalent of;
- `regexp_count` refuses a start position that is not an integer literal, because the
  rewrite has to turn it into a `substring` offset and needs the value at unparse time.

Refusing is right — there is no faithful rendering to reach for instead. What was wrong is
**where the refusal landed**. Federation asks for the SQL only *after* it has decided to
federate the plan, so the handler's error came back as a planning error for the whole
query, and a query `DataFusion` can answer on its own failed instead:

```
$ SELECT max(regexp_replace(s,'a','X','U')) AS r FROM t_fed      # DuckDB-accelerated
Failed to execute query: Error during planning: Regular expression flags `U` or `R` are not supported by DuckDB for function regexp_replace.
$ SELECT max(regexp_replace(s,'a','X','U')) AS r FROM t_local    # same data, not accelerated
[{"r":"bXnana"}]
```

Federation is an optimization. When a call cannot be rendered for the remote engine, the
plan should keep it above the federation boundary and let `DataFusion` evaluate it — which
is exactly what the deny-list exists to arrange, and what `BigQuery` already does through
`ScalarCallSupport`. The function-level deny-list cannot express this on its own, because
whether the call is renderable depends on its arguments.

## Changes

- **`dialect/mod.rs`** — new `duckdb_can_translate(&ScalarFunction) -> bool`. It answers by
  running the dialect's **own** handler (`Dialect::scalar_function_to_sql_overrides`) and
  keeping only whether it succeeded, so the check cannot drift from what the dialect does:
  whatever `new_duckdb_dialect()` installs is what is asked, and a name with no handler
  renders as `Ok(None)` and is deferred to. The dialect is built once behind a `LazyLock`.
- **`function_support.rs`** — the `DuckDB` deny-list installs it via
  `with_scalar_call_support`, the same shape `deny_spice_functions_for_bigquery_table_providers`
  already uses. `deny_spice_functions_for_duckdb()` now delegates to
  `deny_spice_functions_for_duckdb_table_providers()` so the connector's and the
  accelerator's deny-lists cannot drift apart.
- **`catalogconnector/ducklake.rs`** — the DuckLake **catalog** route pairs the same DuckDB
  dialect with the *plain* deny-list, so it carried the defect too. The gate is attached to
  that list rather than swapping it for the DuckDB-flavored one: the flavored list carves out
  the vector UDFs, and `cosine_distance` is not value-preserving across that rewrite (#13728),
  so swapping would trade a planning error for a silently wrong number. The two are
  independent layers, so attaching composes. Found by Copilot on this PR.
- **`datafusion/udf.rs`** — the `btrim` deny-list probe now passes an argument. A backend
  that answers per-call as well as per-name asks its dialect to render the probe, and the
  zero-argument probe is a call the planner cannot build and that the dialect refuses on
  arity alone.

This covers the class, not one function: the check is generic over every `DuckDB` handler,
and `BigQuery` is the only other dialect this repo builds — it already has its per-call
check. `SQLite`, `MySQL` and `PostgreSQL` install no Spice handler that can refuse a call,
so they have nothing to gate.

**Direction of the change:** `supports_scalar_call` is consulted only for calls the
name-based restriction already allows, so this can only turn *allow → deny*. It strictly
narrows what is unparsed into remote SQL; nothing newly reaches `DuckDB`.

## Performance impact

The check runs at federation-planning time, once per scalar call the plan contains. For a
name the dialect has no handler for — every ordinary function — it is one hash lookup on
the override map and returns `true`. For a name that *does* have a handler it renders the
call's arguments to AST and throws the result away, so that rendering happens twice for a
call that goes on to federate. Both are plan-time, not per-row.

The trade the fix makes is a lost pushdown for the calls that were failing outright: the
`U`-flag plan below now scans the column and evaluates the scalar and the aggregate
locally, where before it returned an error. Renderable calls are unaffected — the whole
aggregate is still pushed.

## Test plan

Reproduced end-to-end through a real `spiced` (built `--no-default-features --features
duckdb`) against a `DuckDB`-accelerated CSV dataset `t_fed`, with a non-accelerated
`t_local` over the same file as the control.

**Before — on `trunk` at `91f73ca290`:**

```
$ SELECT max(regexp_replace(s,'a','X','U')) AS r FROM t_fed
Failed to execute query: Error during planning: Regular expression flags `U` or `R` are not supported by DuckDB for function regexp_replace.
$ SELECT max(regexp_replace(s,'a','X','U')) AS r FROM t_local
[{"r":"bXnana"}]
$ SELECT regexp_count(s,'a',id) AS c FROM t_fed
Failed to execute query: Error during planning: Only integer start positions are supported for regular expression function regexp_extract_all with DuckDB
$ SELECT regexp_count(s,'a',id) AS c FROM t_local
[{"c":2},{"c":2},{"c":2}]
$ SELECT max(regexp_replace(s,'a','X','g')) AS r FROM t_fed
[{"r":"bXnXnX"}]
```

**After — same commands, same pod, on this branch:**

```
$ SELECT max(regexp_replace(s,'a','X','U')) AS r FROM t_fed
[{"r":"bXnana"}]
$ SELECT max(regexp_replace(s,'a','X','U')) AS r FROM t_local
[{"r":"bXnana"}]
$ SELECT regexp_count(s,'a',id) AS c FROM t_fed
[{"c":2},{"c":2},{"c":2}]
$ SELECT regexp_count(s,'a',id) AS c FROM t_local
[{"c":2},{"c":2},{"c":2}]
$ SELECT max(regexp_replace(s,'a','X','g')) AS r FROM t_fed
[{"r":"bXnXnX"}]
```

The federated answers now match the local ones, and the renderable case is unchanged.

**The plans show where the boundary moved.** `EXPLAIN` on the fixed build:

```
-- untranslatable: the boundary is now BELOW the call
EXPLAIN SELECT max(regexp_replace(s,'a','X','U')) AS r FROM t_fed
  AggregateExec: mode=Final, gby=[], aggr=[max(regexp_replace(...,Utf8("U")))]
    ...
      VirtualExecutionPlan name=duckdb base_sql=SELECT "t_fed"."s" FROM "t_fed"

-- renderable: unchanged, the whole aggregate is still pushed
EXPLAIN SELECT max(regexp_replace(s,'a','X','g')) AS r FROM t_fed
  VirtualExecutionPlan name=duckdb base_sql=SELECT max(regexp_replace("t_fed"."s", 'a', 'X', 'g')) AS "r" FROM "t_fed"
```

**Regression guards, demonstrated to fail on unfixed code.** With the
`with_scalar_call_support` line removed and everything else identical:

```
$ cargo test -p runtime-datafusion --lib function_support::
test function_support::tests::a_duckdb_renderable_call_still_federates ... ok
test function_support::tests::a_duckdb_untranslatable_call_is_not_federated ... FAILED
  panicked at crates/runtime-datafusion/src/function_support.rs:208:9:
  the `U` flag has no DuckDB rendering, so this plan must stay local
test result: FAILED. 1 passed; 1 failed
```

With the line restored, both pass. The complement guard passes either way by design — it
is the control that pins that the check costs no working pushdown.

**The catalog route's guard, likewise demonstrated to fail without its wiring.** With the
`with_scalar_call_support` line removed from `ducklake_federation()`:

```
$ cargo test -p runtime --features duckdb --lib catalogconnector::ducklake
test ..._the_catalog_denies_the_spice_functions_duckdb_cannot_run ... ok
test ..._the_vector_udfs_are_denied_rather_than_carved_out ... ok
test ..._the_installed_dialect_translates_the_regexp_builtins ... ok
test ..._an_untranslatable_call_is_not_federated_by_the_catalog_route ... FAILED
  panicked at crates/runtime/src/catalogconnector/ducklake.rs:506:9:
  the `U` flag has no DuckDB rendering, so this call must stay local
test result: FAILED. 4 passed; 1 failed
```

With the line restored, all 5 pass:

```
$ cargo test -p runtime --features duckdb --lib catalogconnector::ducklake
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1288 filtered out
```

**Not claimed for the catalog route:** the end-to-end `spiced` reproduction above covers the
connector/accelerator route only. Standing up a DuckLake catalog needs the `ducklake` DuckDB
extension, which is not statically linked into this build. The catalog route's defect is
established by the wiring (it pairs `new_duckdb_dialect()` with a deny-list carrying no
per-call gate) and by the guard above failing on the unwired code — **not** by a run of a
DuckLake catalog. Labelled here rather than implied.

Tests added:

- `function_support.rs` — `a_duckdb_untranslatable_call_is_not_federated` and
  `a_duckdb_renderable_call_still_federates`, asserted at the seam
  `SqlTable::can_execute_plan` uses (`contains_unsupported_functions`).
- `catalogconnector/ducklake.rs` — `an_untranslatable_call_is_not_federated_by_the_catalog_route`,
  asserted on `ducklake_federation().function_support`, with the renderable call as its control.
- `dialect/mod.rs` — the `U`/`R` flags across `regexp_replace`/`regexp_like`, the
  `regexp_count` start position (column, `0`, and `1`), a deferral case (`upper`), and
  `duckdb_can_translate_agrees_with_what_the_unparser_renders`, which reaches the handler
  by the unparser's own dispatch rather than by the accessor the check uses.

Suite runs on this branch:

```
$ cargo test -p runtime-datafusion --lib
test result: ok. 249 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p runtime --lib datafusion::udf::
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 1263 filtered out
```

`make lint` and `make test`/`make nextest` run as part of `make signoff` on the pushed HEAD.

## Review gate

- Adversarial review: **skipped** — `codex` errored, and `grok` is not installed in this
  harness. Receipt: `engine=none exit=1`, `attempt=codex result=exit-1`,
  `attempt=grok result=not-installed`. The engine's own reason: `[codex] Codex error: Your
  workspace is out of credits. Ask your workspace owner to refill in order to continue.`
  Re-run per shipping HEAD; the last receipt is on `a43a4e7a1c`, and the two commits after it
  (the DuckLake wiring and a test-helper dedup) were not re-submitted because the engine's
  failure is unconditional.
- `/security-review`: no findings. The change emits no SQL — it discards the rendered AST and
  keeps only `is_ok()` — adds no log line, error message or metric label, and can only narrow
  what reaches the remote, since `supports_scalar_call` is reached only for calls the name
  check already allows. The DuckLake commit is the same class on a second route: a federation
  decision, no new surface, so it was not re-audited separately.
- `/simplify`: applied twice. First pass — the test fixture built a `Projection` by hand and
  wrapped it in a no-op `LogicalPlanBuilder::from(...).build()`; it now goes through the scan
  builder's own `.project()`. Second pass, on the DuckLake commit — `stub_udf_called_with`
  duplicated `stub_udf`'s body, so the arity form now delegates to the call form. Neither
  changed behavior; the targeted tests were re-run green after each.

Fixes #13900

## Checklist

- [x] Reproduced the reported failure on `trunk` before writing the fix
- [x] Demonstrated the failure's absence after the fix, with the same commands
- [x] Regression guard fails on unfixed code and passes on fixed code
- [x] Control case pins that a renderable call keeps its pushdown
- [ ] `make signoff` green and `Attestation` re-run