### PR TITLE
fix(ci): preserve Cargo discovery markers during runner disk sweeps

### DIFF
--- a/scripts/reclaim_runner_disk.sh
+++ b/scripts/reclaim_runner_disk.sh
@@ -365,17 +365,19 @@ reclaim_stale_build_output() {
 
     if [[ "$DRY_RUN" == "1" ]]; then
       local count
-      count=$(find "$target_dir" -type f -mtime "+${days}" 2>/dev/null | wc -l | tr -d ' ')
+      count=$(find "$target_dir" -type f ! -name CACHEDIR.TAG -mtime "+${days}" 2>/dev/null | wc -l | tr -d ' ')
       info "would prune ${count} file(s) older than ${days}d from: ${target_dir}"
       pruned+=1
       continue
     fi
 
+    # Keep discovery markers, including those of nested targets, so later
+    # sweeps can still identify build output after its artifacts age out.
     info "pruning files older than ${days}d from: ${target_dir}"
     # stderr is dropped -- a walk this wide reports every unreadable entry and
     # the log is for an operator, not a debugger -- so the exit status is the
     # only signal that the prune did not do what the line above just announced.
-    if ! find "$target_dir" -type f -mtime "+${days}" -delete 2>/dev/null; then
+    if ! find "$target_dir" -type f ! -name CACHEDIR.TAG -mtime "+${days}" -delete 2>/dev/null; then
       info "failed to prune some files from: ${target_dir}"
       SWEEP_FAILURES=$((SWEEP_FAILURES + 1))
     fi

--- a/scripts/test_reclaim_runner_disk.sh
+++ b/scripts/test_reclaim_runner_disk.sh
@@ -295,6 +295,31 @@ pass_or_fail "never walks a directory merely named target" \
 pass_or_fail "sweeps a nested target directory only through its ancestor" \
   "$([[ "$output" == *"build output directories swept: 1"* ]] && echo 1 || echo 0)" "got: $output"
 
+echo "repeated sweeps preserve Cargo discovery"
+
+repeated="$tmp/repeated"
+repeated_target="$repeated/spiceai/spiceai/target"
+make_cargo_target "$repeated_target"
+make_cargo_target "$repeated_target/package/inner/target"
+touch "$repeated_target/fresh.rlib"
+age_path "$repeated_target/CACHEDIR.TAG" 30
+age_path "$repeated_target/package/inner/target/CACHEDIR.TAG" 30
+
+output="$(env "RUNNER_WORKSPACE=$repeated/spiceai" bash "$subject" --root "$repeated" --dry-run --free-gib "$ALWAYS_PRUNE_FLOOR" 2>&1)"
+pass_or_fail "dry run excludes discovery markers from its prune count" \
+  "$([[ "$output" == *"would prune 0 file(s)"* ]] && echo 1 || echo 0)" "got: $output"
+
+env "RUNNER_WORKSPACE=$repeated/spiceai" bash "$subject" --root "$repeated" --free-gib "$ALWAYS_PRUNE_FLOOR" >/dev/null 2>&1
+pass_or_fail "keeps an aged Cargo marker while pruning build output" \
+  "$([[ -f "$repeated_target/CACHEDIR.TAG" ]] && echo 1 || echo 0)" "Cargo discovery marker was removed"
+pass_or_fail "keeps nested Cargo markers while pruning through their ancestor" \
+  "$([[ -f "$repeated_target/package/inner/target/CACHEDIR.TAG" ]] && echo 1 || echo 0)" "nested Cargo discovery marker was removed"
+
+age_path "$repeated_target/fresh.rlib" 30
+output="$(env "RUNNER_WORKSPACE=$repeated/spiceai" bash "$subject" --root "$repeated" --free-gib "$ALWAYS_PRUNE_FLOOR" 2>&1)"
+pass_or_fail "a later sweep discovers and prunes artifacts that have aged out" \
+  "$([[ ! -e "$repeated_target/fresh.rlib" && "$output" == *"build output directories swept: 1"* ]] && echo 1 || echo 0)" "got: $output"
+
 echo "free-space gate on build output"
 
 # A host with room to spare keeps its cache. The point of the gate: a pruned


### PR DESCRIPTION
## WHAT
Preserve `CACHEDIR.TAG` files during runner build-output pruning, including nested targets and dry-run counts.

## WHY
The sweep discovers Cargo targets by their marker, then deletes that marker once it ages past the threshold. Running the script twice against a target with an old marker and a fresh artifact produced `directories swept: 1`, then `directories swept: 0`; the artifact remained. Runner diagnostics also found missing markers on macOS slots 01 and 02, though their removal history is unverified ([diagnostic run](https://github.com/spiceai/spiceai/actions/runs/34067700583)).

## HOW
Exclude marker files from both pruning predicates. Keep the existing age, free-space, Cargo-producer, and runner-root rules. `bash scripts/test_reclaim_runner_disk.sh` reports `4 of 47 checks failed` without the fix and `all 47 checks passed` with it on macOS. The two-sweep reproduction retains the marker and discovers the target on both passes after the fix. `bash -n` passes for both scripts.
