### PR TITLE
fix(postgres): preserve microseconds in timestamp writeback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7310,7 +7310,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=ae32853c9b122ac3e48d6fa87c740113379c0aa3#ae32853c9b122ac3e48d6fa87c740113379c0aa3"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=a7d9a3a2787fbaaf5315fb30c2d124825b5e8e3d#a7d9a3a2787fbaaf5315fb30c2d124825b5e8e3d"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -18978,7 +18978,7 @@ dependencies = [
 [[package]]
 name = "sea-query"
 version = "0.32.0-rc.1"
-source = "git+https://github.com/spiceai/sea-query.git?rev=213b6b876068f58159ebdd5852604a021afaebf9#213b6b876068f58159ebdd5852604a021afaebf9"
+source = "git+https://github.com/spiceai/sea-query.git?rev=b18fecfa59c5e5742c81e16f58eef6ae18e95e0d#b18fecfa59c5e5742c81e16f58eef6ae18e95e0d"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -18991,7 +18991,7 @@ dependencies = [
 [[package]]
 name = "sea-query-derive"
 version = "0.4.1"
-source = "git+https://github.com/spiceai/sea-query.git?rev=213b6b876068f58159ebdd5852604a021afaebf9#213b6b876068f58159ebdd5852604a021afaebf9"
+source = "git+https://github.com/spiceai/sea-query.git?rev=b18fecfa59c5e5742c81e16f58eef6ae18e95e0d#b18fecfa59c5e5742c81e16f58eef6ae18e95e0d"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7310,7 +7310,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=a7d9a3a2787fbaaf5315fb30c2d124825b5e8e3d#a7d9a3a2787fbaaf5315fb30c2d124825b5e8e3d"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=96c361a7c8d0d29c7a76b0e92acf64268da3e2a2#96c361a7c8d0d29c7a76b0e92acf64268da3e2a2"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -18978,7 +18978,7 @@ dependencies = [
 [[package]]
 name = "sea-query"
 version = "0.32.0-rc.1"
-source = "git+https://github.com/spiceai/sea-query.git?rev=b18fecfa59c5e5742c81e16f58eef6ae18e95e0d#b18fecfa59c5e5742c81e16f58eef6ae18e95e0d"
+source = "git+https://github.com/spiceai/sea-query.git?rev=ae75baef819513fb8d19af014972dcfa324e201a#ae75baef819513fb8d19af014972dcfa324e201a"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -18991,7 +18991,7 @@ dependencies = [
 [[package]]
 name = "sea-query-derive"
 version = "0.4.1"
-source = "git+https://github.com/spiceai/sea-query.git?rev=b18fecfa59c5e5742c81e16f58eef6ae18e95e0d#b18fecfa59c5e5742c81e16f58eef6ae18e95e0d"
+source = "git+https://github.com/spiceai/sea-query.git?rev=ae75baef819513fb8d19af014972dcfa324e201a#ae75baef819513fb8d19af014972dcfa324e201a"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,7 +272,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "ae32853c9b122ac3e48d6fa87c740113379c0aa3" } # branch: spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "a7d9a3a2787fbaaf5315fb30c2d124825b5e8e3d" } # branch: phillip/13957-timestamp-precision
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,7 +272,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "a7d9a3a2787fbaaf5315fb30c2d124825b5e8e3d" } # branch: phillip/13957-timestamp-precision
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "96c361a7c8d0d29c7a76b0e92acf64268da3e2a2" } # branch: spiceai-54
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",

--- a/crates/runtime/tests/postgres/write_back_delivery.rs
+++ b/crates/runtime/tests/postgres/write_back_delivery.rs
@@ -749,3 +749,95 @@ async fn a_pk_point_lookup_ordered_by_the_pk_plans_after_a_transactional_commit(
         })
         .await
 }
+
+/// Durable delivery preserves both wall-clock timestamps and timestamp instants
+/// at `PostgreSQL` microsecond precision, including the upsert UPDATE path.
+#[tokio::test(flavor = "multi_thread")]
+async fn timestamp_microseconds_survive_write_back_and_echo() -> Result<(), anyhow::Error> {
+    use arrow::array::{Array, AsArray};
+    use arrow::datatypes::TimestampNanosecondType;
+
+    let _tracing = init_tracing(Some(tracing_filter()));
+    test_request_context().scope(async {
+        let (port, _container) = common::replication_test_database().await?;
+        let source = connect(port).await?;
+        let slot = "spice_wb_precision";
+        crate::postgres::replication::drop_replication_slot_when_inactive(&source, slot).await?;
+        exec(&source, "DROP TABLE IF EXISTS public.wb_precision; CREATE TABLE public.wb_precision (id int PRIMARY KEY, wall timestamp, instant timestamptz, n int); INSERT INTO public.wb_precision VALUES (0,NULL,NULL,0)").await?;
+        let accel = tempfile::tempdir()?;
+        let rt = build_runtime("write_back_precision", vec![write_back_dataset(port, "wb_precision", slot, accel.path())]).await?;
+        wait_for_bootstrap(&rt, "wb_precision").await?;
+        let cases = [
+            ("2026-01-02 03:04:05.000001", "2026-01-02T03:04:05.000001Z"),
+            ("2026-01-02 03:04:05.123456", "2026-01-02T03:04:05.123456+09:00"),
+            ("1969-12-31 23:59:59.123456", "1969-12-31T23:59:59.123456-07:00"),
+            ("2026-01-02 03:04:05", "2026-01-02T03:04:05Z"),
+        ];
+        for phase in 1..=2 {
+            for (index, (wall, instant)) in cases.iter().enumerate() {
+                let id = index + 1;
+                let wall = if phase == 2 { wall.replace("2026-01-02", "2026-02-03") } else { (*wall).to_string() };
+                let instant = if phase == 2 { instant.replace("2026-01-02", "2026-02-03") } else { (*instant).to_string() };
+                let values = format!("CAST('{wall}' AS TIMESTAMP),CAST('{instant}' AS TIMESTAMP WITH TIME ZONE)");
+                let statement = if phase == 1 {
+                    format!("INSERT INTO wb_precision VALUES ({id},{values},{phase})")
+                } else {
+                    format!("UPDATE wb_precision SET wall=CAST('{wall}' AS TIMESTAMP),instant=CAST('{instant}' AS TIMESTAMP WITH TIME ZONE),n={phase} WHERE id={id}")
+                };
+                run_txn(&rt, &format!("BEGIN; {statement}; COMMIT;")).await.map_err(|e| anyhow!("{}", describe(&e)))?;
+                let probe = format!("SELECT n FROM public.wb_precision WHERE id={id}");
+                wait_for("timestamp source delivery", Some(phase), || source_value(&source, &probe)).await?;
+                let query = format!("SELECT wall,instant FROM wb_precision WHERE id={id}");
+                let before = run_query(&rt, &query).await?;
+                let source_row = source.query_one(&format!("SELECT (extract(epoch FROM wall)*1000000)::bigint,(extract(epoch FROM instant)*1000000)::bigint FROM public.wb_precision WHERE id={id}"), &[]).await?;
+                for column in 0..2 {
+                    let local = before[0].column(column).as_primitive::<TimestampNanosecondType>();
+                    assert!(!local.is_null(0));
+                    let nanos = local.value(0);
+                    assert_eq!(nanos % 1000, 0, "microsecond fixture must not conceal rounding");
+                    let expected_micros = if column == 0 {
+                        chrono::NaiveDateTime::parse_from_str(&wall, "%Y-%m-%d %H:%M:%S%.f")?.and_utc().timestamp_micros()
+                    } else {
+                        chrono::DateTime::parse_from_rfc3339(&instant)?.timestamp_micros()
+                    };
+                    assert_eq!(nanos / 1000, expected_micros, "acknowledged timestamp changed the requested value");
+                    let source_micros: i64 = source_row.get(column);
+                    assert_eq!(nanos / 1000, source_micros, "phase={phase} id={id} column={column}");
+                }
+                // A later foreign source write is a WAL ordering barrier for the own echo.
+                exec(&source, "UPDATE public.wb_precision SET n=n+1 WHERE id=0").await?;
+                let barrier = source_value(&source, "SELECT n FROM public.wb_precision WHERE id=0").await?;
+                wait_for("timestamp CDC barrier", barrier, || accel_scalar(&rt, "SELECT n FROM wb_precision WHERE id=0")).await?;
+                assert_eq!(run_query(&rt, &query).await?, before, "own echo changed the acknowledged timestamp");
+            }
+        }
+        // The time formatter emits six fractional digits for a naive timestamp;
+        // Chrono retains all digits and PostgreSQL rounds them to microseconds.
+        // The authoritative accelerator keeps the acknowledged nanoseconds.
+        run_txn(&rt, "BEGIN; INSERT INTO wb_precision VALUES (7,CAST('2026-01-02 03:04:05.123456789' AS TIMESTAMP),CAST('2026-01-02T03:04:05.123456789Z' AS TIMESTAMP WITH TIME ZONE),1); COMMIT;").await.map_err(|e| anyhow!("{}", describe(&e)))?;
+        wait_for("nanosecond input delivery", Some(1), || source_value(&source, "SELECT n FROM public.wb_precision WHERE id=7")).await?;
+        let finer = source.query_one("SELECT to_char(wall,'US'),to_char(instant,'US') FROM public.wb_precision WHERE id=7", &[]).await?;
+        assert_eq!(finer.get::<_, String>(0), "123456");
+        assert_eq!(finer.get::<_, String>(1), "123457");
+        exec(&source, "UPDATE public.wb_precision SET n=n+1 WHERE id=0").await?;
+        let barrier = source_value(&source, "SELECT n FROM public.wb_precision WHERE id=0").await?;
+        wait_for("timestamp CDC barrier", barrier, || accel_scalar(&rt, "SELECT n FROM wb_precision WHERE id=0")).await?;
+        let local = run_query(&rt, "SELECT wall,instant FROM wb_precision WHERE id=7").await?;
+        for column in 0..2 {
+            assert_eq!(local[0].column(column).as_primitive::<TimestampNanosecondType>().value(0) % 1_000_000_000, 123_456_789);
+        }
+        run_txn(&rt, "BEGIN; UPDATE wb_precision SET wall=NULL,instant=NULL,n=3 WHERE id=1; COMMIT;").await.map_err(|e| anyhow!("{}", describe(&e)))?;
+        wait_for("timestamp NULL delivery", Some(3), || source_value(&source, "SELECT n FROM public.wb_precision WHERE id=1")).await?;
+        let nulls: bool = source.query_one("SELECT wall IS NULL AND instant IS NULL FROM public.wb_precision WHERE id=1", &[]).await?.get(0);
+        assert!(nulls);
+        exec(&source, "UPDATE public.wb_precision SET n=n+1 WHERE id=0").await?;
+        let barrier = source_value(&source, "SELECT n FROM public.wb_precision WHERE id=0").await?;
+        wait_for("timestamp CDC barrier", barrier, || accel_scalar(&rt, "SELECT n FROM wb_precision WHERE id=0")).await?;
+        let local = run_query(&rt, "SELECT wall,instant FROM wb_precision WHERE id=1").await?;
+        assert!(local[0].columns().iter().all(|column| column.is_null(0)));
+        rt.shutdown().await;
+        drop(rt);
+        crate::postgres::replication::drop_replication_slot_when_inactive(&source, slot).await?;
+        Ok(())
+    }).await
+}

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -97,7 +97,7 @@ own section below — a count here would be one more thing to keep true by hand.
 | [datafusion-ballista](#datafusion-ballista) | `f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0` | `spiceai-54` |
 | [datafusion-federation](#datafusion-federation-and-datafusion-table-providers) | `3af703dba0accdff5fdb0ae92ef12588e1dfe88a` | `spiceai-54` |
 | [datafusion-functions-json](#datafusion-functions-json) | `ca9d4c6e5a0de3bfa9fe20a683a9f7d58e36e2cc` | `spiceai-54` |
-| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `a7d9a3a2787fbaaf5315fb30c2d124825b5e8e3d` | `phillip/13957-timestamp-precision` |
+| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `96c361a7c8d0d29c7a76b0e92acf64268da3e2a2` | `spiceai-54` |
 | [delta-kernel-rs](#delta-kernel-rs) | `714d64fd5369efc4835109be0fd718db5a3be0aa` | `spiceai-0.23.0` |
 | [docx-rs](#docx-rs) | `2a85dce57d0128e2cd7c369545516c347cb8c529` | `spiceai` |
 | [duckdb-rs](#duckdb-rs) | `9d7be742f060d70066fc041319af787772716e0d` | `spiceai-1.4.4` |
@@ -107,7 +107,7 @@ own section below — a count here would be one more thing to keep true by hand.
 | [model2vec-rs](#model2vec-rs) | `55fef28a3556895b20204634b788f7c836b610bc` | `spiceai` |
 | [reqwest-eventsource](#dependency-only-forks) | `eb11e695128ce264bf05e4220ce2311c25992c73` | `spiceai` |
 | [rusqlite](#rusqlite-and-tokio-rusqlite) | `e39c9c46dea1f0983cd8d87dabb69b41c9efe1fd` | `master` |
-| [sea-query](#sea-query) | `b18fecfa59c5e5742c81e16f58eef6ae18e95e0d` | `phillip/preserve-chrono-fractions` |
+| [sea-query](#sea-query) | `ae75baef819513fb8d19af014972dcfa324e201a` | `spiceai` |
 | [snowflake-rs](#snowflake-rs) | `744ffd77fe82171a805562ce001a341a94d52541` | `spiceai-58` |
 | [spark-connect-rs](#spark-connect-rs) | `5f7c2452d4202d7496abac0a6f2eaa4bef46a5ad` | `spiceai` |
 | [text-embeddings-inference](#mistralrs-and-text-embeddings-inference) | `ac4e457936bc11c9b4fee453f2be33133d3146d8` | `spiceai` |

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -97,7 +97,7 @@ own section below — a count here would be one more thing to keep true by hand.
 | [datafusion-ballista](#datafusion-ballista) | `f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0` | `spiceai-54` |
 | [datafusion-federation](#datafusion-federation-and-datafusion-table-providers) | `3af703dba0accdff5fdb0ae92ef12588e1dfe88a` | `spiceai-54` |
 | [datafusion-functions-json](#datafusion-functions-json) | `ca9d4c6e5a0de3bfa9fe20a683a9f7d58e36e2cc` | `spiceai-54` |
-| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `ae32853c9b122ac3e48d6fa87c740113379c0aa3` | `spiceai-54` |
+| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `a7d9a3a2787fbaaf5315fb30c2d124825b5e8e3d` | `phillip/13957-timestamp-precision` |
 | [delta-kernel-rs](#delta-kernel-rs) | `714d64fd5369efc4835109be0fd718db5a3be0aa` | `spiceai-0.23.0` |
 | [docx-rs](#docx-rs) | `2a85dce57d0128e2cd7c369545516c347cb8c529` | `spiceai` |
 | [duckdb-rs](#duckdb-rs) | `9d7be742f060d70066fc041319af787772716e0d` | `spiceai-1.4.4` |
@@ -107,7 +107,7 @@ own section below — a count here would be one more thing to keep true by hand.
 | [model2vec-rs](#model2vec-rs) | `55fef28a3556895b20204634b788f7c836b610bc` | `spiceai` |
 | [reqwest-eventsource](#dependency-only-forks) | `eb11e695128ce264bf05e4220ce2311c25992c73` | `spiceai` |
 | [rusqlite](#rusqlite-and-tokio-rusqlite) | `e39c9c46dea1f0983cd8d87dabb69b41c9efe1fd` | `master` |
-| [sea-query](#sea-query) | `213b6b876068f58159ebdd5852604a021afaebf9` | `spiceai` |
+| [sea-query](#sea-query) | `b18fecfa59c5e5742c81e16f58eef6ae18e95e0d` | `phillip/preserve-chrono-fractions` |
 | [snowflake-rs](#snowflake-rs) | `744ffd77fe82171a805562ce001a341a94d52541` | `spiceai-58` |
 | [spark-connect-rs](#spark-connect-rs) | `5f7c2452d4202d7496abac0a6f2eaa4bef46a5ad` | `spiceai` |
 | [text-embeddings-inference](#mistralrs-and-text-embeddings-inference) | `ac4e457936bc11c9b4fee453f2be33133d3146d8` | `spiceai` |
@@ -401,6 +401,7 @@ Upstream [SeaQL/sea-query](https://github.com/SeaQL/sea-query).
 | Patch | What breaks if it is lost | Loss | Guard |
 |---|---|---|---|
 | SQLite backend emits a decimal declared type rather than panicking above 16 digits | `CREATE TABLE` for a `Decimal256(40, 4)` column panics; below that the declared type changes, and the SQLite reader keys value decoding off the declared type | silent (panic / wrong decode) | `crates/accelerators/accelerator-sqlite/src/lib.rs::test_sqlite_decimal_round_trip` |
+| Chrono fractional seconds in SQL literals | Timestamp writeback loses microseconds for timezone-aware values rendered through `InsertBuilder` | silent (wrong data) | `crates/runtime/tests/postgres/write_back_delivery.rs::timestamp_microseconds_survive_write_back_and_echo` |
 
 ## snowflake-rs
 


### PR DESCRIPTION
## WHAT

Preserve timestamp microseconds through PostgreSQL durable writeback and own echoes. Closes [#13957](https://github.com/spiceai/spiceai/issues/13957).


## WHY

Acknowledged timestamp fractions are lost when the source write uses whole-second SQL literals.

## HOW

Pin [the merged provider fix](https://github.com/spiceai/datafusion-table-providers/pull/73) and add exact-value INSERT/UPDATE and own-echo regressions, building on merged [#13962](https://github.com/spiceai/spiceai/pull/13962). Cover offsets, NULLs, whole seconds, and finer inputs: the runtime’s naive timestamp formatter truncates to six digits, PostgreSQL rounds full Chrono fractions to microseconds, and local acknowledged nanoseconds remain unchanged. Native PostgreSQL 16.15 tests reproduce the loss before the fix and pass afterward, including trigger, queue-drain, and graceful-restart checks. On the final merged dependency pins, the timestamp writeback, JSONB replication, and broad-type integration tests each execute and pass. Full signoff and Attestation pass on `db785253`: all 12,983 full-suite tests passed without retries, along with full lint and CLI verification. Its integration checks also pass.
