### PR TITLE
fix(cli): keep the API key on its origin in the SDK-built query client (fixes #12502)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20002,7 +20002,7 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "3.2.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=93b75c3c7d1a812b23d00b45adf537d7a2415496#93b75c3c7d1a812b23d00b45adf537d7a2415496"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=3267ff355f1bc2e0f382aa0b1e0113e5b98f1d76#3267ff355f1bc2e0f382aa0b1e0113e5b98f1d76"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -472,7 +472,7 @@ vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "3c52468
 vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "3c5246867e627158211e8eafab7be55b0dc559f8" } # branch: spiceai-54 (vortex 0.79.0)
 
 x509-certificate = "0.25.0"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "93b75c3c7d1a812b23d00b45adf537d7a2415496" } # spiceai/spice-rs#77
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "3267ff355f1bc2e0f382aa0b1e0113e5b98f1d76" } # spiceai/spice-rs#85: same-origin redirect policy on the credentialed client
 
 [profile.release-lto]
 inherits = "release"

--- a/bin/spice/src/commands/query/mod.rs
+++ b/bin/spice/src/commands/query/mod.rs
@@ -950,3 +950,125 @@ fn print_query_help() {
     println!("  - Press Ctrl+D or type .exit to quit");
     println!();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::Deadline;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+    const API_KEY: &str = "cli-api-key-must-not-leak";
+
+    fn submitted() -> ResponseTemplate {
+        ResponseTemplate::new(202).set_body_json(json!({
+            "query_id": "query-1",
+            "status": "PENDING",
+            "status_url": "/v1/queries/query-1/status",
+            "results_url": "/v1/queries/query-1/results"
+        }))
+    }
+
+    /// A 307 keeps the method and the body, so a hop that is followed replays the
+    /// credentialed `POST` verbatim to `location`.
+    fn redirect_to(location: &str) -> ResponseTemplate {
+        ResponseTemplate::new(307).insert_header("location", location)
+    }
+
+    fn context_for(runtime: &MockServer) -> RuntimeContext {
+        RuntimeContext::with_deadlines_for_test(
+            &runtime.uri(),
+            Deadline::Total(Duration::from_secs(30)),
+            Deadline::Silence(Duration::from_secs(30)),
+        )
+        .with_api_key_for_test(API_KEY)
+    }
+
+    fn api_key_header(request: &Request) -> Option<String> {
+        request
+            .headers
+            .get("x-api-key")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned)
+    }
+
+    /// `spice query` builds its client from the SDK rather than from
+    /// `RuntimeContext::http_client`, so the CLI's own same-origin redirect policy does not
+    /// reach it: the SDK has to refuse to leave the origin itself. The key travels as
+    /// `X-API-Key`, which `reqwest` does not strip on a cross-origin hop the way it strips
+    /// `Authorization`, so a runtime, proxy or ingress answering with an off-origin
+    /// `Location` would otherwise be handed the key.
+    /// <https://github.com/spiceai/spiceai/issues/12502>
+    #[tokio::test]
+    async fn the_query_client_does_not_carry_the_api_key_off_its_origin() {
+        let elsewhere = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/queries"))
+            .respond_with(submitted())
+            .mount(&elsewhere)
+            .await;
+
+        let runtime = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/queries"))
+            .respond_with(redirect_to(&format!("{}/v1/queries", elsewhere.uri())))
+            .mount(&runtime)
+            .await;
+
+        let client = build_client(&context_for(&runtime))
+            .await
+            .expect("building the client dials nothing");
+        let submitted = client.query("SELECT 1").await;
+
+        let leaked = elsewhere
+            .received_requests()
+            .await
+            .expect("the mock server records its requests");
+        assert!(
+            leaked.is_empty(),
+            "the redirect target received {} request(s); the first carried X-API-Key = {:?}",
+            leaked.len(),
+            leaked.first().and_then(api_key_header)
+        );
+        assert!(
+            submitted.is_err(),
+            "a refused redirect must not read as a submitted query"
+        );
+    }
+
+    /// The policy is about the origin, not about redirects: a hop that stays on the
+    /// configured origin is followed, and the key goes with it.
+    #[tokio::test]
+    async fn the_query_client_follows_a_same_origin_redirect_with_the_api_key() {
+        let runtime = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/queries"))
+            .respond_with(redirect_to(&format!("{}/v1/queries/moved", runtime.uri())))
+            .mount(&runtime)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/queries/moved"))
+            .respond_with(submitted())
+            .mount(&runtime)
+            .await;
+
+        let client = build_client(&context_for(&runtime))
+            .await
+            .expect("building the client dials nothing");
+        client
+            .query("SELECT 1")
+            .await
+            .expect("a same-origin redirect is followed through to the submission");
+
+        let requests = runtime
+            .received_requests()
+            .await
+            .expect("the mock server records its requests");
+        let moved = requests
+            .iter()
+            .find(|request| request.url.path() == "/v1/queries/moved")
+            .expect("the redirected submission reached the runtime");
+        assert_eq!(api_key_header(moved).as_deref(), Some(API_KEY));
+    }
+}

--- a/bin/spice/src/context.rs
+++ b/bin/spice/src/context.rs
@@ -253,6 +253,16 @@ impl RuntimeContext {
         }
     }
 
+    /// The context [`with_deadlines_for_test`](Self::with_deadlines_for_test) builds, carrying
+    /// an API key — for the tests that check where a credential is and is not sent.
+    #[cfg(test)]
+    pub(crate) fn with_api_key_for_test(self, api_key: &str) -> Self {
+        Self {
+            api_key: Some(api_key.to_string()),
+            ..self
+        }
+    }
+
     /// Create a context whose runtime binary is `<spice_bin_dir>/spiced`.
     ///
     /// This is how a test drives the parts of the CLI that *run* the runtime —


### PR DESCRIPTION
## Summary

`spice query` and `spice nsql analyze` do not use `RuntimeContext::http_client`; they build their own credentialed client from the pinned `spiceai` SDK (`bin/spice/src/commands/query/mod.rs::build_client`, `bin/spice/src/commands/nsql/analyze.rs::build_spice_client`). The CLI's same-origin redirect policy from #12495 therefore never reached them, and the SDK at the pinned rev `93b75c3` sent the key as a custom `X-API-Key` header on a stock `reqwest` client — which strips only `Authorization`, `Cookie`, `cookie2`, `Proxy-Authorization` and `WWW-Authenticate` on a cross-origin hop. A runtime, proxy or ingress answering a `POST /v1/queries` with an off-origin `Location` was handed the key.

The SDK fixed this in spiceai/spice-rs#85 (merged 2026-08-05): every HTTP client it builds now carries a same-origin redirect policy (`src/redirect.rs`), and a hop that leaves the origin is refused rather than followed. This PR moves the workspace pin to that commit and adds a CLI-side regression test that exercises `build_client` itself, so the guarantee is checked where the CLI relies on it, not only inside the SDK.

`spice nsql analyze` builds its client the same way (`build_spice_client`) and the SDK policy covers it identically; per the issue's own analysis it only sends the key when it actually reaches the `/v1/queries` API, which is why the test targets `spice query`.

## Changes

- `Cargo.toml` / `Cargo.lock`: `spiceai` git pin `93b75c3c` (spice-rs#77) → `3267ff35` (spice-rs#85). The lockfile change is the single `source` line; validated with `cargo metadata --locked`. The SDK's own dependency pins are unchanged in kind (`arrow` 58 → 58.3 tightens within the version the lock already resolves to; `reqwest` stays 0.12).
- `bin/spice/src/commands/query/mod.rs`: two `#[cfg(test)]` tests against `build_client` with `wiremock` — an off-origin 307 must not deliver `X-API-Key` to the redirect target and must not read as a submitted query; a same-origin 307 is still followed with the key.
- `bin/spice/src/context.rs`: `RuntimeContext::with_api_key_for_test`, a `#[cfg(test)]` builder so the test context carries a key.

## Test plan

- [x] `make lint` (fmt + clippy with the repo's deny set; never a per-crate invocation)
- [x] `make test` / `make nextest` via `make signoff` after push
- [x] Reproduction on `trunk` (pin `93b75c3`), then the same command on this branch:

```
# trunk pin (93b75c3c), same test module:
$ cargo test --manifest-path bin/spice/Cargo.toml --lib -- commands::query::tests
test commands::query::tests::the_query_client_follows_a_same_origin_redirect_with_the_api_key ... ok
test commands::query::tests::the_query_client_does_not_carry_the_api_key_off_its_origin ... FAILED
---- commands::query::tests::the_query_client_does_not_carry_the_api_key_off_its_origin stdout ----
panicked at bin\spice\src\commands\query\mod.rs:1028:9:
the redirect target received 1 request(s); the first carried X-API-Key = Some("cli-api-key-must-not-leak")
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 524 filtered out

# this branch (3267ff35):
$ cargo test --manifest-path bin/spice/Cargo.toml --lib -- commands::query::tests
test commands::query::tests::the_query_client_does_not_carry_the_api_key_off_its_origin ... ok
test commands::query::tests::the_query_client_follows_a_same_origin_redirect_with_the_api_key ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 524 filtered out
```

Run on Windows, where `bin/spice`'s test target only compiles with a throwaway local gate on two pre-existing Unix-only tests (`nix::unistd` in `connect/service`, `passwd_entry_home` in `context.rs`); that patch was reverted before commit and is not in this diff. `cargo clippy --lib --no-deps -D warnings -W clippy::pedantic` on the crate reports nothing in the two files this PR touches; its remaining errors are trunk's Windows-cfg lints (`runtime_launcher.rs`, `connect/service/manifest.rs`, `cluster.rs`), the shape #13687 tracks, so the full `make lint` verdict comes from the sign-off run.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits"; `grok` is not permitted under this identity (receipt on head `ebc9531d9a`)
- `/security-review`: no findings — the diff is a dependency pin move plus `#[cfg(test)]` code (run by hand against this worktree's diff; the slash command diffs the primary checkout). The SDK delta between the two pins (`93b75c3c..3267ff35`: `client.rs`, `params.rs`, `query.rs`, new `redirect.rs`) was read for credential handling: it adds no logging of the key, and the one credential-touching change is the same-origin redirect policy that narrows the exposure.
- `/simplify`: reviewed the branch diff by hand for reuse and dead code — nothing to apply; the two test helpers are each used twice and the context builder mirrors the existing `with_deadlines_for_test`

Fixes #12502

## Checklist

- [x] No `.unwrap()` in new code (tests use `expect` with a reason)
- [x] `cargo fmt --all` clean; no `.claude/worktrees/` paths
- [x] No customer, credential, or internal-infrastructure detail in this body or the diff