### PR TITLE
fix(functions): discard cached plans when a hot reload changes the function set (refs #13873)

### DIFF
--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -403,11 +403,29 @@ fn info_from_decl(decl: &Function) -> UserFunctionInfo {
 
 /// Rebuild + re-register user functions against `new_app`, removing any
 /// that are no longer declared. Called on spicepod hot-reload.
+///
+/// Discards the cached logical plans when the registered set changes: a
+/// cached plan embeds the `Arc<ScalarUDF>` it was planned against, so it
+/// keeps evaluating a dropped or redefined function's own body no matter
+/// what the session context now holds for that name. Dataset and view
+/// registration already discard them for the same reason.
 pub async fn apply_function_diff(
     runtime: &crate::Runtime,
     current_app: &Arc<app::App>,
     new_app: &Arc<app::App>,
 ) {
+    if apply_function_diff_inner(runtime, current_app, new_app).await {
+        runtime.df.clear_cached_plans().await;
+    }
+}
+
+/// The body of [`apply_function_diff`]. Returns whether the registered set
+/// changed, which is what makes a cached plan over a user function stale.
+async fn apply_function_diff_inner(
+    runtime: &crate::Runtime,
+    current_app: &Arc<app::App>,
+    new_app: &Arc<app::App>,
+) -> bool {
     let ctx = &runtime.df.ctx;
     let current_enabled = current_app.runtime.functions.enabled;
     let new_enabled = new_app.runtime.functions.enabled;
@@ -457,13 +475,13 @@ pub async fn apply_function_diff(
     }
 
     if new_app.functions.is_empty() {
-        return;
+        return !functions_to_drop.is_empty();
     }
     if !new_enabled {
         tracing::error!(
             "User-defined functions are declared but disabled. Set `runtime.functions.enabled: true` to register spicepod `functions:` entries."
         );
-        return;
+        return !functions_to_drop.is_empty();
     }
 
     let functions_to_register = new_app
@@ -533,10 +551,13 @@ pub async fn apply_function_diff(
             }
         }
     }
+    let registered_any = !registered_function_names.is_empty();
     add_user_functions_to_deny_list(registered_function_names);
     for next in functions_to_expose_as_tools {
         maybe_register_function_as_tool(runtime, &next).await;
     }
+
+    registered_any || !functions_to_drop.is_empty()
 }
 
 /// Names of UDFs whose invocation can execute external code or make RPC/API
@@ -1302,5 +1323,123 @@ mod tests {
                 "{name}: expected a FixedSizeList coercion error from Spice's impl, got: {err}"
             );
         }
+    }
+
+    /// A cached logical plan embeds the `Arc<ScalarUDF>` it was planned
+    /// against, so it keeps evaluating that UDF's own body regardless of what
+    /// the session context now holds for the name. The plan cache is installed
+    /// unconditionally with a one-hour TTL, so a hot reload that redefines a
+    /// `functions:` body must discard the cached plans or the old body keeps
+    /// answering the same SQL for up to an hour.
+    ///
+    /// Regression test for #13873. Fails on the code this test landed with:
+    /// `apply_function_diff` deregistered and re-registered the UDF without
+    /// touching the plan cache, so the second query returned the first body's
+    /// answer.
+    #[tokio::test]
+    async fn function_diff_discards_cached_plans_so_a_redefined_body_answers() {
+        use cache::CacheProvider;
+
+        /// One `functions:`-declared SQL scalar function, `myscale(x)`, with
+        /// the given body — parsed from YAML so the declaration is the same
+        /// shape a spicepod produces.
+        fn app_with_body(body: &str) -> Arc<app::App> {
+            let function: Function = yaml::from_str(&format!(
+                "
+name: myscale
+from: sql
+kind: scalar
+volatility: immutable
+signature:
+  args: [{{ name: x, type: int64 }}]
+  returns: int64
+body: \"{body}\"
+"
+            ))
+            .expect("the function declaration should parse");
+
+            let spicepod_runtime = spicepod::component::runtime::Runtime {
+                functions: spicepod::component::runtime::Functions::enabled(),
+                ..Default::default()
+            };
+
+            Arc::new(
+                app::AppBuilder::new("plan_cache_function_diff")
+                    .with_function(function)
+                    .with_runtime(spicepod_runtime)
+                    .build(),
+            )
+        }
+
+        static SQL: &str = "SELECT myscale(21) AS v";
+
+        let doubling = app_with_body("x * 2");
+        let tripling = app_with_body("x * 3");
+
+        // `Runtime::builder().build()` registers the app's `functions:` and
+        // `Runtime::init_caching` installs the plans cache unconditionally, so
+        // building from the app is the whole setup — nothing about caching
+        // needs to be configured for the window to exist.
+        let runtime = crate::Runtime::builder()
+            .with_app_opt(Some(Arc::clone(&doubling)))
+            .build()
+            .await;
+        let df = Arc::clone(&runtime.df);
+        let plans = df
+            .plans_cache_provider()
+            .expect("the plans cache is installed unconditionally");
+
+        // Any hasher works here — the key only has to be the same on both lookups.
+        let key = cache::key::CacheKey::Query(SQL, None)
+            .as_raw_key(Box::new(std::hash::DefaultHasher::new()));
+        let plan = df
+            .get_or_create_logical_plan(&df.ctx.state(), Some(&key), SQL)
+            .await
+            .expect("the query over myscale should plan");
+        assert_eq!(
+            eval_i64(&df.ctx, plan).await,
+            42,
+            "precondition: the first body must be the one that answers"
+        );
+        plans.checkpoint().await;
+        assert_eq!(
+            plans.item_count().await,
+            1,
+            "precondition: the plan must be cached, or this test cannot observe staleness"
+        );
+
+        // The hot reload: `myscale` is redefined, which takes the same drop
+        // path as a removal (`next != current`) and then re-registers.
+        apply_function_diff(&runtime, &doubling, &tripling).await;
+
+        plans.checkpoint().await;
+        assert_eq!(
+            plans.item_count().await,
+            0,
+            "a function diff must discard the cached plans; a plan left in the cache still holds \
+             the pre-reload ScalarUDF"
+        );
+
+        let replanned = df
+            .get_or_create_logical_plan(&df.ctx.state(), Some(&key), SQL)
+            .await
+            .expect("the same SQL should re-plan after the reload");
+        assert_eq!(
+            eval_i64(&df.ctx, replanned).await,
+            63,
+            "the redefined body must answer; 42 means the cached plan's old ScalarUDF answered"
+        );
+    }
+
+    /// Execute a planned query expected to yield a single `Int64` value.
+    async fn eval_i64(ctx: &SessionContext, plan: datafusion::logical_expr::LogicalPlan) -> i64 {
+        let batches = datafusion::dataframe::DataFrame::new(ctx.state(), plan)
+            .collect()
+            .await
+            .expect("the plan should execute");
+        batches[0]
+            .column(0)
+            .as_primitive::<datafusion::arrow::datatypes::Int64Type>()
+            .value(0)
     }
 }

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -551,13 +551,14 @@ async fn apply_function_diff_inner(
             }
         }
     }
-    let registered_any = !registered_function_names.is_empty();
+    // Computed before `registered_function_names` is moved into the deny list.
+    let changed = !registered_function_names.is_empty() || !functions_to_drop.is_empty();
     add_user_functions_to_deny_list(registered_function_names);
     for next in functions_to_expose_as_tools {
         maybe_register_function_as_tool(runtime, &next).await;
     }
 
-    registered_any || !functions_to_drop.is_empty()
+    changed
 }
 
 /// Names of UDFs whose invocation can execute external code or make RPC/API
@@ -1338,8 +1339,6 @@ mod tests {
     /// answer.
     #[tokio::test]
     async fn function_diff_discards_cached_plans_so_a_redefined_body_answers() {
-        use cache::CacheProvider;
-
         /// One `functions:`-declared SQL scalar function, `myscale(x)`, with
         /// the given body — parsed from YAML so the declaration is the same
         /// shape a spicepod produces.

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -1326,25 +1326,12 @@ mod tests {
         }
     }
 
-    /// A cached logical plan embeds the `Arc<ScalarUDF>` it was planned
-    /// against, so it keeps evaluating that UDF's own body regardless of what
-    /// the session context now holds for the name. The plan cache is installed
-    /// unconditionally with a one-hour TTL, so a hot reload that redefines a
-    /// `functions:` body must discard the cached plans or the old body keeps
-    /// answering the same SQL for up to an hour.
-    ///
-    /// Regression test for #13873. Fails on the code this test landed with:
-    /// `apply_function_diff` deregistered and re-registered the UDF without
-    /// touching the plan cache, so the second query returned the first body's
-    /// answer.
-    #[tokio::test]
-    async fn function_diff_discards_cached_plans_so_a_redefined_body_answers() {
-        /// One `functions:`-declared SQL scalar function, `myscale(x)`, with
-        /// the given body — parsed from YAML so the declaration is the same
-        /// shape a spicepod produces.
-        fn app_with_body(body: &str) -> Arc<app::App> {
-            let function: Function = yaml::from_str(&format!(
-                "
+    /// A one-function app: `myscale(x)` as a `from: sql` scalar with the given
+    /// body, parsed from YAML so the declaration is the shape a spicepod
+    /// produces. `functions:` is enabled, since registration is opt-in.
+    fn app_with_body(body: &str) -> Arc<app::App> {
+        let function: Function = yaml::from_str(&format!(
+            "
 name: myscale
 from: sql
 kind: scalar
@@ -1354,33 +1341,47 @@ signature:
   returns: int64
 body: \"{body}\"
 "
-            ))
-            .expect("the function declaration should parse");
+        ))
+        .expect("the function declaration should parse");
 
-            let spicepod_runtime = spicepod::component::runtime::Runtime {
-                functions: spicepod::component::runtime::Functions::enabled(),
-                ..Default::default()
-            };
+        Arc::new(
+            app::AppBuilder::new("plan_cache_function_diff")
+                .with_function(function)
+                .with_runtime(spicepod::component::runtime::Runtime {
+                    functions: spicepod::component::runtime::Functions::enabled(),
+                    ..Default::default()
+                })
+                .build(),
+        )
+    }
 
-            Arc::new(
-                app::AppBuilder::new("plan_cache_function_diff")
-                    .with_function(function)
-                    .with_runtime(spicepod_runtime)
-                    .build(),
-            )
-        }
+    /// The same app with no `functions:` at all — what a hot reload that
+    /// removes the declaration produces.
+    fn app_with_no_functions() -> Arc<app::App> {
+        Arc::new(
+            app::AppBuilder::new("plan_cache_function_diff")
+                .with_runtime(spicepod::component::runtime::Runtime {
+                    functions: spicepod::component::runtime::Functions::enabled(),
+                    ..Default::default()
+                })
+                .build(),
+        )
+    }
 
-        static SQL: &str = "SELECT myscale(21) AS v";
-
-        let doubling = app_with_body("x * 2");
-        let tripling = app_with_body("x * 3");
-
-        // `Runtime::builder().build()` registers the app's `functions:` and
-        // `Runtime::init_caching` installs the plans cache unconditionally, so
-        // building from the app is the whole setup — nothing about caching
-        // needs to be configured for the window to exist.
+    /// A runtime built from `app`, with the plans cache `Runtime::init_caching`
+    /// installs unconditionally, plus a cached plan for `sql` and the key it
+    /// was cached under.
+    async fn runtime_with_cached_plan(
+        app: &Arc<app::App>,
+        sql: &'static str,
+    ) -> (
+        crate::Runtime,
+        Arc<crate::datafusion::DataFusion>,
+        Arc<dyn cache::TabledCacheProvider<datafusion::logical_expr::LogicalPlan> + Send + Sync>,
+        cache::key::RawCacheKey,
+    ) {
         let runtime = crate::Runtime::builder()
-            .with_app_opt(Some(Arc::clone(&doubling)))
+            .with_app_opt(Some(Arc::clone(app)))
             .build()
             .await;
         let df = Arc::clone(&runtime.df);
@@ -1388,23 +1389,46 @@ body: \"{body}\"
             .plans_cache_provider()
             .expect("the plans cache is installed unconditionally");
 
-        // Any hasher works here — the key only has to be the same on both lookups.
-        let key = cache::key::CacheKey::Query(SQL, None)
+        // Any hasher works — the key only has to be the same on every lookup.
+        let key = cache::key::CacheKey::Query(sql, None)
             .as_raw_key(Box::new(std::hash::DefaultHasher::new()));
-        let plan = df
-            .get_or_create_logical_plan(&df.ctx.state(), Some(&key), SQL)
+        df.get_or_create_logical_plan(&df.ctx.state(), Some(&key), sql)
             .await
             .expect("the query over myscale should plan");
-        assert_eq!(
-            eval_i64(&df.ctx, plan).await,
-            42,
-            "precondition: the first body must be the one that answers"
-        );
         plans.checkpoint().await;
         assert_eq!(
             plans.item_count().await,
             1,
-            "precondition: the plan must be cached, or this test cannot observe staleness"
+            "precondition: the plan must be cached, or the test cannot observe staleness"
+        );
+
+        (runtime, df, plans, key)
+    }
+
+    /// A cached logical plan embeds the `Arc<ScalarUDF>` it was planned
+    /// against, so it keeps evaluating that UDF's own body regardless of what
+    /// the session context now holds for the name. The plan cache is installed
+    /// unconditionally with a one-hour TTL, so a hot reload that redefines a
+    /// `functions:` body must discard the cached plans or the old body keeps
+    /// answering the same SQL for up to an hour.
+    ///
+    /// Regression test for #13873.
+    #[tokio::test]
+    async fn function_diff_discards_cached_plans_so_a_redefined_body_answers() {
+        static SQL: &str = "SELECT myscale(21) AS v";
+
+        let doubling = app_with_body("x * 2");
+        let tripling = app_with_body("x * 3");
+        let (runtime, df, plans, key) = runtime_with_cached_plan(&doubling, SQL).await;
+
+        let cached = df
+            .get_or_create_logical_plan(&df.ctx.state(), Some(&key), SQL)
+            .await
+            .expect("the cached plan should come back");
+        assert_eq!(
+            eval_i64(&df.ctx, cached).await,
+            42,
+            "precondition: the first body must be the one that answers"
         );
 
         // The hot reload: `myscale` is redefined, which takes the same drop
@@ -1427,6 +1451,66 @@ body: \"{body}\"
             eval_i64(&df.ctx, replanned).await,
             63,
             "the redefined body must answer; 42 means the cached plan's old ScalarUDF answered"
+        );
+    }
+
+    /// The removal path has its own exit from the diff: a reload that drops
+    /// every `functions:` entry returns through `new_app.functions.is_empty()`
+    /// before any registration runs, so that arm has to report the drop on its
+    /// own. A plan surviving it still holds the removed function and keeps
+    /// answering for a name the user has taken away.
+    ///
+    /// Regression test for #13873.
+    #[tokio::test]
+    async fn function_diff_discards_cached_plans_when_a_reload_removes_every_function() {
+        static SQL: &str = "SELECT myscale(21) AS v";
+
+        let doubling = app_with_body("x * 2");
+        let removed = app_with_no_functions();
+        let (runtime, df, plans, key) = runtime_with_cached_plan(&doubling, SQL).await;
+
+        // Exits through the `new_app.functions.is_empty()` arm, not the tail.
+        apply_function_diff(&runtime, &doubling, &removed).await;
+
+        plans.checkpoint().await;
+        assert_eq!(
+            plans.item_count().await,
+            0,
+            "removing every function must discard the cached plans; a plan left in the cache \
+             still holds the removed ScalarUDF"
+        );
+
+        // Re-planning now fails to resolve the name, which is the correct
+        // outcome: the user removed the function. The point is that the query
+        // no longer silently answers from the copy the cached plan held.
+        let err = df
+            .get_or_create_logical_plan(&df.ctx.state(), Some(&key), SQL)
+            .await
+            .expect_err("the removed function must not resolve after the reload");
+        assert!(
+            err.to_string().contains("myscale"),
+            "the planning error should name the removed function, got: {err}"
+        );
+    }
+
+    /// The signal is "the registered set changed", not "a reload happened":
+    /// a reload that leaves `functions:` untouched must keep the cached plans,
+    /// or every unrelated spicepod edit throws away the whole plan cache.
+    #[tokio::test]
+    async fn function_diff_keeps_cached_plans_when_the_function_set_is_unchanged() {
+        static SQL: &str = "SELECT myscale(21) AS v";
+
+        let doubling = app_with_body("x * 2");
+        let same = app_with_body("x * 2");
+        let (runtime, _df, plans, _key) = runtime_with_cached_plan(&doubling, SQL).await;
+
+        apply_function_diff(&runtime, &doubling, &same).await;
+
+        plans.checkpoint().await;
+        assert_eq!(
+            plans.item_count().await,
+            1,
+            "an unchanged function set must not discard cached plans"
         );
     }
 


### PR DESCRIPTION
## Summary

A cached logical plan embeds the `Arc<ScalarUDF>` it was planned against, so it keeps
evaluating that UDF's own body regardless of what the session context now holds for the name.
`apply_function_diff` deregistered and re-registered user functions on a spicepod hot reload
without touching the plan cache, so the same SQL kept answering from a dropped or redefined
function.

The window is open in a default deployment: the plan cache is installed **unconditionally**
with a **1-hour TTL** (`crates/runtime/src/init/caching.rs:63-76` — unlike the results, search
and embeddings caches beside it, each behind `if <config>.enabled`) and is keyed on the SQL
text alone (`crates/cache/src/key.rs:100`). No caching needs to be configured, and no
accelerator or federation is involved.

Root cause: a SQL `functions:` body is parsed and lowered to a `PhysicalExpr` at **build**
time and baked into the `SqlScalarUdf`
(`crates/runtime-datafusion-udfs/src/user_functions/sql.rs:175`), so the pre-reload `Arc`
carries the old body for as long as anything holds it. Dataset and view registration already
discard cached plans for exactly this reason (`init/dataset.rs:1179`, `init/view.rs:444`:
"Updating a dataset may cause the cached LogicalPlans to be obsolete, so we remove them").
The function diff was the outlier.

Note this is broader than the *removal* case #13873 describes: `apply_function_diff` drops a
function whenever `next != current`, so a **redefined body** takes the same path — and that is
a plain silent wrong answer on `trunk` today, needing nothing from the deny-list work #13873
was filed against.

## Changes

- `apply_function_diff` now delegates to `apply_function_diff_inner`, which reports whether the
  registered set actually changed, and discards the cached plans when it did.
- The signal is precise rather than "clear on every reload": a drop, a redefinition, or a newly
  registered function clears; a reload that leaves the function set untouched does not. Both
  early returns (`new_app.functions.is_empty()`, `!new_enabled`) report drops that already
  happened, so a reload that removes every function still clears. A registration that *fails to
  build* still clears, because its drop already took the old function out.
- Regression test `function_diff_discards_cached_plans_so_a_redefined_body_answers`.

## Test plan

**Reproduced end-to-end on a real `spiced`** — one CSV dataset, one `from: sql` user function,
`--pods-watcher-enabled`, no caching configured. Same command both times; the only difference
is the fix.

Fixture (`spicepod.yaml`), hot-reloaded by rewriting `body:` from `x * 2` to `x * 3`:

```yaml
runtime:
  functions:
    enabled: true
functions:
  - name: myscale
    from: sql
    kind: scalar
    volatility: immutable
    signature:
      args: [{ name: x, type: int64 }]
      returns: int64
    body: x * 2
```

Before — `trunk` @ `91f73ca290`:

```
A. myscale(21) with body 'x * 2'      -> [{"v":42}]
   INFO runtime::datafusion::udf: Deregistered user function name=myscale
   INFO runtime::datafusion::udf: Registered user function name=myscale from=sql
B. SAME SQL after reload to 'x * 3'   -> [{"v":42}]   <-- the bug; expected 63
C. CONTROL, different SQL text        -> [{"v":63}]   <-- new body IS registered
D. CONTROL, different argument        -> [{"v":60}]   <-- new body IS registered
```

After — this branch, same fixture and same commands:

```
A. myscale(21) with body 'x * 2'      -> [{"v":42}]
   INFO runtime::datafusion::udf: Deregistered user function name=myscale
   INFO runtime::datafusion::udf: Registered user function name=myscale from=sql
B. SAME SQL after reload to 'x * 3'   -> [{"v":63}]   <-- fixed
C. CONTROL, different SQL text        -> [{"v":63}]
D. CONTROL, different argument        -> [{"v":60}]
```

Controls C and D are what make this a located defect rather than a symptom: the reload genuinely
took effect and the new body evaluates correctly, so the only thing wrong is that the query whose
plan was already cached kept using the deregistered `ScalarUDF`.

The regression test discriminates — run with the production `clear_cached_plans()` call neutered
and the test otherwise untouched, it fails; restored, it passes:

```
# fix neutered
test datafusion::udf::tests::function_diff_discards_cached_plans_so_a_redefined_body_answers ... FAILED
  panicked at crates/runtime/src/datafusion/udf.rs:1412:
  assertion `left == right` failed: a function diff must discard the cached plans; a plan left in
  the cache still holds the pre-reload ScalarUDF
    left: 1
   right: 0
test result: FAILED. 0 passed; 1 failed

# fix restored
test datafusion::udf::tests::function_diff_discards_cached_plans_so_a_redefined_body_answers ... ok
test result: ok. 1 passed; 0 failed
```

Gate:

```bash
make lint
```

```bash
make nextest
```

## Review gate

- Adversarial review: **skipped** — no engine available. Receipt
  `.git/worktrees/<wt>/spice-review-gate/adversarial-review.txt` reads `engine=none`, `exit=1`,
  `job=none`, with `attempt=codex result=exit-1` and `attempt=grok result=not-installed`. Codex's
  own reason, quoted from its log: `Codex error: Your workspace is out of credits. Ask your
  workspace owner to refill in order to continue.` Grok is not installed in this environment, so
  no permitted fallback existed. The reading here is not the only evidence — the defect was
  reproduced end-to-end on a running `spiced` above — so the skip does not leave the claim
  resting on code inspection.
- `/security-review`: ran, **no findings**. No new attack surface (no input parsing, no
  filesystem or network path, no deserialization, no route, no tool), no new caller or privilege
  boundary, and no secret or internal detail added to any log, error, or metric label. Cache
  *invalidation* is the safe direction — `invalidate_all()` only removes entries, so it cannot
  cross the per-principal plan-cache namespace (`as_raw_key_in_namespace`). It also narrows a
  pre-existing gap rather than widening one: `CODE_EXECUTING_FUNCTION_NAMES` gates read-only API
  keys out of code-executing functions, and a plan served from cache skips the re-plan that
  applies that gate.
- `/simplify`: ran, **one fix applied**. Collapsed the return value into a single `changed`
  binding (it was split across three lines because `registered_function_names` is moved into the
  deny list) and removed a test import the compiler reported unused. Two findings noted and
  deliberately not changed: the *altitude* option of keying the plan cache on a function-registry
  generation so invalidation is precise rather than global — that changes `CacheKey` derivation
  for every cache consumer, and this fix sits at the same altitude as the two existing
  precedents; and the *efficiency* observation that the clear is coarse —
  `TabledCacheProvider` offers only table-scoped invalidation, so there is no function-scoped
  equivalent to call, and dataset/view registration are equally coarse. No behaviour changed, no
  test weakened, no snapshot edited.

**Re-attested for `d1c756f`**, the review-feedback push. That iteration is **test-only** — the
production diff is byte-identical to the one reviewed above. Adversarial review re-attempted and
**skipped again**, same receipt shape (`engine=none`, `exit=1`; codex still reports the workspace
out of credits, grok still absent). `/security-review` not re-run: the change adds no production
code and no security-relevant surface, which the hygiene guidance names as the case where a second
audit is not required. The `/simplify` pass on that iteration is folded into the change itself —
the three tests share `app_with_body` / `app_with_no_functions` / `runtime_with_cached_plan`
helpers rather than repeating the fixture.

## Out of scope, filed separately

`apply_catalog_diff` has the same shape — it reloads a changed catalog and replaces the provider
(`init/catalog.rs:232-240` → `register_catalog` → `ctx.register_catalog`) without discarding
cached plans, so a cached plan can keep reading the pre-reload catalog's provider. Filed as
#13910, labelled *unverified, code inspection only*: reproducing it needs a live catalog
connector whose params change under a hot reload, which this pass did not run.

Refs #13873
