### PR TITLE
fix(github): bound the pull request page to GitHub's per-request compute budget (refs #13762)

### DIFF
--- a/crates/data-connectors/connector-github/src/pull_requests.rs
+++ b/crates/data-connectors/connector-github/src/pull_requests.rs
@@ -329,9 +329,12 @@ impl PullRequestTableArgs {
 
     /// Returns the outer `first:` page size for the pull request connection.
     ///
-    /// When comments are included (review, discussion, or both), the page size
-    /// is reduced to keep total node count well under GitHub's 500,000 node
-    /// hard limit on a single GraphQL query.
+    /// Every comment mode requests the same number of pull requests per page:
+    /// `DEFAULT_PAGE_SIZE` and `COMMENTS_PAGE_SIZE` are both 25. They stay
+    /// separate constants because different limits hold them there — the
+    /// comment-free page is bounded by GitHub's per-request compute budget,
+    /// the commented one by the 500,000 node hard limit on a single GraphQL
+    /// query — so either may move without the other.
     fn outer_page_size(&self) -> u32 {
         match self.include_comments {
             PullRequestCommentType::None => Self::DEFAULT_PAGE_SIZE,

--- a/crates/data-connectors/connector-github/src/pull_requests.rs
+++ b/crates/data-connectors/connector-github/src/pull_requests.rs
@@ -258,15 +258,28 @@ impl PullRequestTableArgs {
     /// returns a full page. 25 also matches `COMMENTS_PAGE_SIZE`, so both
     /// paths now request the same number of pull requests per page.
     ///
+    /// The trade-off is the maximum scannable repository. `execute_paginated`
+    /// stops a scan at `MAX_PAGINATION_ITERATIONS` (1000) pages and returns an
+    /// error rather than truncating, so the ceiling is `page_size x 1001`:
+    /// 25,025 pull requests here, down from 100,100. That ceiling is only
+    /// reachable where the wider page worked at all — on a repository large
+    /// enough for this to matter, `first: 100` currently returns zero rows, so
+    /// the effective ceiling goes up rather than down. Sizing the page per
+    /// repository instead of by a constant is tracked in #13937.
+    ///
     /// See: <https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api>
     const DEFAULT_PAGE_SIZE: u32 = 25;
 
-    /// Reduced outer `first:` value when `include_comments` is enabled.
+    /// Outer `first:` value when `include_comments` is enabled.
     ///
     /// With comments enabled, each PR can expand to up to `20 * max_comments_fetched`
     /// review-thread comments plus `max_comments_fetched` discussion comments.
     /// Keeping the outer page at 25 keeps the total node count safely under
     /// GitHub's 500,000 node hard limit and within secondary rate limits.
+    ///
+    /// This equals `DEFAULT_PAGE_SIZE`: the comment-free page is bounded by the
+    /// per-request compute budget at the same width that the node limit bounds
+    /// the commented one, so the two arrive at 25 for different reasons.
     ///
     /// See: <https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api#node-limit>
     const COMMENTS_PAGE_SIZE: u32 = 25;

--- a/crates/data-connectors/connector-github/src/pull_requests.rs
+++ b/crates/data-connectors/connector-github/src/pull_requests.rs
@@ -244,7 +244,22 @@ impl PullRequestTableArgs {
 
     /// Default outer `first:` value for the pull request connection when
     /// `include_comments` is not enabled.
-    const DEFAULT_PAGE_SIZE: u32 = 100;
+    ///
+    /// GitHub enforces a per-request compute budget that is separate from, and
+    /// reached long before, the `GITHUB_NODE_LIMIT` above: a page of 100 pull
+    /// requests on a large repository is rejected outright with `Resource
+    /// limits for this query exceeded`, leaving every node in the page `null`.
+    /// `estimated_node_count` cannot see this — the same page is only ~26,000
+    /// nodes, about 5% of the node limit — so the page size has to be chosen
+    /// against the compute budget rather than validated against the node one.
+    ///
+    /// Measured against `spiceai/spiceai` (13,700+ pull requests): `first: 100`
+    /// fails on the very first page, deterministically, while `first: 25`
+    /// returns a full page. 25 also matches `COMMENTS_PAGE_SIZE`, so both
+    /// paths now request the same number of pull requests per page.
+    ///
+    /// See: <https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api>
+    const DEFAULT_PAGE_SIZE: u32 = 25;
 
     /// Reduced outer `first:` value when `include_comments` is enabled.
     ///
@@ -809,12 +824,17 @@ mod tests {
     #[test]
     fn outer_page_size_uses_default_when_no_comments() {
         let a = args(PullRequestCommentType::None, 25);
-        assert_eq!(a.outer_page_size(), 100);
+        assert_eq!(a.outer_page_size(), 25);
     }
 
     #[test]
-    fn outer_page_size_shrinks_when_comments_enabled() {
+    fn outer_page_size_stays_within_the_compute_budget() {
+        // Every comment mode requests the same number of pull requests per
+        // page. The bound is GitHub's per-request compute budget, which a page
+        // of 100 exceeds on a large repository regardless of whether comments
+        // are attached, so no mode may exceed DEFAULT_PAGE_SIZE.
         for include in [
+            PullRequestCommentType::None,
             PullRequestCommentType::Review,
             PullRequestCommentType::Discussion,
             PullRequestCommentType::All,


### PR DESCRIPTION
## What this fixes

`E2E Test CI` → `Test GitHub connector on Linux x64` fails merge-queue batches on `spiceai/spiceai`, taking each batch with it. It is the failing job in **9 of 9** sampled failed batches, and it fails on `trunk`'s own `push` runs too, so it is not attributable to any diff under test.

Root cause: the pull request connection asks GitHub for `first: 100`, and a page that wide is now over GitHub's **per-request compute budget** for this repository. GitHub rejects the page with `Resource limits for this query exceeded` and returns every node as `null`, so `spiceai.pulls` never loads and the runtime never reports ready.

This refines the diagnosis in #13762. That issue attributed the failure to the connector paginating the entire pull request set; the measurements below show the rejection lands on the **first page**, before pagination is a factor. The lever is the page's width, not the number of pages.

## Evidence

The connector's own node selection (`base_requested_nodes()`, `include_comments: None`) run against the live GitHub GraphQL API, varying only the outer `first:`:

| `first:` | `repository.pullRequests` (auto mode) | `search(type: ISSUE)` (search mode) |
|---|---|---|
| **100** | **246 errors, 100/100 nodes `null`** — `Resource limits for this query exceeded` (7.8s / 10.2s / 8.1s) | **HTTP 502** |
| 50 | 50/50 nodes, no errors (4.9s) | HTTP 502 |
| 40 | 40/40 nodes, no errors (4.3s) | — |
| 30 | 30/30 nodes, no errors (2.9s) | — |
| **25** | **25/25 nodes, no errors** (2.5s / 3.4s / 2.6s) | **25/25 nodes, no errors** (5.0s) |
| 20 | 20/20 nodes, no errors (2.4s) | 20/20 nodes, no errors (3.0s) |

`first: 100` failed **3 of 3** trials and `first: 25` succeeded **3 of 3**. Both query modes are affected, and both recover at 25.

Corroboration from the job itself: a *passing* run of this job took **40s** to reach ready against a 60s timeout, so the dataset was already at the edge before it tipped over.

Why the existing guard did not catch it: `check_node_limit()` validates against `GITHUB_NODE_LIMIT`, GitHub's 500,000-*node* ceiling. A page of 100 pull requests is only ~26,000 nodes — about 5% of it. The compute budget is a separate limit that binds first, so the page size has to be chosen against it directly rather than validated against the node one.

## The change

`DEFAULT_PAGE_SIZE: 100 → 25`, the value `COMMENTS_PAGE_SIZE` already uses, so both comment modes request the same number of pull requests per page. The two `outer_page_size` tests move to the new value, and `outer_page_size_shrinks_when_comments_enabled` becomes `outer_page_size_stays_within_the_compute_budget` — the bound now applies to every mode rather than being a comments-only reduction.

## The trade-off, stated plainly

`execute_paginated` stops a scan at `MAX_PAGINATION_ITERATIONS` (1000) pages and **errors** rather than truncating, so the maximum scannable repository is `page_size × 1001`: **25,025 pull requests, down from 100,100**, and a full scan of this repo grows from 137 to 548 requests, each still charged the same `BASE_QUERY_COST`.

That ceiling only ever applied where the wider page worked at all. On a repository large enough for it to matter, `first: 100` currently returns zero rows — so the *reachable* ceiling goes up, not down. It is still a real cost and it is now documented on the constant.

This is a per-request fix, not a bound on total work: auto mode still declines filter pushdown and a refresh still walks every pull request. Sizing the page per repository — by extending the client's existing reverse-Fibonacci page shrink, which today triggers only on HTTP 502/504 and not on this error — is filed as **#13937** and is the better long-term fix.

Refs #13762.

## Verification status

The root-cause measurements above are direct and complete: they are the connector's own query against the live API, and they settle that `first: 100` is rejected and `first: 25` is not.

What they do **not** yet settle is the last link — that this is sufficient to turn `gh_connector_quickstart` green. A `workflow_dispatch` E2E run on this branch is in flight for exactly that ([run 34054068445](https://github.com/spiceai/spiceai/actions/runs/34054068445)); its Linux build has passed, and the connector job is queued behind the macOS build leg it shares a `needs:` on. I will post the job's verdict here when it lands. Treat the end-to-end claim as unconfirmed until then.

## Review gate

- Adversarial review: `codex` — scoped to `origin/trunk..HEAD`. Five findings; the pagination-ceiling regression and the stale `COMMENTS_PAGE_SIZE` wording are addressed in `32f13bd8` above, and the adaptive-shrink finding is filed as #13937. Its "evidence covers only `pullRequests`" point is answered by the search-mode column in the table.
- `make signoff` could not run locally: `crates/cayenne` does not compile on Windows on unmodified `trunk` (#13936), so the workspace build dies before this crate. Signed off remotely instead.
