### PR TITLE
fix(models): read the HuggingFace chat token as hf_token again (fixes #13932)

### DIFF
--- a/.schema/spicepod.schema.json
+++ b/.schema/spicepod.schema.json
@@ -10795,8 +10795,8 @@
           "description": "Customizes the transformation of OpenAI chat messages into a character stream for the model.",
           "type": "string"
         },
-        "huggingface_token": {
-          "description": "The Huggingface access token.",
+        "hf_token": {
+          "description": "The Hugging Face access token. `huggingface_token` is accepted as an alias.",
           "type": "string"
         },
         "distributed_backend": {
@@ -10839,73 +10839,73 @@
           "description": "Maximum requests per minute for this model. Overrides provider defaults.",
           "type": "string"
         },
-        "huggingface_frequency_penalty": {
+        "hf_frequency_penalty": {
           "type": "string"
         },
-        "huggingface_logit_bias": {
+        "hf_logit_bias": {
           "type": "string"
         },
-        "huggingface_logprobs": {
+        "hf_logprobs": {
           "type": "string"
         },
-        "huggingface_top_logprobs": {
+        "hf_top_logprobs": {
           "type": "string"
         },
-        "huggingface_max_completion_tokens": {
+        "hf_max_completion_tokens": {
           "type": "string"
         },
-        "huggingface_reasoning_effort": {
+        "hf_reasoning_effort": {
           "type": "string"
         },
-        "huggingface_store": {
+        "hf_store": {
           "type": "string"
         },
-        "huggingface_metadata": {
+        "hf_metadata": {
           "type": "string"
         },
-        "huggingface_n": {
+        "hf_n": {
           "type": "string"
         },
-        "huggingface_presence_penalty": {
+        "hf_presence_penalty": {
           "type": "string"
         },
-        "huggingface_response_format": {
+        "hf_response_format": {
           "type": "string"
         },
-        "huggingface_seed": {
+        "hf_seed": {
           "type": "string"
         },
-        "huggingface_stop": {
+        "hf_stop": {
           "type": "string"
         },
-        "huggingface_stream": {
+        "hf_stream": {
           "type": "string"
         },
-        "huggingface_stream_options": {
+        "hf_stream_options": {
           "type": "string"
         },
-        "huggingface_temperature": {
+        "hf_temperature": {
           "type": "string"
         },
-        "huggingface_top_p": {
+        "hf_top_p": {
           "type": "string"
         },
-        "huggingface_tools": {
+        "hf_tools": {
           "type": "string"
         },
-        "huggingface_tool_choice": {
+        "hf_tool_choice": {
           "type": "string"
         },
-        "huggingface_parallel_tool_calls": {
+        "hf_parallel_tool_calls": {
           "type": "string"
         },
-        "huggingface_prompt_cache_key": {
+        "hf_prompt_cache_key": {
           "type": "string"
         },
-        "huggingface_prompt_cache_retention": {
+        "hf_prompt_cache_retention": {
           "type": "string"
         },
-        "huggingface_user": {
+        "hf_user": {
           "type": "string"
         },
         "openai_frequency_penalty": {

--- a/.schema/spicepod.schema.json
+++ b/.schema/spicepod.schema.json
@@ -454,7 +454,7 @@
       },
       {
         "name": "huggingface",
-        "prefix": "huggingface",
+        "prefix": "hf",
         "paramsRef": "#/$defs/HuggingfaceModelParams",
         "schemaRef": "#/$defs/HuggingfaceModel"
       },

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -371,7 +371,7 @@ async fn huggingface(
     };
 
     let model_type = params.model_type.as_deref();
-    let hf_token = params.token.as_ref();
+    let hf_token = params.hf_token.as_ref();
 
     // For GGUF models, we require user specify via `.files[].path`
     let gguf_path = component

--- a/crates/runtime/src/model/params/huggingface.rs
+++ b/crates/runtime/src/model/params/huggingface.rs
@@ -19,9 +19,14 @@ use runtime_parameters::TypedParams;
 use secrecy::SecretString;
 
 /// Parameters for `from: huggingface` chat models.
+///
+/// The prefix is `hf`, the source's short name (`ModelSource::HuggingFace.short_name()`):
+/// the request-override lookup in `chat.rs` reads the prefixed passthrough overrides
+/// (`hf_temperature`, `hf_tools`, …) by that name, so the struct must spell its keys
+/// with the same prefix or a consumed override is never applied.
 #[derive(TypedParams)]
 #[params(
-    prefix = "huggingface",
+    prefix = "hf",
     passthrough = crate::model::params::common::PREFIXED_COMMON,
     emit_specs
 )]
@@ -35,8 +40,9 @@ pub struct HuggingFaceModelParams {
     /// Customizes the transformation of `OpenAI` chat messages into a character stream for the model.
     #[param(runtime)]
     pub chat_template: Option<String>,
-    /// The Huggingface access token.
-    pub token: Option<SecretString>,
+    /// The Hugging Face access token. `huggingface_token` is accepted as an alias.
+    #[param(runtime, alias = "huggingface_token")]
+    pub hf_token: Option<SecretString>,
     /// Run the model tensor-parallel across multiple nodes (a Spice enterprise feature; standard builds are single-node only). Set to 'ring' to pool the model over the `nodes` list (the 'ring' backend currently supports exactly 2 nodes); omit or 'none' for single-node.
     #[param(runtime, default = "none")]
     pub distributed_backend: DistributedBackendSetting,

--- a/crates/runtime/src/model/params/huggingface.rs
+++ b/crates/runtime/src/model/params/huggingface.rs
@@ -20,10 +20,8 @@ use secrecy::SecretString;
 
 /// Parameters for `from: huggingface` chat models.
 ///
-/// The prefix is `hf`, the source's short name (`ModelSource::HuggingFace.short_name()`):
-/// the request-override lookup in `chat.rs` reads the prefixed passthrough overrides
-/// (`hf_temperature`, `hf_tools`, …) by that name, so the struct must spell its keys
-/// with the same prefix or a consumed override is never applied.
+/// `prefix` must equal `ModelSource::HuggingFace.short_name()` (`hf`); enforced by
+/// `model_param_prefixes_match_the_source_short_name`.
 #[derive(TypedParams)]
 #[params(
     prefix = "hf",
@@ -41,6 +39,10 @@ pub struct HuggingFaceModelParams {
     #[param(runtime)]
     pub chat_template: Option<String>,
     /// The Hugging Face access token. `huggingface_token` is accepted as an alias.
+    // `runtime` keeps the alias unprefixed (a component alias would render as
+    // `hf_huggingface_token`). Unlike the embeddings and reranker `hf_token`, not
+    // `autoload_secret`: a chat model that names no token must not start reading
+    // one from the secret stores.
     #[param(runtime, alias = "huggingface_token")]
     pub hf_token: Option<SecretString>,
     /// Run the model tensor-parallel across multiple nodes (a Spice enterprise feature; standard builds are single-node only). Set to 'ring' to pool the model over the `nodes` list (the 'ring' backend currently supports exactly 2 nodes); omit or 'none' for single-node.

--- a/crates/runtime/src/model/params/mod.rs
+++ b/crates/runtime/src/model/params/mod.rs
@@ -145,16 +145,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn huggingface_accepts_prefixed_token_and_runtime_model_type() {
+    async fn huggingface_accepts_hf_token_and_runtime_model_type() {
+        // `hf_token` is the documented key, shared with the embeddings and
+        // reranker components. Regression test for #13932.
         let typed = huggingface::HuggingFaceModelParams::try_from_params(
             "model huggingface",
-            params(&[("huggingface_token", "hf_abc"), ("model_type", "llama")]),
+            params(&[("hf_token", "hf_abc"), ("model_type", "llama")]),
             &empty_secrets(),
         )
         .await
         .expect("huggingface params should deserialize");
         assert_eq!(
-            typed.token.as_ref().map(ExposeSecret::expose_secret),
+            typed.hf_token.as_ref().map(ExposeSecret::expose_secret),
             Some("hf_abc")
         );
         assert_eq!(typed.model_type.as_deref(), Some("llama"));
@@ -162,6 +164,79 @@ mod tests {
             typed.distributed_backend,
             llms::chat::DistributedBackendSetting::None
         );
+    }
+
+    #[tokio::test]
+    async fn huggingface_accepts_huggingface_token_alias() {
+        let typed = huggingface::HuggingFaceModelParams::try_from_params(
+            "model huggingface",
+            params(&[("huggingface_token", "hf_abc")]),
+            &empty_secrets(),
+        )
+        .await
+        .expect("huggingface params should deserialize");
+        assert_eq!(
+            typed.hf_token.as_ref().map(ExposeSecret::expose_secret),
+            Some("hf_abc")
+        );
+    }
+
+    #[test]
+    fn huggingface_spec_advertises_hf_token() {
+        // The schema generator renders this spec list, so the key it advertises
+        // must be the key `try_from_params` reads.
+        let specs = get_params_spec(&ModelSource::HuggingFace);
+        let token = specs
+            .iter()
+            .find(|s| s.name == "hf_token")
+            .expect("spec for hf_token");
+        assert_eq!(token.r#type, ParameterType::Runtime);
+        assert!(
+            specs.iter().all(|s| s.name != "token"),
+            "a component `token` spec would render as `{{prefix}}_token` in the schema"
+        );
+    }
+
+    #[test]
+    fn model_param_prefixes_match_the_source_short_name() {
+        // `construct_model` reads the prefixed passthrough overrides
+        // (`{prefix}_temperature`, `{prefix}_tools`, …) through
+        // `get_openai_request_overrides(component, source.short_name())`, while
+        // `try_from_params` consumes them under the struct's `prefix`. When the two
+        // disagree, an override spelled the documented way is warned about as unknown
+        // and one spelled the struct's way is consumed but never applied.
+        fn struct_prefix(source: &ModelSource) -> &'static str {
+            match source {
+                ModelSource::OpenAi => openai::OpenAiModelParams::PREFIX,
+                ModelSource::Azure => azure::AzureModelParams::PREFIX,
+                ModelSource::File => file::FileModelParams::PREFIX,
+                ModelSource::Databricks => databricks::DatabricksModelParams::PREFIX,
+                ModelSource::HuggingFace => huggingface::HuggingFaceModelParams::PREFIX,
+                ModelSource::Anthropic => anthropic::AnthropicModelParams::PREFIX,
+                ModelSource::Xai => xai::XaiModelParams::PREFIX,
+                ModelSource::Bedrock => bedrock::BedrockModelParams::PREFIX,
+                ModelSource::SpiceAI => spiceai::SpiceAiModelParams::PREFIX,
+                ModelSource::Google => google::GoogleModelParams::PREFIX,
+            }
+        }
+        for source in [
+            ModelSource::OpenAi,
+            ModelSource::Azure,
+            ModelSource::File,
+            ModelSource::Databricks,
+            ModelSource::HuggingFace,
+            ModelSource::Anthropic,
+            ModelSource::Xai,
+            ModelSource::Bedrock,
+            ModelSource::SpiceAI,
+            ModelSource::Google,
+        ] {
+            assert_eq!(
+                struct_prefix(&source),
+                source.short_name(),
+                "params struct prefix for {source:?} must match the source short name"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/runtime/src/model/params/mod.rs
+++ b/crates/runtime/src/model/params/mod.rs
@@ -144,10 +144,10 @@ mod tests {
         );
     }
 
+    /// Regression test for #13932: `hf_token` is the documented key, shared with
+    /// the embeddings and reranker components.
     #[tokio::test]
     async fn huggingface_accepts_hf_token_and_runtime_model_type() {
-        // `hf_token` is the documented key, shared with the embeddings and
-        // reranker components. Regression test for #13932.
         let typed = huggingface::HuggingFaceModelParams::try_from_params(
             "model huggingface",
             params(&[("hf_token", "hf_abc"), ("model_type", "llama")]),
@@ -193,46 +193,41 @@ mod tests {
         assert_eq!(token.r#type, ParameterType::Runtime);
         assert!(
             specs.iter().all(|s| s.name != "token"),
-            "a component `token` spec would render as `{{prefix}}_token` in the schema"
+            "only one spec may render to the `hf_token` key"
         );
     }
 
+    /// `construct_model` and the responses API read the prefixed passthrough
+    /// overrides (`{prefix}_temperature`, `{prefix}_tools`, …) through
+    /// `get_openai_request_overrides(component, source.short_name())`, while
+    /// `try_from_params` consumes them under the struct's `prefix`. When the two
+    /// disagree, an override spelled the documented way is warned about as unknown
+    /// and one spelled the struct's way is consumed but never applied (#13932).
     #[test]
     fn model_param_prefixes_match_the_source_short_name() {
-        // `construct_model` reads the prefixed passthrough overrides
-        // (`{prefix}_temperature`, `{prefix}_tools`, …) through
-        // `get_openai_request_overrides(component, source.short_name())`, while
-        // `try_from_params` consumes them under the struct's `prefix`. When the two
-        // disagree, an override spelled the documented way is warned about as unknown
-        // and one spelled the struct's way is consumed but never applied.
-        fn struct_prefix(source: &ModelSource) -> &'static str {
-            match source {
-                ModelSource::OpenAi => openai::OpenAiModelParams::PREFIX,
-                ModelSource::Azure => azure::AzureModelParams::PREFIX,
-                ModelSource::File => file::FileModelParams::PREFIX,
-                ModelSource::Databricks => databricks::DatabricksModelParams::PREFIX,
-                ModelSource::HuggingFace => huggingface::HuggingFaceModelParams::PREFIX,
-                ModelSource::Anthropic => anthropic::AnthropicModelParams::PREFIX,
-                ModelSource::Xai => xai::XaiModelParams::PREFIX,
-                ModelSource::Bedrock => bedrock::BedrockModelParams::PREFIX,
-                ModelSource::SpiceAI => spiceai::SpiceAiModelParams::PREFIX,
-                ModelSource::Google => google::GoogleModelParams::PREFIX,
-            }
-        }
-        for source in [
-            ModelSource::OpenAi,
-            ModelSource::Azure,
-            ModelSource::File,
-            ModelSource::Databricks,
-            ModelSource::HuggingFace,
-            ModelSource::Anthropic,
-            ModelSource::Xai,
-            ModelSource::Bedrock,
-            ModelSource::SpiceAI,
-            ModelSource::Google,
+        for (source, prefix) in [
+            (ModelSource::OpenAi, openai::OpenAiModelParams::PREFIX),
+            (ModelSource::Azure, azure::AzureModelParams::PREFIX),
+            (ModelSource::File, file::FileModelParams::PREFIX),
+            (
+                ModelSource::Databricks,
+                databricks::DatabricksModelParams::PREFIX,
+            ),
+            (
+                ModelSource::HuggingFace,
+                huggingface::HuggingFaceModelParams::PREFIX,
+            ),
+            (
+                ModelSource::Anthropic,
+                anthropic::AnthropicModelParams::PREFIX,
+            ),
+            (ModelSource::Xai, xai::XaiModelParams::PREFIX),
+            (ModelSource::Bedrock, bedrock::BedrockModelParams::PREFIX),
+            (ModelSource::SpiceAI, spiceai::SpiceAiModelParams::PREFIX),
+            (ModelSource::Google, google::GoogleModelParams::PREFIX),
         ] {
             assert_eq!(
-                struct_prefix(&source),
+                prefix,
                 source.short_name(),
                 "params struct prefix for {source:?} must match the source short name"
             );

--- a/tools/spicepodschema/src/collector.rs
+++ b/tools/spicepodschema/src/collector.rs
@@ -214,52 +214,52 @@ pub fn collect_model_sources() -> Vec<ModelSourceSchema> {
     vec![
         ModelSourceSchema {
             name: "openai",
-            prefix: "openai",
+            prefix: ModelSource::OpenAi.short_name(),
             parameters: get_params_spec(&ModelSource::OpenAi),
         },
         ModelSourceSchema {
             name: "azure",
-            prefix: "azure",
+            prefix: ModelSource::Azure.short_name(),
             parameters: get_params_spec(&ModelSource::Azure),
         },
         ModelSourceSchema {
             name: "file",
-            prefix: "file",
+            prefix: ModelSource::File.short_name(),
             parameters: get_params_spec(&ModelSource::File),
         },
         ModelSourceSchema {
             name: "databricks",
-            prefix: "databricks",
+            prefix: ModelSource::Databricks.short_name(),
             parameters: get_params_spec(&ModelSource::Databricks),
         },
         ModelSourceSchema {
             name: "huggingface",
-            prefix: "hf",
+            prefix: ModelSource::HuggingFace.short_name(),
             parameters: get_params_spec(&ModelSource::HuggingFace),
         },
         ModelSourceSchema {
             name: "anthropic",
-            prefix: "anthropic",
+            prefix: ModelSource::Anthropic.short_name(),
             parameters: get_params_spec(&ModelSource::Anthropic),
         },
         ModelSourceSchema {
             name: "xai",
-            prefix: "xai",
+            prefix: ModelSource::Xai.short_name(),
             parameters: get_params_spec(&ModelSource::Xai),
         },
         ModelSourceSchema {
             name: "bedrock",
-            prefix: "bedrock",
+            prefix: ModelSource::Bedrock.short_name(),
             parameters: get_params_spec(&ModelSource::Bedrock),
         },
         ModelSourceSchema {
             name: "google",
-            prefix: "google",
+            prefix: ModelSource::Google.short_name(),
             parameters: get_params_spec(&ModelSource::Google),
         },
         ModelSourceSchema {
             name: "spiceai",
-            prefix: "spiceai",
+            prefix: ModelSource::SpiceAI.short_name(),
             parameters: get_params_spec(&ModelSource::SpiceAI),
         },
     ]

--- a/tools/spicepodschema/src/collector.rs
+++ b/tools/spicepodschema/src/collector.rs
@@ -234,7 +234,7 @@ pub fn collect_model_sources() -> Vec<ModelSourceSchema> {
         },
         ModelSourceSchema {
             name: "huggingface",
-            prefix: "huggingface",
+            prefix: "hf",
             parameters: get_params_spec(&ModelSource::HuggingFace),
         },
         ModelSourceSchema {

--- a/tools/spicepodschema/tests/spicepod.all.yaml
+++ b/tools/spicepodschema/tests/spicepod.all.yaml
@@ -1319,7 +1319,7 @@ models:
     from: huggingface:mistralai/Mistral-7B-Instruct-v0.2
     params:
       model_type: mistral
-      huggingface_token: hf_xxx
+      hf_token: hf_xxx
       tools: auto
       system_prompt: You are a helpful assistant.
 
@@ -1374,7 +1374,7 @@ embeddings:
   - name: hf_embeddings
     from: huggingface:sentence-transformers/all-MiniLM-L6-v2
     params:
-      huggingface_token: hf_xxx
+      hf_token: hf_xxx
 
   # File-based embeddings
   - name: file_embeddings

--- a/tools/spicepodschema/tests/spicepod.embeddings.yaml
+++ b/tools/spicepodschema/tests/spicepod.embeddings.yaml
@@ -38,7 +38,7 @@ embeddings:
   - name: hf_embeddings
     from: huggingface:sentence-transformers/all-MiniLM-L6-v2
     params:
-      huggingface_token: hf_xxx
+      hf_token: hf_xxx
 
   # ---------------------------------------------------------------------------
   # File-based Embeddings

--- a/tools/spicepodschema/tests/spicepod.models.yaml
+++ b/tools/spicepodschema/tests/spicepod.models.yaml
@@ -76,7 +76,7 @@ models:
   # - name: hf_mistral
   #   from: huggingface:mistralai/Mistral-7B-Instruct-v0.2
   #   params:
-  #     huggingface_token: hf_xxx
+  #     hf_token: hf_xxx
   #     model_type: mistral
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A `from: huggingface:` chat model silently ignored the documented `hf_token` parameter, so a gated or private repository was downloaded anonymously and failed with a 401 that pointed at nothing.

`HuggingFaceModelParams` was given the prefix `huggingface` when it moved to `#[derive(TypedParams)]`, so its component params rendered as `huggingface_token`, `huggingface_temperature`, …. Everything around it still keys the source by its short name `hf`: `ModelSource::HuggingFace.short_name()` is `"hf"`, `construct_model` reads the prefixed chat overrides through `get_openai_request_overrides(component, source.short_name())`, the published docs and the integration tests pass `hf_token`, and the embeddings and reranker components read `hf_token` too. The disagreement had two consequences on every HuggingFace chat model:

- `hf_token` and `hf_temperature` were warned about as unknown parameters and dropped, so the model loaded without a token.
- `huggingface_temperature` (and the other 22 `huggingface_*` overrides the schema advertised) were consumed without a warning but never applied, because the override lookup reads `hf_*`.

Affects v2.2.0, v2.2.1 and `trunk`; v2.1.x is unaffected. Regression of #6695.

## Changes

- `HuggingFaceModelParams` uses the prefix `hf`, the source's short name, so its component params and its prefixed passthrough overrides are spelled the way the override lookup and the docs spell them.
- The token is the runtime field `hf_token`, matching the embeddings and reranker specs. `huggingface_token` stays accepted as an alias so a spicepod written against v2.2.0/v2.2.1 keeps loading; the schema advertises `hf_token` and names the alias in its description.
- The schema collector reads every model source's prefix from `ModelSource::short_name()` instead of a second string literal, so the published schema cannot drift from the runtime again on its own. `.schema/spicepod.schema.json` follows: `huggingface_*` → `hf_*` in the HuggingFace model params block (24 keys) and `"prefix": "hf"` in the `modelSources` metadata block. The rename was applied by hand and then checked against the generator: `cargo run -p spicepodschema -- .schema/spicepod.schema.json` on this branch produces the same 24 `hf_*` keys and the same `hf_token` description; the only HuggingFace-touching lines in the diff between its output and the committed file are a position change of `hf_tools` inside the passthrough block, which every source's block shares and which predates this branch. The generator's output also differs from the committed file by ~1,000 unrelated lines that predate this branch (the committed schema is stale, and no check compares it to the generator); that is tracked separately in #13945 rather than folded in here. The schema fixtures use `hf_token`.
- Unit tests: `hf_token` and the `huggingface_token` alias both deserialize; the emitted spec advertises a runtime `hf_token` and no bare `token`; and a class guard asserts every model params struct's `PREFIX` equals its source `short_name()`, since the override lookup depends on that equality for every source with a passthrough table.

Not changed: `hf_token` is not given `autoload_secret`. The pre-refactor spec did not autoload it either, and turning that on would silently start reading an `hf_token` secret for chat models that never asked for one.

## Test plan

Reproduced on a real `spiced` with a two-line manifest (`hf_token`, `hf_temperature`, `huggingface_temperature` on a `from: huggingface:` chat model pointing at a nonexistent repository, so the load fails fast after the params are read):

**Before** — installed `spiced v2.2.1+models.metal`:

```
WARN runtime_parameters_typed: Ignoring parameter `hf_token`: not supported for model huggingface.
WARN runtime_parameters_typed: Ignoring parameter `hf_temperature`: not supported for model huggingface. Did you mean `openai_temperature`?
WARN runtime::init::model: Failed to load LLM: hf_chat. ... Could not access `spiceai-repro/does-not-exist` (revision `main`) on Hugging Face (HTTP 401). ...
```

`huggingface_temperature` drew no warning at all.

**After** — `spiced` built from this branch, same manifest, same command:

```
WARN runtime_parameters_typed: Ignoring parameter `huggingface_temperature`: not supported for model huggingface.
WARN runtime::init::model: Failed to load LLM: hf_chat. ... Could not access `spiceai-repro/does-not-exist` (revision `main`) on Hugging Face (HTTP 401). ...
```

`hf_token` and `hf_temperature` are consumed without a warning, and the never-applied `huggingface_temperature` is now reported as unsupported instead of being silently swallowed. (The 401 is expected on both runs: the manifest carries a placeholder token against a repository that does not exist, so the log cannot distinguish an anonymous request from a bad token; the parameter warnings are the artifact.) Binaries: before `v2.2.1+models.metal`, after `v2.3.0-unstable-build.72fb3d69d9-dev+models`.

- [x] `cargo test -p runtime --lib --features models model::params` — 16 passed, 0 failed (run twice: on the fix, and again after the `/simplify` edits)
- [ ] `make lint`
- [ ] `make test`
- [ ] `make signoff` (dispatched remotely via `signoff.yml`; the local gate cannot run from a nested worktree)

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` not installed
- `/security-review`: no findings — verified that only parameter *keys* reach the leftover/deprecation warnings, the token stays a `SecretString` end to end, and the prefix change does not alter which params are marked secret or autoloaded
- `/simplify`: applied — the schema collector now derives prefixes from `short_name()` (it had a third copy of the literal, and the review found the `modelSources` metadata block still said `huggingface`), the guard test lists each source once, the struct doc points at the enforcing test, and the regression reference moved to a doc comment. Light checks re-run: `rustfmt --check` clean on every touched file, `cargo test -p runtime --lib --features models model::params` 16 passed

Fixes #13932

## Checklist

- [x] Root cause identified and fixed at the source (prefix disagreement), not the symptom
- [x] Regression tests added that fail on `trunk` and pass on this branch
- [x] Back-compat for the v2.2.x key preserved via an alias
- [ ] Sign-off attested on the pushed HEAD