### PR TITLE
fix(cayenne): release the keyset bytes an abandoned PK checkout accounted (fixes #13668)

### DIFF
--- a/crates/cayenne/src/provider/pk_index.rs
+++ b/crates/cayenne/src/provider/pk_index.rs
@@ -1422,6 +1422,18 @@ impl PendingPkKeys {
 /// open a window it does not also own.
 pub(crate) struct PkCheckoutGuard {
     pending: Arc<ParkingMutex<PendingPkKeys>>,
+    /// Republishes the resident-byte accounting of the cache this window covers.
+    /// Keys recorded while the window is open are accounted against that cache's
+    /// published bytes as they land (`record_pending_pk_keys`), on top of the bytes
+    /// the checked-out index itself still holds. A restore overwrites both with the
+    /// stored index's size; an abandoned window restores nothing, so without this
+    /// the bytes of an index that no longer exists and of keys that were just
+    /// dropped would stay reserved against the table's memory account until an
+    /// unrelated publish happened to overwrite them.
+    ///
+    /// Run by [`Drop`] on the abandon path only — [`Self::close`] hands the window
+    /// to a restore, which publishes the truth itself.
+    release_accounting: Option<Box<dyn FnOnce() + Send + Sync>>,
     /// Set by [`Self::close`], which has already closed the window and owns the
     /// keys it handed back, so [`Drop`] must not close it a second time.
     closed: bool,
@@ -1429,10 +1441,18 @@ pub(crate) struct PkCheckoutGuard {
 
 impl PkCheckoutGuard {
     /// Open a checkout window over `pending`.
-    pub(crate) fn open(pending: &Arc<ParkingMutex<PendingPkKeys>>) -> Self {
+    ///
+    /// `release_accounting` is what an *abandoned* window must do to the published
+    /// resident bytes of the cache it covers (see the field); the table passes a
+    /// closure that republishes what the cache cell actually holds.
+    pub(crate) fn open(
+        pending: &Arc<ParkingMutex<PendingPkKeys>>,
+        release_accounting: impl FnOnce() + Send + Sync + 'static,
+    ) -> Self {
         pending.lock().begin_checkout();
         Self {
             pending: Arc::clone(pending),
+            release_accounting: Some(Box::new(release_accounting)),
             closed: false,
         }
     }
@@ -1457,6 +1477,11 @@ impl Drop for PkCheckoutGuard {
         // stays cold — the next validation rebuilds from the table and sees every
         // committed key.
         let _ = self.pending.lock().end_checkout();
+        // The pending lock is released before this runs: the release takes the
+        // cache cell's lock and the publish lock, never the pending log's.
+        if let Some(release) = self.release_accounting.take() {
+            release();
+        }
     }
 }
 
@@ -2957,15 +2982,47 @@ mod tests {
     ///
     /// [`PkCheckoutGuard`] is what makes the window impossible to abandon; this
     /// pins the behaviour it buys.
+    /// The accounting release runs only when a window is abandoned. A restore
+    /// closes the window and publishes the stored index's size itself, so running
+    /// the release there too would publish a stale figure over the true one.
+    #[test]
+    fn only_an_abandoned_checkout_runs_its_accounting_release() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let pending = Arc::new(ParkingMutex::new(PendingPkKeys::default()));
+        let released = Arc::new(AtomicUsize::new(0));
+        let release = |released: &Arc<AtomicUsize>| {
+            let released = Arc::clone(released);
+            move || {
+                released.fetch_add(1, Ordering::Relaxed);
+            }
+        };
+
+        let closed = PkCheckoutGuard::open(&pending, release(&released));
+        drop(closed.close());
+        assert_eq!(
+            released.load(Ordering::Relaxed),
+            0,
+            "a restore publishes the truth itself, so a closed window must not release"
+        );
+
+        drop(PkCheckoutGuard::open(&pending, release(&released)));
+        assert_eq!(
+            released.load(Ordering::Relaxed),
+            1,
+            "an abandoned window must release the accounting it grew"
+        );
+    }
+
     #[test]
     fn an_abandoned_checkout_leaves_the_next_one_usable() {
         let pending = Arc::new(ParkingMutex::new(PendingPkKeys::default()));
 
         // A validation that fails, panics, or is cancelled part-way: the window
         // opened, nothing restored an index, and the guard closed it on the way out.
-        drop(PkCheckoutGuard::open(&pending));
+        drop(PkCheckoutGuard::open(&pending, || {}));
 
-        let checkout = PkCheckoutGuard::open(&pending);
+        let checkout = PkCheckoutGuard::open(&pending, || {});
         let mut keys = PkDigestSet::with_capacity(1);
         let k = owned_key(&key(7));
         keys.insert_with_digest(pk_digest(&k), k.clone());
@@ -3002,8 +3059,8 @@ mod tests {
     fn closing_a_checkout_does_not_also_close_it_on_drop() {
         let pending = Arc::new(ParkingMutex::new(PendingPkKeys::default()));
 
-        let outer = PkCheckoutGuard::open(&pending);
-        let inner = PkCheckoutGuard::open(&pending);
+        let outer = PkCheckoutGuard::open(&pending, || {});
+        let inner = PkCheckoutGuard::open(&pending, || {});
         assert_eq!(pending.lock().outstanding, 2, "two windows are open");
 
         drop(inner.close());
@@ -3032,8 +3089,8 @@ mod tests {
     fn two_concurrent_checkouts_are_both_discarded() {
         let pending = Arc::new(ParkingMutex::new(PendingPkKeys::default()));
 
-        let first = PkCheckoutGuard::open(&pending);
-        let second = PkCheckoutGuard::open(&pending);
+        let first = PkCheckoutGuard::open(&pending, || {});
+        let second = PkCheckoutGuard::open(&pending, || {});
 
         assert!(
             second.close().index_must_be_discarded(),
@@ -3046,7 +3103,7 @@ mod tests {
 
         // ...and the flags clear once the last window closes, so the NEXT
         // checkout is trusted again.
-        let third = PkCheckoutGuard::open(&pending);
+        let third = PkCheckoutGuard::open(&pending, || {});
         assert!(
             !third.close().index_must_be_discarded(),
             "the discard must not outlive the overlap that caused it"

--- a/crates/cayenne/src/provider/pk_index.rs
+++ b/crates/cayenne/src/provider/pk_index.rs
@@ -1433,7 +1433,7 @@ pub(crate) struct PkCheckoutGuard {
     ///
     /// Run by [`Drop`] on the abandon path only — [`Self::close`] hands the window
     /// to a restore, which publishes the truth itself.
-    release_accounting: Option<Box<dyn FnOnce() + Send + Sync>>,
+    release_accounting: Option<Box<dyn FnOnce() + Send>>,
     /// Set by [`Self::close`], which has already closed the window and owns the
     /// keys it handed back, so [`Drop`] must not close it a second time.
     closed: bool,
@@ -1447,7 +1447,7 @@ impl PkCheckoutGuard {
     /// closure that republishes what the cache cell actually holds.
     pub(crate) fn open(
         pending: &Arc<ParkingMutex<PendingPkKeys>>,
-        release_accounting: impl FnOnce() + Send + Sync + 'static,
+        release_accounting: impl FnOnce() + Send + 'static,
     ) -> Self {
         pending.lock().begin_checkout();
         Self {

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4248,6 +4248,47 @@ impl std::fmt::Debug for CayenneTableProvider {
     }
 }
 
+/// The two resident-byte components of a table's PK caches and the slot they are
+/// published into as a sum. Every publish goes through here so the sum is read
+/// and written under one lock (see [`Self::publish_total`]); the provider hands one
+/// to each [`PkCheckoutGuard`] it opens so an abandoned window can restate the
+/// cache's true residency from wherever the guard is dropped.
+struct PkKeysetBytesPublisher {
+    single: Arc<AtomicUsize>,
+    sharded: Arc<AtomicUsize>,
+    publish_lock: Arc<ParkingMutex<()>>,
+    table_memory: Arc<CayenneMemoryAccount>,
+}
+
+impl PkKeysetBytesPublisher {
+    /// Publish the table-wide PK cache's resident bytes and refresh the sum.
+    fn publish_single(&self, bytes: usize) {
+        self.single.store(bytes, Ordering::Relaxed);
+        self.publish_total();
+    }
+
+    /// Publish the sharded PK cache's resident bytes and refresh the sum.
+    fn publish_sharded(&self, bytes: usize) {
+        self.sharded.store(bytes, Ordering::Relaxed);
+        self.publish_total();
+    }
+
+    fn publish_total(&self) {
+        // Read both components AND publish under one lock. The components are
+        // stored before this point, so whichever publisher holds the lock last
+        // reads every completed store and publishes the true sum; splitting the
+        // read from the publish lets a stale total land last and under-report.
+        let _guard = self.publish_lock.lock();
+        let total = self
+            .single
+            .load(Ordering::Relaxed)
+            .saturating_add(self.sharded.load(Ordering::Relaxed));
+        // `set_keyset_bytes` also restates this table's share of the fleet
+        // ceiling, and releases it on drop.
+        self.table_memory.set_keyset_bytes(total);
+    }
+}
+
 impl CayenneTableProvider {
     pub(crate) fn metadata_catalog(&self) -> &Arc<dyn MetadataCatalog> {
         &self.catalog
@@ -10425,7 +10466,14 @@ impl CayenneTableProvider {
     /// table and every key committed after it must still reach the restored index.
     fn take_cached_pk_index(&self) -> (Option<CachedPkIndex>, PkCheckoutGuard) {
         let mut guard = self.pk_keyset_cache.lock();
-        let checkout = PkCheckoutGuard::open(&self.pk_keyset_pending);
+        let checkout = PkCheckoutGuard::open(&self.pk_keyset_pending, {
+            let cache = Arc::clone(&self.pk_keyset_cache);
+            let publisher = self.pk_keyset_bytes_publisher();
+            move || {
+                publisher
+                    .publish_single(cache.lock().as_ref().map_or(0, CachedPkIndex::approx_bytes));
+            }
+        });
         (guard.take(), checkout)
     }
 
@@ -10491,29 +10539,28 @@ impl CayenneTableProvider {
 
     /// Publish the table-wide PK cache's resident bytes and refresh the sum.
     fn publish_single_keyset_bytes(&self, bytes: usize) {
-        self.pk_keyset_bytes_single.store(bytes, Ordering::Relaxed);
-        self.publish_keyset_bytes_total();
+        self.pk_keyset_bytes_publisher().publish_single(bytes);
     }
 
     /// Publish the sharded PK cache's resident bytes and refresh the sum.
     fn publish_sharded_keyset_bytes(&self, bytes: usize) {
-        self.pk_keyset_bytes_sharded.store(bytes, Ordering::Relaxed);
-        self.publish_keyset_bytes_total();
+        self.pk_keyset_bytes_publisher().publish_sharded(bytes);
     }
 
     fn publish_keyset_bytes_total(&self) {
-        // Read both components AND publish under one lock. The components are
-        // stored before this point, so whichever publisher holds the lock last
-        // reads every completed store and publishes the true sum; splitting the
-        // read from the publish lets a stale total land last and under-report.
-        let _guard = self.pk_keyset_publish_lock.lock();
-        let total = self
-            .pk_keyset_bytes_single
-            .load(Ordering::Relaxed)
-            .saturating_add(self.pk_keyset_bytes_sharded.load(Ordering::Relaxed));
-        // `set_keyset_bytes` also restates this table's share of the fleet
-        // ceiling, and releases it on drop.
-        self.table_memory.set_keyset_bytes(total);
+        self.pk_keyset_bytes_publisher().publish_total();
+    }
+
+    /// The PK-cache byte accounting, detached from the provider so a
+    /// [`PkCheckoutGuard`] can carry it to wherever the checked-out index ends up
+    /// and republish on the abandon path (see `take_cached_pk_index`).
+    fn pk_keyset_bytes_publisher(&self) -> PkKeysetBytesPublisher {
+        PkKeysetBytesPublisher {
+            single: Arc::clone(&self.pk_keyset_bytes_single),
+            sharded: Arc::clone(&self.pk_keyset_bytes_sharded),
+            publish_lock: Arc::clone(&self.pk_keyset_publish_lock),
+            table_memory: Arc::clone(&self.table_memory),
+        }
     }
 
     /// Deferred cross-partition appends carry their on-conflict metadata and
@@ -12871,7 +12918,18 @@ impl CayenneTableProvider {
         // exit between here and `store_sharded_pk_index` — close it.
         let (cached, checkout) = {
             let mut guard = self.sharded_pk_keyset_cache.lock();
-            let checkout = PkCheckoutGuard::open(&self.sharded_pk_keyset_pending);
+            let checkout = PkCheckoutGuard::open(&self.sharded_pk_keyset_pending, {
+                let cache = Arc::clone(&self.sharded_pk_keyset_cache);
+                let publisher = self.pk_keyset_bytes_publisher();
+                move || {
+                    publisher.publish_sharded(
+                        cache
+                            .lock()
+                            .as_ref()
+                            .map_or(0, ShardedPkIndex::approx_bytes),
+                    );
+                }
+            });
             (guard.take(), checkout)
         };
         if let Some(cached) = cached {
@@ -59716,6 +59774,111 @@ mod tests {
                 other.is_some()
             ),
         }
+    }
+
+    /// An abandoned checkout must release the resident-byte accounting its window
+    /// grew — regression test for #13668. Keys committed while the keyset is checked
+    /// out are accounted against the published residency as they land, and only a
+    /// restore overwrites that figure; a validation that is dropped or cancelled
+    /// restores nothing, so the bytes of keys that were just discarded stayed
+    /// reserved against the table's memory account and narrowed every sibling's
+    /// keyset budget.
+    #[tokio::test]
+    async fn an_abandoned_checkout_releases_the_keyset_bytes_its_window_grew() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) = create_cdc_upsert_table_with_vortex_config(
+            "pk_checkout_abandoned_bytes",
+            ctx.runtime_env(),
+            VortexConfig::default(),
+        )
+        .await;
+        let pk_indices = provider
+            .primary_key_indices()
+            .expect("primary key indices resolve")
+            .expect("the table declares a primary key");
+        let converter = provider
+            .build_pk_converter(&pk_indices)
+            .expect("primary key converter");
+
+        // A validation checks the (cold) keyset out; while its window is open a
+        // concurrent commit lands three keys, which the log holds for the replay.
+        let (cached, checkout) = provider.take_cached_pk_index();
+        assert!(cached.is_none(), "a fresh table has no cached keyset");
+        provider.record_file_pk_keys(&pk_digest_set_for_ids(&converter, &[7, 8, 9]), 11);
+
+        let held = provider.pk_keyset_bytes_single.load(Ordering::Relaxed);
+        assert!(
+            held > 0,
+            "keys held for the replay are accounted while the window is open"
+        );
+        assert_eq!(
+            provider.table_memory.snapshot().keyset,
+            held,
+            "the held bytes reach the table's memory account"
+        );
+
+        // The validation is dropped without storing an index back.
+        drop(checkout);
+
+        assert_eq!(
+            provider.pk_keyset_bytes_single.load(Ordering::Relaxed),
+            0,
+            "an abandoned window releases the bytes of the keys it discarded"
+        );
+        assert_eq!(
+            provider.table_memory.snapshot().keyset,
+            0,
+            "the memory account no longer carries the phantom reservation"
+        );
+    }
+
+    /// The per-shard index has the same window and the same accounting — the
+    /// sharded twin of the test above (#13668).
+    #[tokio::test]
+    async fn an_abandoned_sharded_checkout_releases_the_keyset_bytes_its_window_grew() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) = create_sharded_cdc_upsert_table_with_cap(
+            "pk_sharded_checkout_abandoned_bytes",
+            ctx.runtime_env(),
+            4,
+            0,
+        )
+        .await;
+        let pk_indices = provider
+            .primary_key_indices()
+            .expect("primary key indices resolve")
+            .expect("the table declares a primary key");
+        let converter = provider
+            .build_pk_converter(&pk_indices)
+            .expect("primary key converter");
+        provider.maybe_install_warm_pk_caches().await;
+
+        // An apply checks the per-shard index out; a concurrent commit lands while
+        // the window is open and is held for the replay.
+        let checked_out = provider
+            .build_sharded_pk_index(&pk_indices, &converter, 4)
+            .await
+            .expect("the warm per-shard index is checked out");
+        let before = provider.pk_keyset_bytes_sharded.load(Ordering::Relaxed);
+        provider.record_file_pk_keys(&pk_digest_set_for_ids(&converter, &[7, 8, 9]), 11);
+        assert!(
+            provider.pk_keyset_bytes_sharded.load(Ordering::Relaxed) > before,
+            "keys held for the replay are accounted while the per-shard window is open"
+        );
+
+        // The apply is abandoned without restoring the index.
+        drop(checked_out);
+
+        assert_eq!(
+            provider.pk_keyset_bytes_sharded.load(Ordering::Relaxed),
+            0,
+            "the per-shard cell is empty after the abandon, so its published residency is zero"
+        );
+        assert_eq!(
+            provider.table_memory.snapshot().keyset,
+            provider.pk_keyset_bytes_single.load(Ordering::Relaxed),
+            "the memory account carries only the table-wide keyset's bytes"
+        );
     }
 
     /// The table-wide keyset has the same window and the same latch — regression


### PR DESCRIPTION
## Summary

Keys committed while a PK index is checked out for validation are held in the pending log for the restore to replay, and `record_pending_pk_keys` accounts their bytes against that cache's published residency (`pk_keyset_bytes_single` / `pk_keyset_bytes_sharded`) as they land, on top of the bytes the checked-out index itself still holds. A restore overwrites the figure with the stored index's size. An abandoned checkout — a validation stream dropped or cancelled, an apply that errors before the store — restores nothing: `PkCheckoutGuard`'s `Drop` closed the window and discarded the held keys, but the published bytes stayed where they were. That phantom reservation sat against the table's `CayenneMemoryAccount` and the fleet keyset ceiling until an unrelated publish overwrote it, narrowing every sibling table's keyset budget and pushing them toward bloom degradation sooner than their real residency warranted.

Not a data-correctness bug: the keys themselves are correctly discarded and the next validation rebuilds from the table. It is an accounting bug in the budget that decides whether an exact keyset is kept.

## Changes

- `crates/cayenne/src/provider/pk_index.rs`: `PkCheckoutGuard::open` takes a release hook. `Drop` runs it after closing the window on the abandon path only; `close` (the restore path) does not, because the restore publishes the stored index's size itself. The pending lock is released before the hook runs, so the hook's cache-cell and publish locks never nest inside it.
- `crates/cayenne/src/provider/table.rs`: the two publish paths and the sum move onto a small `PkKeysetBytesPublisher` (four `Arc` clones) that the provider hands to each guard it opens, so the guard can publish from wherever the checked-out index ends up without a reference to the provider. Both open sites (`take_cached_pk_index`, `build_sharded_pk_index`) pass a hook that republishes **what the cache cell actually holds** — zero when the take left it empty, the resident index's size if something was stored meanwhile — rather than a hard-coded zero.
- Tests: `an_abandoned_checkout_releases_the_keyset_bytes_its_window_grew` (table-wide keyset), `an_abandoned_sharded_checkout_releases_the_keyset_bytes_its_window_grew` (per-shard index), and `only_an_abandoned_checkout_runs_its_accounting_release` (the hook runs on drop, not on close).

## Test plan

- [x] `make lint` (fmt + clippy with the repo's deny set; never a per-crate invocation)
- [x] `make test` / `make nextest` via `make signoff` after push
- [x] Reproduction on `trunk`, then the same command on this branch:

```
# Neutered control: Drop takes the release hook and drops it without running it
# (the rest of the branch unchanged), then the same three tests:
$ cargo test -p cayenne --lib -- keyset_bytes_its_window_grew only_an_abandoned_checkout_runs_its_accounting_release
test provider::pk_index::tests::only_an_abandoned_checkout_runs_its_accounting_release ... FAILED
test provider::table::tests::an_abandoned_checkout_releases_the_keyset_bytes_its_window_grew ... FAILED
test provider::table::tests::an_abandoned_sharded_checkout_releases_the_keyset_bytes_its_window_grew ... FAILED
---- an_abandoned_checkout_releases_the_keyset_bytes_its_window_grew ----
assertion `left == right` failed: an abandoned window releases the bytes of the keys it discarded
  left: 291
 right: 0
---- an_abandoned_sharded_checkout_releases_the_keyset_bytes_its_window_grew ----
assertion `left == right` failed: the per-shard cell is empty after the abandon, so its published residency is zero
  left: 291
 right: 0
test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 1192 filtered out

# This branch, pk_index.rs restored byte-for-byte (cmp-verified):
test provider::pk_index::tests::only_an_abandoned_checkout_runs_its_accounting_release ... ok
test provider::table::tests::an_abandoned_checkout_releases_the_keyset_bytes_its_window_grew ... ok
test provider::table::tests::an_abandoned_sharded_checkout_releases_the_keyset_bytes_its_window_grew ... ok
test result: ok. 3 passed; 0 failed
```

The 291 bytes are exactly the three held keys' `approx_pk_keyset_entry_bytes`, still published against the memory account after the window that held them was gone — the phantom reservation the issue describes, on both cache shapes. The neutered control stands in for `trunk` because the tests call `PkCheckoutGuard::open` with its new second argument and do not compile against the old signature; it isolates the one behaviour this PR adds.

Run on Windows with a throwaway local stub of `compaction_writer.rs`'s three Unix-only functions and a `cfg(unix)` gate on one pre-existing symlink test, both reverted before commit (the diff is the two files above only). `CLIPPY_CONF_DIR=.ci cargo clippy -p cayenne --lib --tests --no-deps -- -D warnings` reports nothing in the two touched files; its one error is an `unfulfilled_lint_expectations` in an untouched integration test, which the repo's own `--tests` lint pass allows. The full `make lint` / `make nextest` verdict comes from the sign-off run.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits"; `grok` is not permitted under this identity (receipt on head `7ee2bd596d`, re-run after the review-driven `Send`-only bound; the same reason on `02982b2af4` before it)
- `/security-review`: no findings — the diff is in-process byte accounting and test code; it reads no input, touches no filesystem or network path, and logs nothing (run by hand against this worktree's diff; the slash command diffs the primary checkout)
- `/simplify`: reviewed the branch diff by hand — dropped an unused `Clone` derive on the new publisher; the three former publish bodies now delegate to it rather than duplicating the lock-and-sum

Fixes #13668

## Checklist

- [x] No `.unwrap()` in new code
- [x] `cargo fmt --all` clean; no `.claude/worktrees/` paths
- [x] `compaction_writer.rs` untouched (the local Windows build stub was reverted before commit)
- [x] No customer, credential, or internal-infrastructure detail