### PR TITLE
fix(cayenne): an unreviewed unverified order fails the correctness gate

### DIFF
--- a/crates/cayenne/tests/correctness/support/inventory.rs
+++ b/crates/cayenne/tests/correctness/support/inventory.rs
@@ -44,6 +44,36 @@ pub struct InventoryEntry {
     pub chdb_exclusion: Option<&'static str>,
     /// `None` means compared vs SQLite; `Some(reason)` is a justified exclusion.
     pub sqlite_exclusion: Option<&'static str>,
+    /// `Some(reason)` names why this query's own `ORDER BY` cannot be fully
+    /// verified — an `ORDER BY` term the result columns do not carry, so no
+    /// engine's row order can be checked against it. Reviewed here rather than
+    /// tolerated at the gate: an unverified order that nobody has looked at is
+    /// the outcome the sort check exists to surface, so it fails instead.
+    pub order_unchecked_review: Option<&'static str>,
+}
+
+/// Why a query's `ORDER BY` cannot be verified against its own result columns.
+///
+/// Every entry is an `ORDER BY` over an expression the projection does not
+/// carry, so there is no output column holding the values the engine sorted by.
+/// The mappable leading terms are still enforced where there are any; the list
+/// records what remains unverified so a *new* hole cannot hide among them.
+fn order_unchecked_review(suite: &str, name: &str) -> Option<&'static str> {
+    match (suite, name) {
+        ("tpcds", "tpcds_q36" | "tpcds_q70" | "tpcds_q86") => Some(
+            "ORDER BY over `CASE WHEN lochierarchy = 0 THEN …`, which the projection \
+             does not carry; the leading `lochierarchy` term is still enforced",
+        ),
+        ("tpcds", "tpcds_q47" | "tpcds_q57" | "tpcds_q89") => Some(
+            "ORDER BY over the derived `sum_sales - avg_monthly_sales`, which the \
+             projection does not carry, so no result column holds the sort key",
+        ),
+        ("clickbench", "clickbench_q25" | "clickbench_q27") => Some(
+            "ORDER BY over a `to_timestamp(…)` expression absent from the projection, \
+             so no result column holds the sort key",
+        ),
+        _ => None,
+    }
 }
 
 /// Build the full inventory from suite sources + micro + SQLLancer.
@@ -65,6 +95,7 @@ pub fn build_inventory() -> Vec<InventoryEntry> {
                 "TPC-H SQL uses DataFusion/DuckDB dialect (EXTRACT, INTERVAL, …); \
                  SQLite lane covers SSB + SQLLancer + micro",
             ),
+            order_unchecked_review: order_unchecked_review("tpch", q.name.as_ref()),
         });
     }
 
@@ -82,6 +113,7 @@ pub fn build_inventory() -> Vec<InventoryEntry> {
                 "TPC-DS SQL targets DataFusion/DuckDB dialect; \
                  SQLite lane covers SSB + SQLLancer + micro",
             ),
+            order_unchecked_review: order_unchecked_review("tpcds", q.name.as_ref()),
         });
     }
 
@@ -98,6 +130,7 @@ pub fn build_inventory() -> Vec<InventoryEntry> {
                 "ClickBench hits schema/SQL surface is DataFusion-oriented; \
                  SQLite lane covers SSB + SQLLancer + micro",
             ),
+            order_unchecked_review: order_unchecked_review("clickbench", q.name.as_ref()),
         });
     }
 
@@ -113,6 +146,7 @@ pub fn build_inventory() -> Vec<InventoryEntry> {
             sqlite_exclusion: Some(
                 "CH-benCHmark SQL uses mod()/dialect forms; SQLite lane covers SSB + SQLLancer + micro",
             ),
+            order_unchecked_review: order_unchecked_review("chbench", q.name.as_ref()),
         });
     }
 
@@ -127,6 +161,7 @@ pub fn build_inventory() -> Vec<InventoryEntry> {
                  chDB runs SQLLancer + micro",
             ),
             sqlite_exclusion: None,
+            order_unchecked_review: order_unchecked_review("ssb", q.name.as_ref()),
         });
     }
 
@@ -134,6 +169,7 @@ pub fn build_inventory() -> Vec<InventoryEntry> {
     for q in get_tpch_test_queries(None) {
         let name = q.name.replacen("tpch_", "spicebench_", 1);
         let sq = Query::new(name.clone().into(), Arc::clone(&q.sql), false);
+        let review = order_unchecked_review("spicebench", &name);
         entries.push(InventoryEntry {
             suite: "spicebench",
             name,
@@ -145,6 +181,7 @@ pub fn build_inventory() -> Vec<InventoryEntry> {
             sqlite_exclusion: Some(
                 "SpiceBench SF1 is TPC-H dialect; SQLite lane covers SSB + SQLLancer + micro",
             ),
+            order_unchecked_review: review,
         });
     }
 
@@ -156,6 +193,7 @@ pub fn build_inventory() -> Vec<InventoryEntry> {
             duckdb_exclusion: None,
             chdb_exclusion: sqllancer_chdb_exclusion(&q),
             sqlite_exclusion: sqllancer_sqlite_exclusion(&q),
+            order_unchecked_review: order_unchecked_review("sqllancer", q.name.as_ref()),
         });
     }
 
@@ -167,6 +205,7 @@ pub fn build_inventory() -> Vec<InventoryEntry> {
             duckdb_exclusion: None,
             chdb_exclusion: None,
             sqlite_exclusion: None,
+            order_unchecked_review: order_unchecked_review("micro", q.name.as_ref()),
         });
     }
 

--- a/crates/cayenne/tests/correctness/support/mod.rs
+++ b/crates/cayenne/tests/correctness/support/mod.rs
@@ -78,6 +78,48 @@ use test_framework::queries::{
     get_tpch_test_queries,
 };
 
+/// Whether `dir` already holds a fixture that *this* generator finished writing.
+///
+/// The scratch tree (`target/cayenne_parity_scratch` by default) outlives
+/// builds, branch switches and self-hosted CI jobs, so "some parquet is here"
+/// says nothing about which generator produced it. Reusing on that alone lets a
+/// fixture written before a generator change quietly revert whatever the change
+/// was for — and a suite comparing two engines against the same stale rows still
+/// agrees with itself, so nothing turns red.
+///
+/// The stamp closes both halves. It is written only after every file lands, so
+/// an interrupted run leaves no stamp and is regenerated rather than reused
+/// half-written; and it records `revision`, so a fixture from an older generator
+/// no longer matches.
+#[must_use]
+pub fn fixture_is_current(dir: &Path, revision: &str) -> bool {
+    std::fs::read_to_string(dir.join(FIXTURE_STAMP)).is_ok_and(|stamp| stamp.trim() == revision)
+}
+
+/// Record that `dir` now holds a complete fixture built by `revision`.
+///
+/// Call only once every file is written: the stamp is what a later run trusts.
+pub fn mark_fixture_complete(dir: &Path, revision: &str) {
+    std::fs::write(dir.join(FIXTURE_STAMP), revision).expect("write fixture stamp");
+}
+
+/// Digest of a generator's own source, used as its fixture revision.
+///
+/// Derived from the source rather than a hand-maintained constant because the
+/// constant is what gets forgotten: the edit that changes the generated rows is
+/// exactly the moment someone is thinking about the data, not the version.
+#[must_use]
+pub fn generator_revision(source: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    source.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// Name of the stamp file. Dotted so directory scans that collect `*.parquet`
+/// table names never pick it up.
+const FIXTURE_STAMP: &str = ".fixture-complete";
+
 /// Outcome for one inventory query on one engine pair.
 /// Outcome of the **harness** after executing SQL and comparing actual batches.
 #[derive(Debug, Clone)]
@@ -104,12 +146,18 @@ pub enum ParityOutcome {
 }
 
 impl ParityOutcome {
+    /// Whether this outcome needs no explanation.
+    ///
+    /// `OrderUnchecked` is deliberately absent. It means the rows matched and
+    /// the order they came back in was never verified, which is the outcome the
+    /// sort check exists to surface — counting it here would let a resolver
+    /// regression, or an `ORDER BY` the projection stops carrying, settle into a
+    /// summary bucket instead of turning a lane red. A hole that has been looked
+    /// at is named in the inventory and accepted by [`report::unexplained`]; one
+    /// that has not fails.
     #[must_use]
     pub fn is_pass_or_excluded(&self) -> bool {
-        matches!(
-            self,
-            Self::Pass | Self::Excluded { .. } | Self::OrderUnchecked { .. }
-        )
+        matches!(self, Self::Pass | Self::Excluded { .. })
     }
 }
 

--- a/crates/cayenne/tests/correctness/support/report.rs
+++ b/crates/cayenne/tests/correctness/support/report.rs
@@ -29,6 +29,37 @@ pub struct RunResult {
     pub outcome: ParityOutcome,
 }
 
+/// The results a lane must not accept.
+///
+/// A `Pass` needs no explanation and an `Excluded` carries its own. An
+/// `OrderUnchecked` is accepted only where the inventory names why that query's
+/// `ORDER BY` cannot be verified against its own result columns — otherwise it
+/// lands here, because an order nothing verified and nobody reviewed is exactly
+/// what the sort check was added to stop passing quietly.
+///
+/// A reviewed name does not blanket the query: it accepts an unverified order,
+/// not a violation or a content mismatch, both of which stay failures.
+#[must_use]
+pub fn unexplained<'a>(
+    results: &'a [RunResult],
+    inventory: &[InventoryEntry],
+) -> Vec<&'a RunResult> {
+    results
+        .iter()
+        .filter(|r| {
+            if r.outcome.is_pass_or_excluded() {
+                return false;
+            }
+            if !matches!(r.outcome, ParityOutcome::OrderUnchecked { .. }) {
+                return true;
+            }
+            !inventory.iter().any(|e| {
+                e.suite == r.suite && e.name == r.name && e.order_unchecked_review.is_some()
+            })
+        })
+        .collect()
+}
+
 /// Write a machine-readable + human coverage report.
 pub fn write_coverage_report(path: &Path, results: &[RunResult]) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {

--- a/crates/cayenne/tests/correctness/support/ssb_data.rs
+++ b/crates/cayenne/tests/correctness/support/ssb_data.rs
@@ -31,6 +31,22 @@ use test_framework::queries::Query;
 pub const SSB_TABLES: &[&str] = &["lineorder", "customer", "supplier", "part", "date"];
 
 /// Write all SSB tables as `{table}.parquet` under `out_dir`.
+/// Generate the SSB fixture into `out_dir` unless this generator already
+/// finished writing one there.
+///
+/// Shared by every SSB lane so the reuse rule is decided once. A bare
+/// `if !lineorder.parquet.exists()` is not that rule: it accepts a fixture an
+/// older generator wrote, and this one's rows are what the ORDER BY checks are
+/// calibrated against.
+pub fn ensure_ssb_fixture(out_dir: &Path, scale: i64) {
+    let revision = super::generator_revision(include_str!("ssb_data.rs"));
+    if super::fixture_is_current(out_dir, &revision) {
+        return;
+    }
+    write_ssb_parquet(out_dir, scale);
+    super::mark_fixture_complete(out_dir, &revision);
+}
+
 pub fn write_ssb_parquet(out_dir: &Path, scale: i64) {
     std::fs::create_dir_all(out_dir).expect("ssb out dir");
     let scale = scale.max(1);

--- a/crates/cayenne/tests/correctness/support/tpch_data.rs
+++ b/crates/cayenne/tests/correctness/support/tpch_data.rs
@@ -95,6 +95,18 @@ fn date(name: &str) -> Field {
 
 /// Generate every TPC-H table at `scale_factor` and write it as parquet under
 /// `out_dir`, matching the layout the lane already loads from.
+/// Generate the TPC-H fixture into `out_dir` unless this generator already
+/// finished writing one there. Same reuse rule as the SSB fixture: a leftover
+/// tree from an older generator is regenerated rather than trusted.
+pub fn ensure_tpch_fixture(out_dir: &Path, scale_factor: f64) {
+    let revision = super::generator_revision(include_str!("tpch_data.rs"));
+    if super::fixture_is_current(out_dir, &revision) {
+        return;
+    }
+    write_tpch_parquet(out_dir, scale_factor);
+    super::mark_fixture_complete(out_dir, &revision);
+}
+
 pub fn write_tpch_parquet(out_dir: &Path, scale_factor: f64) {
     std::fs::create_dir_all(out_dir).expect("tpch out dir");
     for (name, batch) in tpch_batches(scale_factor) {

--- a/crates/cayenne/tests/result_correctness_inventory_test.rs
+++ b/crates/cayenne/tests/result_correctness_inventory_test.rs
@@ -417,6 +417,57 @@ fn a_content_only_recovery_cannot_pass_an_unverified_order() {
     );
 }
 
+/// An order nothing verified must fail the lane unless the inventory names why
+/// it cannot be verified. Counting every `OrderUnchecked` as acceptable is how a
+/// resolver regression — or an `ORDER BY` whose projection stops carrying the
+/// term — settles into a summary bucket instead of turning a lane red, which is
+/// the outcome the sort check exists to surface.
+#[test]
+fn an_unreviewed_unverified_order_fails_the_lane() {
+    use support::report::{RunResult, unexplained};
+
+    let hole = |suite: &str, name: &str| RunResult {
+        suite: suite.to_string(),
+        name: name.to_string(),
+        engine_pair: "cayenne-duckdb",
+        outcome: support::ParityOutcome::OrderUnchecked {
+            reasons: vec!["left: ORDER BY term does not map to a result column".to_string()],
+        },
+    };
+    let inventory = build_inventory();
+
+    // Reviewed in the inventory: an accepted, named hole.
+    let reviewed = [hole("tpcds", "tpcds_q36")];
+    assert!(
+        unexplained(&reviewed, &inventory).is_empty(),
+        "tpcds_q36's ORDER BY over a CASE the projection omits is reviewed"
+    );
+
+    // Not reviewed: the lane must not accept it.
+    let unreviewed = [hole("tpcds", "tpcds_q1")];
+    assert_eq!(
+        unexplained(&unreviewed, &inventory).len(),
+        1,
+        "an unverified order nobody has reviewed has to fail, not be counted"
+    );
+
+    // A violation is never covered by a review — that names an unverified order,
+    // not a wrong one.
+    let violating = [RunResult {
+        suite: "tpcds".to_string(),
+        name: "tpcds_q36".to_string(),
+        engine_pair: "cayenne-duckdb",
+        outcome: support::ParityOutcome::Fail {
+            detail: "SortOrderViolation".to_string(),
+        },
+    }];
+    assert_eq!(
+        unexplained(&violating, &inventory).len(),
+        1,
+        "a reviewed hole does not excuse a violation on the same query"
+    );
+}
+
 /// Prove the harness routes through the shipped `compare_query_result_batches`.
 #[test]
 fn harness_compare_actual_results_drives_shipped_path() {

--- a/crates/cayenne/tests/result_correctness_standalone_engines_test.rs
+++ b/crates/cayenne/tests/result_correctness_standalone_engines_test.rs
@@ -38,7 +38,7 @@ use std::path::PathBuf;
 
 use support::inventory::build_inventory;
 use support::report::{RunResult, summary_line};
-use support::ssb_data::{SSB_TABLES, ssb_queries, write_ssb_parquet};
+use support::ssb_data::{SSB_TABLES, ensure_ssb_fixture, ssb_queries};
 use support::standalone_engines::{
     STANDALONE_DUCKDB, STANDALONE_SQLITE, duckdb_query_batches, load_duckdb_from_batches,
     load_duckdb_from_parquet, load_sqlite_from_batches, load_sqlite_from_parquet,
@@ -152,9 +152,7 @@ async fn standalone_duckdb_vs_sqlite_ssb() {
     eprintln!("standalone SSB DuckDB vs SQLite scale={scale}");
 
     let ssb_dir = scratch.join(format!("ssb_scale{scale}"));
-    if !ssb_dir.join("lineorder.parquet").exists() {
-        write_ssb_parquet(&ssb_dir, scale);
-    }
+    ensure_ssb_fixture(&ssb_dir, scale);
 
     let (duck_temp, duck) = load_duckdb_from_parquet(&ssb_dir, SSB_TABLES);
     let (sqlite_temp, sqlite) = load_sqlite_from_parquet(&ssb_dir, SSB_TABLES).await;

--- a/crates/cayenne/tests/result_correctness_vs_chdb_test.rs
+++ b/crates/cayenne/tests/result_correctness_vs_chdb_test.rs
@@ -251,10 +251,12 @@ async fn micro_bench_shapes_full_result_parity_vs_chdb_inner() {
     write_coverage_report(&coverage_path, &results).expect("coverage");
     eprintln!("{}", summary_line(&results));
 
-    let micro_fails: Vec<_> = results
+    let micro: Vec<RunResult> = results
         .iter()
-        .filter(|r| r.suite == "micro" && !r.outcome.is_pass_or_excluded())
+        .filter(|r| r.suite == "micro")
+        .cloned()
         .collect();
+    let micro_fails = support::report::unexplained(&micro, &build_inventory());
     assert!(
         micro_fails.is_empty(),
         "chDB micro-bench full-result parity failures: {micro_fails:#?}\nsee {}",
@@ -468,10 +470,12 @@ async fn sqllancer_corpus_parity_vs_chdb_inner() {
     write_coverage_report(&scratch.join("parity_coverage_chdb.md"), &results).ok();
     eprintln!("{}", summary_line(&results));
 
-    let sl_fails: Vec<_> = results
+    let sqllancer: Vec<RunResult> = results
         .iter()
-        .filter(|r| r.suite == "sqllancer" && !r.outcome.is_pass_or_excluded())
+        .filter(|r| r.suite == "sqllancer")
+        .cloned()
         .collect();
+    let sl_fails = support::report::unexplained(&sqllancer, &build_inventory());
     assert!(
         sl_fails.is_empty(),
         "SQLLancer Cayenne↔chDB failures: {sl_fails:#?}\nsee {}",

--- a/crates/cayenne/tests/result_correctness_vs_duckdb_test.rs
+++ b/crates/cayenne/tests/result_correctness_vs_duckdb_test.rs
@@ -293,6 +293,49 @@ fn normalize_ts(s: &str) -> String {
 }
 
 /// Run SQL against parquet files via plain DataFusion (no Cayenne) as a baseline.
+/// Verify Cayenne on its own when DuckDB is the side that cannot run the query.
+///
+/// A DuckDB binder rejection is a fact about DuckDB, not about Cayenne. The
+/// DataFusion baseline resolves the same SQL over the same parquet, so Cayenne's
+/// rows — and, through the shared compare path, the order it returned them in —
+/// can still be checked. Recording the exclusion without doing that left these
+/// queries with no verification of Cayenne at all, in the lane whose job is to
+/// provide it.
+async fn verify_cayenne_against_baseline(
+    query: &Query,
+    cayenne: &CayenneHarness,
+    parquet_dir: &Path,
+    duckdb_reason: &str,
+) -> ParityOutcome {
+    let rows = match execute_cayenne(cayenne, query.sql.as_ref()).await {
+        Ok(rows) => rows,
+        Err(detail) => {
+            return ParityOutcome::EngineError {
+                side: "cayenne",
+                detail,
+            };
+        }
+    };
+    match datafusion_query_parquet(parquet_dir, cayenne.tables.keys(), query.sql.as_ref()).await {
+        // A pass here is still an exclusion from the *DuckDB* comparison, and is
+        // recorded as one so the inventory and the census keep agreeing; what
+        // changes is that Cayenne was actually checked before it was recorded.
+        Ok(baseline) => match compare_actual_results(query, &rows, &baseline) {
+            ParityOutcome::Pass => ParityOutcome::Excluded {
+                reason: format!(
+                    "{duckdb_reason}; Cayenne verified against the DataFusion baseline instead"
+                ),
+            },
+            judged => judged,
+        },
+        Err(e) => ParityOutcome::Excluded {
+            reason: format!(
+                "{duckdb_reason}; the DataFusion baseline could not run it either: {e}"
+            ),
+        },
+    }
+}
+
 async fn datafusion_query_parquet(
     parquet_dir: &Path,
     table_names: impl Iterator<Item = &String>,
@@ -349,10 +392,7 @@ async fn micro_bench_shapes_full_result_parity_vs_duckdb() {
         });
     }
 
-    let fails: Vec<_> = results
-        .iter()
-        .filter(|r| !r.outcome.is_pass_or_excluded())
-        .collect();
+    let fails = support::report::unexplained(&results, &build_inventory());
     let report_path = scratch.join("cayenne_duckdb_micro_parity.log");
     let mut log = String::new();
     for r in &results {
@@ -372,9 +412,7 @@ async fn micro_bench_shapes_full_result_parity_vs_duckdb() {
 /// Make sure the TPC-H fixture is on disk. Shared by the TPC-H and SpiceBench
 /// lanes, which load the same generated tables.
 fn ensure_tpch_fixture(dir: &Path, sf: f64) {
-    if !dir.join("lineitem.parquet").exists() {
-        generate_tpch_parquet(dir, sf);
-    }
+    support::tpch_data::ensure_tpch_fixture(dir, sf);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -431,10 +469,7 @@ async fn tpch_full_result_parity_vs_duckdb() {
     std::fs::write(&log_path, &log).expect("write tpch log");
     eprintln!("{}", summary_line(&results));
 
-    let fails: Vec<_> = results
-        .iter()
-        .filter(|r| !r.outcome.is_pass_or_excluded())
-        .collect();
+    let fails = support::report::unexplained(&results, &build_inventory());
     assert!(
         fails.is_empty(),
         "TPC-H full-result parity failures (SF={sf}): {fails:#?}\nsee {}",
@@ -472,9 +507,14 @@ const TPCDS_TABLES: &[&str] = &[
 
 /// Needs network for `INSTALL tpcds`; see [`generate_tpch_parquet`].
 fn generate_tpcds_parquet(out_dir: &Path, sf: f64) -> Option<PathBuf> {
-    std::fs::create_dir_all(out_dir).expect("tpcds out dir");
-    let gen_db = out_dir.join("gen.duckdb");
-    let conn = Connection::open(&gen_db).expect("duckdb open for tpcds gen");
+    // The generation database is temporary and fresh per run. `dsdgen` populates
+    // a schema and cannot be run twice against the same database — a reused one
+    // fails with `Table with name "call_center" already exists` the moment
+    // regeneration actually happens, which it never did while any leftover
+    // fixture was trusted.
+    let gen_home = tempfile::tempdir().expect("tpcds gen dir");
+    let conn =
+        Connection::open(gen_home.path().join("gen.duckdb")).expect("duckdb open for tpcds gen");
     // Only `INSTALL` reaches DuckDB's extension repository, so only it can fail
     // for want of a network and be reported as an environment that cannot supply
     // the fixture. Everything after it is local: a `LOAD` that fails means the
@@ -490,6 +530,12 @@ fn generate_tpcds_parquet(out_dir: &Path, sf: f64) -> Option<PathBuf> {
         .expect("load DuckDB's tpcds extension, which installed successfully");
     conn.execute_batch(&format!("CALL dsdgen(sf={sf});"))
         .expect("generate the TPC-DS fixture with dsdgen");
+
+    // Replace what is on disk only now that generation has succeeded, so a
+    // machine that could not reach the extension repository keeps the fixture it
+    // already had instead of losing it to a run that was never going to finish.
+    let _ = std::fs::remove_dir_all(out_dir);
+    std::fs::create_dir_all(out_dir).expect("tpcds out dir");
 
     // Export every base table that exists after dsdgen.
     let mut stmt = conn
@@ -514,8 +560,45 @@ fn generate_tpcds_parquet(out_dir: &Path, sf: f64) -> Option<PathBuf> {
         ))
         .unwrap_or_else(|e| panic!("export TPC-DS table {table}: {e}"));
     }
+    // The stamp says a run finished; this says it finished with the tables the
+    // suite expects. They catch different things: an interrupted export, and a
+    // `dsdgen` that quietly stops emitting one — which would otherwise surface
+    // as queries failing on both engines and settling into `Excluded`.
+    let exported: std::collections::BTreeSet<String> = std::fs::read_dir(out_dir)
+        .expect("read tpcds fixture dir")
+        .filter_map(Result::ok)
+        .filter_map(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .strip_suffix(".parquet")
+                .map(str::to_string)
+        })
+        .collect();
+    let missing: Vec<&str> = TPCDS_TABLES
+        .iter()
+        .copied()
+        .filter(|t| !exported.contains(*t))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "dsdgen produced no parquet for TPC-DS tables {missing:?} in {}",
+        out_dir.display()
+    );
+
+    // Stamped only now, with every table exported. A run killed part-way leaves
+    // the directory populated but unstamped, so the next one regenerates instead
+    // of reading a fixture that is missing tables — where the queries against
+    // those tables fail on both engines and settle into `Excluded`, which counts
+    // as a pass.
+    support::mark_fixture_complete(out_dir, TPCDS_FIXTURE_REVISION);
     Some(out_dir.to_path_buf())
 }
+
+/// Revision for the TPC-DS fixture. Unlike SSB and TPC-H the generator is
+/// DuckDB's `dsdgen`, not code in this repo, so there is no source to digest;
+/// the stamp is carried for its completeness half, and this bumps only if the
+/// export set or the extension pin changes.
+const TPCDS_FIXTURE_REVISION: &str = "duckdb-dsdgen-1";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn tpcds_and_clickbench_parity_vs_duckdb() {
@@ -527,8 +610,10 @@ async fn tpcds_and_clickbench_parity_vs_duckdb() {
     let sf = env_f64("CAYENNE_PARITY_TPCDS_SF", 1.0);
     eprintln!("TPC-DS parity at SF={sf}");
     let tpcds_dir = scratch.join(format!("tpcds_sf{sf}"));
-    let tpcds_fixture_missing = !tpcds_dir.join("store_sales.parquet").exists()
-        && !tpcds_dir.join("date_dim.parquet").exists()
+    // Reuse only a stamped fixture. Two sentinel files said nothing about the
+    // other twenty-two, so a directory left behind by an interrupted dsdgen was
+    // read as complete and its missing tables became `Excluded` — a pass.
+    let tpcds_fixture_missing = !support::fixture_is_current(&tpcds_dir, TPCDS_FIXTURE_REVISION)
         && generate_tpcds_parquet(&tpcds_dir, sf).is_none();
 
     // Discover exported tables.
@@ -577,9 +662,7 @@ async fn tpcds_and_clickbench_parity_vs_duckdb() {
                 .find(|e| e.suite == "tpcds" && e.name == q.name.as_ref())
                 .and_then(|e| e.duckdb_exclusion)
             {
-                ParityOutcome::Excluded {
-                    reason: reason.to_string(),
-                }
+                verify_cayenne_against_baseline(&q, &cayenne, &tpcds_dir, reason).await
             } else {
                 run_pair_with_df_baseline("tpcds", &q, &cayenne, &duck, None, Some(&tpcds_dir))
                     .await
@@ -703,10 +786,7 @@ async fn tpcds_and_clickbench_parity_vs_duckdb() {
     eprintln!("{}", summary_line(&results));
     eprintln!("coverage report: {}", coverage_path.display());
 
-    let unexplained: Vec<_> = results
-        .iter()
-        .filter(|r| !r.outcome.is_pass_or_excluded())
-        .collect();
+    let unexplained = support::report::unexplained(&results, &build_inventory());
     assert!(
         unexplained.is_empty(),
         "unexplained TPC-DS/ClickBench parity failures: {unexplained:#?}\nsee {}",
@@ -1217,7 +1297,7 @@ async fn chbench_sf1_load_mode_matrix_vs_duckdb() {
 /// Star Schema Benchmark: classic Q1.1–Q4.3 on deterministic reduced-scale data.
 #[tokio::test(flavor = "multi_thread")]
 async fn ssb_full_result_parity_vs_duckdb() {
-    use support::ssb_data::{SSB_TABLES, ssb_queries, write_ssb_parquet};
+    use support::ssb_data::{SSB_TABLES, ensure_ssb_fixture, ssb_queries};
 
     let scratch = scratch_dir();
     std::fs::create_dir_all(&scratch).ok();
@@ -1225,9 +1305,7 @@ async fn ssb_full_result_parity_vs_duckdb() {
     eprintln!("SSB parity vs DuckDB at scale={scale}");
 
     let ssb_dir = scratch.join(format!("ssb_scale{scale}"));
-    if !ssb_dir.join("lineorder.parquet").exists() {
-        write_ssb_parquet(&ssb_dir, scale);
-    }
+    ensure_ssb_fixture(&ssb_dir, scale);
 
     let cayenne = load_cayenne_from_parquet(&ssb_dir, SSB_TABLES).await;
     let (duck_temp, duck) = load_duckdb_from_parquet(&ssb_dir, SSB_TABLES);
@@ -1256,10 +1334,7 @@ async fn ssb_full_result_parity_vs_duckdb() {
     std::fs::write(&log_path, &log).expect("write ssb log");
     eprintln!("{}", summary_line(&results));
 
-    let fails: Vec<_> = results
-        .iter()
-        .filter(|r| !r.outcome.is_pass_or_excluded())
-        .collect();
+    let fails = support::report::unexplained(&results, &build_inventory());
     assert!(
         fails.is_empty(),
         "SSB full-result parity failures: {fails:#?}\nsee {}",
@@ -1329,10 +1404,7 @@ async fn spicebench_sf1_tpch_scenario_parity_vs_duckdb() {
     std::fs::write(&log_path, &log).expect("write spicebench log");
     eprintln!("{}", summary_line(&results));
 
-    let fails: Vec<_> = results
-        .iter()
-        .filter(|r| !r.outcome.is_pass_or_excluded())
-        .collect();
+    let fails = support::report::unexplained(&results, &build_inventory());
     assert!(
         fails.is_empty(),
         "SpiceBench SF1 parity failures: {fails:#?}\nsee {}",
@@ -1398,10 +1470,7 @@ async fn sqllancer_corpus_parity_vs_duckdb() {
     write_coverage_report(&scratch.join("parity_coverage.md"), &results).ok();
     eprintln!("{}", summary_line(&results));
 
-    let fails: Vec<_> = results
-        .iter()
-        .filter(|r| !r.outcome.is_pass_or_excluded())
-        .collect();
+    let fails = support::report::unexplained(&results, &build_inventory());
     assert!(
         fails.is_empty(),
         "SQLLancer corpus parity failures: {fails:#?}\nsee {}",

--- a/crates/cayenne/tests/result_correctness_vs_sqlite_test.rs
+++ b/crates/cayenne/tests/result_correctness_vs_sqlite_test.rs
@@ -43,7 +43,7 @@ use support::report::{RunResult, summary_line};
 use support::sqlite_engine::{
     load_sqlite_from_batches, load_sqlite_from_parquet, sqlite_query_batches,
 };
-use support::ssb_data::{SSB_TABLES, ssb_queries, write_ssb_parquet};
+use support::ssb_data::{SSB_TABLES, ensure_ssb_fixture, ssb_queries};
 use support::{
     CayenneHarness, ParityOutcome, assert_all_pass_or_excluded, compare_actual_results,
     execute_cayenne, make_dim_batch, make_fact_batch, micro_bench_queries, write_parquet,
@@ -153,9 +153,7 @@ async fn ssb_full_result_parity_vs_sqlite() {
     eprintln!("SSB parity vs SQLite at scale={scale}");
 
     let ssb_dir = scratch.join(format!("ssb_scale{scale}"));
-    if !ssb_dir.join("lineorder.parquet").exists() {
-        write_ssb_parquet(&ssb_dir, scale);
-    }
+    ensure_ssb_fixture(&ssb_dir, scale);
 
     let mut cayenne = CayenneHarness::new().await;
     for table in SSB_TABLES {


### PR DESCRIPTION
Follow-up to #13831. An adversarial review of that branch found four ways the
gate it added could stay green on results it had not actually verified. All four
are now on trunk, so this fixes them there.

## An unverified order counted as a pass

`is_pass_or_excluded` listed `OrderUnchecked`, so `assert_all_pass_or_excluded`
and every lane filter accepted a query whose own `ORDER BY` was never verified.
That is the outcome the sort check exists to surface: a resolver regression, or
an `ORDER BY` whose projection stops carrying the term, settled into a summary
bucket instead of turning a lane red. The runtime lane already failed on
`ORDER_UNCHECKED`; the Cayenne lanes that run in `make nextest` did not.

It is dropped from the predicate. The eight queries that legitimately cannot be
verified are named in the inventory with the reason for each — an `ORDER BY` over
a `CASE`, over the derived `sum_sales - avg_monthly_sales`, or over a
`to_timestamp(…)` the projection does not carry. A hole nobody has reviewed now
fails, and a review covers an unverified order only, never a violation or a
content mismatch on the same query.

Demonstrated failing, not just passing: with `tpcds_q36` un-reviewed the lane
goes red and names the term it could not verify, and green again once reviewed.

```
outcome: OrderUnchecked { reasons: ["left: verified through 'lochierarchy';
  ORDER BY term 'CASE WHEN lochierarchy = 0 THEN i_category END' does not map
  to a result column, ..."] }
test result: FAILED. 0 passed; 1 failed
```

## Fixtures were trusted on sight

The scratch tree outlives builds, branch switches and self-hosted CI jobs, so
`if !lineorder.parquet.exists()` accepted data written by an older generator.
#13831 changes the SSB and TPC-H generators, so the rows the new checks are
calibrated against were exactly what a leftover fixture would revert — and a
suite comparing two engines against the same stale rows still agrees with
itself, so nothing turns red.

Both generators now write a stamp carrying a digest of their own source, taken
with `include_str!` rather than a hand-maintained constant, because the constant
is what gets forgotten. The three copies of the SSB check-then-write collapse
into one `ensure_ssb_fixture`.

TPC-DS reused a directory when either of two sentinel files was present, which
said nothing about the other twenty-two: an interrupted `dsdgen` left a fixture
whose missing tables failed on both engines and settled into `Excluded`. It now
reuses only a stamped directory, the stamp is written after every `COPY`
succeeds, and the expected table set is checked so a generator that quietly
stops emitting one is caught too.

Forcing that regeneration found the generator could not run twice. `dsdgen`
populates a schema, and the reused `gen.duckdb` failed with
`Table with name "call_center" already exists` — never seen, because a leftover
fixture meant generation never re-ran. The generation database is now temporary
and per-run, and the on-disk fixture is replaced only after generation succeeds,
so a machine that cannot reach the extension repository keeps the fixture it
has.

## A DuckDB rejection skipped Cayenne entirely

`tpcds_q58` and `tpcds_q72` recorded their exclusion without running anything,
leaving them with no verification of Cayenne at all in the lane meant to provide
it. DuckDB rejecting an unqualified name is a fact about DuckDB; the DataFusion
baseline resolves the same SQL. Those queries now compare Cayenne against it,
sort check included, and are still recorded as DuckDB exclusions so the
inventory and the census keep agreeing.

## Verification

Every fixture regenerated from empty, and the corpus is unchanged — so none of
this costs a real check:

```
chbench            pass=88  excluded=0  order_unchecked=0 fail=0
tpcds/clickbench   pass=119 excluded=11 order_unchecked=8 fail=0
tpch               pass=24  excluded=4  order_unchecked=0 fail=0
ssb / sqllancer / micro / spicebench             fail=0
test result: ok. 7 passed; 0 failed
```

38 unit tests pass; `an_unreviewed_unverified_order_fails_the_lane` pins the
accept, the reject, and that a review does not excuse a violation.

https://claude.ai/code/session_01XUps8UQntxm3SGncixKZTs