### PR TITLE
fix(arrow_tools): round Decimal→Float casts from exact digits (closes #13978)

### DIFF
--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -16,13 +16,14 @@ limitations under the License.
 
 use arrow::{
     array::{
-        Array, ArrayRef, BinaryViewArray, GenericByteViewArray, ListArray, MutableArrayData,
-        RecordBatch, RecordBatchOptions, StringViewArray, StructArray, make_array, new_null_array,
+        Array, ArrayRef, AsArray, BinaryViewArray, Float32Builder, Float64Builder,
+        GenericByteViewArray, ListArray, MutableArrayData, RecordBatch, RecordBatchOptions,
+        StringViewArray, StructArray, make_array, new_null_array,
     },
     buffer::{Buffer, OffsetBuffer},
     datatypes::{
-        BinaryViewType, ByteViewType, DataType, Field, FieldRef, SchemaRef, StringViewType,
-        TimeUnit,
+        BinaryViewType, ByteViewType, DataType, Decimal128Type, Decimal256Type, Field, FieldRef,
+        SchemaRef, StringViewType, TimeUnit, i256,
     },
     error::ArrowError,
 };
@@ -45,6 +46,14 @@ pub enum Error {
 
     #[snafu(display("Field is not nullable: {field}"))]
     FieldNotNullable { field: String },
+
+    #[snafu(display(
+        "Failed to convert decimal value '{value}' to a floating-point number: {source}"
+    ))]
+    DecimalToFloat {
+        value: String,
+        source: std::num::ParseFloatError,
+    },
 }
 
 impl From<Error> for DataFusionError {
@@ -55,6 +64,9 @@ impl From<Error> for DataFusionError {
             } => DataFusionError::ArrowError(Box::new(arrow_error), None),
             Error::FieldNotNullable { .. } => {
                 DataFusionError::ArrowError(Box::new(ArrowError::SchemaError(e.to_string())), None)
+            }
+            Error::DecimalToFloat { .. } => {
+                DataFusionError::ArrowError(Box::new(ArrowError::CastError(e.to_string())), None)
             }
         }
     }
@@ -180,6 +192,10 @@ fn cast_column(
         return relabel_nullability(column, target_field);
     }
 
+    if let Some(casted) = cast_decimal_to_float(column, target_field.data_type())? {
+        return Ok(casted);
+    }
+
     match cast_with_options(column.as_ref(), target_field.data_type(), strict_options) {
         Ok(casted) => Ok(casted),
         Err(ref e)
@@ -208,6 +224,147 @@ fn is_overflow_error(e: &ArrowError) -> bool {
         ArrowError::CastError(msg) | ArrowError::ArithmeticOverflow(msg)
             if msg.contains("Overflow") || msg.contains("overflow")
     )
+}
+
+/// Correctly-rounded conversion of a decimal column to `Float64`/`Float32`,
+/// or `Ok(None)` when the pair is not decimal-to-float and the caller's general
+/// cast path should handle it.
+///
+/// arrow's own `Decimal -> Float` cast widens the integer coefficient to the
+/// float *before* dividing by `10^scale`, so a coefficient beyond the float's
+/// exactly-representable integer range (`2^53` for `f64`, `2^24` for `f32`) is
+/// rounded once on the way in and the divide carries that error through, landing
+/// the result up to a couple of ULP off the true value. An `avg()`/`sum()`
+/// pushed to `PostgreSQL` returns an *undeclared* NUMERIC read at scale 20, whose
+/// coefficient always exceeds `2^53`, so an exactly representable answer like
+/// `47.5` came back as `47.500_000_000_000_01` (issue #13978). Rounding from the
+/// value's exact decimal digits instead removes the loss at every scale.
+fn cast_decimal_to_float(column: &ArrayRef, target_type: &DataType) -> Result<Option<ArrayRef>> {
+    match (column.data_type(), target_type) {
+        (DataType::Decimal128(_, scale), DataType::Float64) => {
+            let (scale, values) = (*scale, column.as_primitive::<Decimal128Type>());
+            f64_array_from(values.len(), |i| {
+                if values.is_null(i) {
+                    Ok(None)
+                } else {
+                    decimal128_to_f64(values.value(i), scale).map(Some)
+                }
+            })
+            .map(Some)
+        }
+        (DataType::Decimal128(_, scale), DataType::Float32) => {
+            let (scale, values) = (*scale, column.as_primitive::<Decimal128Type>());
+            f32_array_from(values.len(), |i| {
+                if values.is_null(i) {
+                    Ok(None)
+                } else {
+                    parse_scaled::<f32>(&values.value(i).to_string(), scale).map(Some)
+                }
+            })
+            .map(Some)
+        }
+        (DataType::Decimal256(_, scale), DataType::Float64) => {
+            let (scale, values) = (*scale, column.as_primitive::<Decimal256Type>());
+            f64_array_from(values.len(), |i| {
+                if values.is_null(i) {
+                    Ok(None)
+                } else {
+                    decimal256_to_f64(values.value(i), scale).map(Some)
+                }
+            })
+            .map(Some)
+        }
+        (DataType::Decimal256(_, scale), DataType::Float32) => {
+            let (scale, values) = (*scale, column.as_primitive::<Decimal256Type>());
+            f32_array_from(values.len(), |i| {
+                if values.is_null(i) {
+                    Ok(None)
+                } else {
+                    parse_scaled::<f32>(&values.value(i).to_string(), scale).map(Some)
+                }
+            })
+            .map(Some)
+        }
+        _ => Ok(None),
+    }
+}
+
+fn f64_array_from(len: usize, get: impl Fn(usize) -> Result<Option<f64>>) -> Result<ArrayRef> {
+    let mut builder = Float64Builder::with_capacity(len);
+    for index in 0..len {
+        match get(index)? {
+            Some(value) => builder.append_value(value),
+            None => builder.append_null(),
+        }
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+fn f32_array_from(len: usize, get: impl Fn(usize) -> Result<Option<f32>>) -> Result<ArrayRef> {
+    let mut builder = Float32Builder::with_capacity(len);
+    for index in 0..len {
+        match get(index)? {
+            Some(value) => builder.append_value(value),
+            None => builder.append_null(),
+        }
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+fn decimal128_to_f64(value: i128, scale: i8) -> Result<f64> {
+    // Fast path: the coefficient is exactly representable and `10^scale` is too
+    // (`scale <= 22`), so a single IEEE division is already correctly rounded and
+    // no string round-trip is needed.
+    if (0..=22).contains(&scale) && value.unsigned_abs() < (1u128 << 53) {
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "guarded: |value| < 2^53 and scale <= 22, so both operands are exact and the single division is correctly rounded"
+        )]
+        let exact = value as f64 / 10f64.powi(i32::from(scale));
+        return Ok(exact);
+    }
+    parse_scaled(&value.to_string(), scale)
+}
+
+fn decimal256_to_f64(value: i256, scale: i8) -> Result<f64> {
+    parse_scaled(&value.to_string(), scale)
+}
+
+/// Parses the exact decimal `signed_digits` scaled by `10^-scale` into a float,
+/// relying on Rust's correctly-rounded float parsing rather than on integer
+/// widening.
+fn parse_scaled<F>(signed_digits: &str, scale: i8) -> Result<F>
+where
+    F: std::str::FromStr<Err = std::num::ParseFloatError>,
+{
+    let literal = scaled_decimal_literal(signed_digits, scale);
+    literal
+        .parse::<F>()
+        .context(DecimalToFloatSnafu { value: literal })
+}
+
+/// Renders the signed integer coefficient `signed_digits` at `scale` decimal
+/// places as a plain decimal literal (e.g. `"475"` at scale 20 becomes
+/// `"0.00000000000000000475"`). A non-positive scale multiplies by `10^-scale`.
+fn scaled_decimal_literal(signed_digits: &str, scale: i8) -> String {
+    let (sign, magnitude) = match signed_digits.strip_prefix('-') {
+        Some(rest) => ("-", rest),
+        None => ("", signed_digits),
+    };
+
+    if scale <= 0 {
+        let zeros = usize::from(scale.unsigned_abs());
+        return format!("{sign}{magnitude}{}", "0".repeat(zeros));
+    }
+
+    let scale = usize::from(scale.unsigned_abs());
+    if magnitude.len() > scale {
+        let split = magnitude.len() - scale;
+        format!("{sign}{}.{}", &magnitude[..split], &magnitude[split..])
+    } else {
+        // |value| < 1: pad the fraction with leading zeros out to the scale.
+        format!("{sign}0.{magnitude:0>scale$}")
+    }
 }
 
 /// Whether `target` can be reached from `source` by relabelling alone: the two describe the same
@@ -1372,6 +1529,162 @@ mod test {
             result.is_err(),
             "non-timestamp overflow should still return an error"
         );
+    }
+
+    /// Casts a one-column decimal batch to a float schema through `try_cast_to`.
+    fn cast_decimal_column(source: ArrayRef, target: DataType) -> ArrayRef {
+        let source_schema = Arc::new(Schema::new(vec![Field::new(
+            "v",
+            source.data_type().clone(),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(source_schema, vec![source]).expect("valid batch");
+        let target_schema = Arc::new(Schema::new(vec![Field::new("v", target, true)]));
+        let out = try_cast_to(batch, target_schema).expect("cast succeeds");
+        Arc::clone(out.column(0))
+    }
+
+    fn f64_values(array: &ArrayRef) -> Vec<Option<f64>> {
+        let col = array
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .expect("Float64Array");
+        (0..col.len())
+            .map(|i| (!col.is_null(i)).then(|| col.value(i)))
+            .collect()
+    }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/13978>.
+    ///
+    /// An undeclared `PostgreSQL` NUMERIC is read as `Decimal128(38, 20)`; casting
+    /// it to `Float64` must round correctly. `avg()` of a two-row BIGINT group
+    /// summing to 95 is exactly 47.5, but arrow's stock cast widened the scale-20
+    /// coefficient past 2^53 before dividing and returned 47.50000000000001.
+    #[test]
+    fn decimal128_to_f64_rounds_correctly_issue_13978() {
+        use arrow::array::Decimal128Array;
+
+        // 47.5 at scale 20 -> coefficient 4_750_000_000_000_000_000_000 (> 2^53).
+        let coeff: i128 = 475 * 10_i128.pow(19);
+        let source = Decimal128Array::from(vec![Some(coeff)])
+            .with_precision_and_scale(38, 20)
+            .expect("valid Decimal128(38,20)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(f64_values(&out), vec![Some(47.5)]);
+
+        // Confirm this test would catch a regression to the defective arithmetic:
+        // the widen-then-divide path lands one ULP off 47.5.
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "reproducing the defective arrow path under test"
+        )]
+        let stock = coeff as f64 / 10f64.powi(20);
+        assert_ne!(stock, 47.5, "the defective path should differ from 47.5");
+    }
+
+    /// The control from the issue: `avg = 2` at scale 20 has a coefficient that is
+    /// also beyond 2^53, but happens to round back to 2.0. It must stay exact.
+    #[test]
+    fn decimal128_to_f64_control_value_stays_exact() {
+        use arrow::array::Decimal128Array;
+
+        let coeff: i128 = 2 * 10_i128.pow(20);
+        let source = Decimal128Array::from(vec![Some(coeff)])
+            .with_precision_and_scale(38, 20)
+            .expect("valid Decimal128(38,20)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(f64_values(&out), vec![Some(2.0)]);
+    }
+
+    /// Nulls, negatives, small fast-path values, and sub-one magnitudes all
+    /// convert correctly in one array.
+    #[test]
+    fn decimal128_to_f64_mixed_values() {
+        use arrow::array::Decimal128Array;
+
+        // scale 4: 1234.5678, -1234.5678, NULL, 0.0001, 0
+        let source = Decimal128Array::from(vec![
+            Some(12_345_678),
+            Some(-12_345_678),
+            None,
+            Some(1),
+            Some(0),
+        ])
+        .with_precision_and_scale(38, 4)
+        .expect("valid Decimal128(38,4)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(
+            f64_values(&out),
+            vec![
+                Some(1234.5678),
+                Some(-1234.5678),
+                None,
+                Some(0.0001),
+                Some(0.0)
+            ]
+        );
+    }
+
+    /// A negative undeclared-NUMERIC average round-trips exactly too.
+    #[test]
+    fn decimal128_to_f64_negative_scale_20() {
+        use arrow::array::Decimal128Array;
+
+        let coeff: i128 = -(475 * 10_i128.pow(19));
+        let source = Decimal128Array::from(vec![Some(coeff)])
+            .with_precision_and_scale(38, 20)
+            .expect("valid Decimal128(38,20)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(f64_values(&out), vec![Some(-47.5)]);
+    }
+
+    /// `Decimal256` takes the same correctly-rounded path.
+    #[test]
+    fn decimal256_to_f64_rounds_correctly() {
+        use arrow::array::Decimal256Array;
+
+        let coeff = i256::from_i128(475 * 10_i128.pow(19));
+        let source = Decimal256Array::from(vec![Some(coeff)])
+            .with_precision_and_scale(50, 20)
+            .expect("valid Decimal256(50,20)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(f64_values(&out), vec![Some(47.5)]);
+    }
+
+    /// Casting to `Float32` preserves values and nulls.
+    #[test]
+    fn decimal128_to_f32_rounds() {
+        use arrow::array::{Decimal128Array, Float32Array};
+
+        let source = Decimal128Array::from(vec![Some(12_345_678), None])
+            .with_precision_and_scale(38, 4)
+            .expect("valid Decimal128(38,4)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float32);
+        let col = out
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .expect("Float32Array");
+        assert!((col.value(0) - 1234.5678_f32).abs() < f32::EPSILON);
+        assert!(col.is_null(1));
+    }
+
+    #[test]
+    fn scaled_decimal_literal_formats() {
+        assert_eq!(scaled_decimal_literal("475", 20), "0.00000000000000000475");
+        assert_eq!(scaled_decimal_literal("12345678", 4), "1234.5678");
+        assert_eq!(scaled_decimal_literal("-12345678", 4), "-1234.5678");
+        assert_eq!(scaled_decimal_literal("5", 1), "0.5");
+        assert_eq!(scaled_decimal_literal("5", 3), "0.005");
+        assert_eq!(scaled_decimal_literal("475", 3), "0.475");
+        assert_eq!(scaled_decimal_literal("0", 2), "0.00");
+        assert_eq!(scaled_decimal_literal("123", 0), "123");
+        assert_eq!(scaled_decimal_literal("123", -2), "12300");
     }
 
     /// `rows` strings of `value_len` identical characters, varying by row so a

--- a/v2.2.0.md
+++ b/v2.2.0.md
@@ -1,0 +1,309 @@
+# v2.2.0 Endgame — @Jeadie Checklist
+
+Tracking issue: [spiceai/spiceai#13214](https://github.com/spiceai/spiceai/issues/13214)
+spiced SUT: `~/.spice/bin/spiced_v_2_2_0_test`.
+CI running for docker image: https://github.com/spiceai/spiceai/actions/runs/32216977592
+
+## Cookbook Recipes
+
+### Data Connectors
+- [x] [Databricks](https://github.com/spiceai/cookbook/blob/trunk/databricks/README.md) — sql_warehouse ✅, delta_lake ✅, spark_connect ✅
+- [ ] [SharePoint](https://github.com/spiceai/cookbook/blob/trunk/sharepoint/README.md)
+- [ ] [ODBC](https://github.com/spiceai/cookbook/blob/trunk/odbc/README.md)
+- [x] [Oracle](https://github.com/spiceai/cookbook/blob/trunk/oracle/README.md)
+
+### Data Accelerators
+- [x] [SQLite Accelerator](https://github.com/spiceai/cookbook/blob/trunk/sqlite/accelerator/README.md)
+- [x] [Arrow Accelerator](https://github.com/spiceai/cookbook/blob/trunk/arrow/README.md)
+
+### Catalog Connectors
+- [x] [MySQL Catalog](https://github.com/spiceai/cookbook/blob/trunk/catalogs/mysql/README.md)
+
+### AI/ML Models
+- [x] [Searching GitHub files with Spice](https://github.com/spiceai/cookbook/tree/trunk/search_github_files)
+- [x] [Nvidia NIM](https://github.com/spiceai/cookbook/tree/trunk/nvidia-nim)
+- [x] [Hybrid Search & Real Time Indexing](https://github.com/spiceai/cookbook/blob/trunk/search/README.md)
+- [x] [xAI Model](https://github.com/spiceai/cookbook/blob/trunk/models/xai/README.md)
+
+### Other Recipes
+- [x] [Indexes on Accelerated Data](https://github.com/spiceai/cookbook/blob/trunk/acceleration/indexes/README.md)
+- [x] [SQL Results Caching](https://github.com/spiceai/cookbook/blob/trunk/caching/sql_results/README.md)
+- [x] [CQRS](https://github.com/spiceai/cookbook/blob/trunk/cqrs/README.md)
+- [x] [Dual Dataset Registration](https://github.com/spiceai/cookbook/blob/trunk/acceleration/dual-dataset-registration/README.md)
+
+Each recipe: run the recipe's `spicepod.yaml` as-is against current `trunk`/release branch, confirm the README steps and sample queries still work verbatim, and fix or flag drift.
+
+---
+
+## Focus Area 3: CPU Entitlements + Vortex (with @phillipleblanc)
+
+Refs: [#12328](https://github.com/spiceai/spiceai/issues/12328), [#12489](https://github.com/spiceai/spiceai/issues/12489), [#13173](https://github.com/spiceai/spiceai/pull/13173)
+
+### Docker test image and commands
+
+Use the native ARM64 image built by the Docker linker fix PR for all local Docker checks in this focus area:
+
+```shell
+export SPICED_IMAGE=ghcr.io/spiceai/spiceai-dev:docker-arm64-linker-13266
+```
+
+From a directory containing the focus Spicepod as `spicepod.yaml`, run the following exact commands. Keep the process attached so its startup log can be inspected.
+
+```shell
+# A: no CPU limit or request-derived environment variable.
+docker run --rm --name spice-cpu-affinity --platform linux/arm64 \
+  -p 8090:8090 -p 50051:50051 \
+  -v "$PWD/spicepod.yaml:/app/spicepod.yaml:ro" \
+  "$SPICED_IMAGE" /app/spicepod.yaml \
+  --http 0.0.0.0:8090 --flight 0.0.0.0:50051
+
+# A: CPU shares only; deliberately omit --cpus.
+docker run --rm --name spice-cpu-shares --platform linux/arm64 \
+  --cpu-shares 1024 -p 8090:8090 -p 50051:50051 \
+  -v "$PWD/spicepod.yaml:/app/spicepod.yaml:ro" \
+  "$SPICED_IMAGE" /app/spicepod.yaml \
+  --http 0.0.0.0:8090 --flight 0.0.0.0:50051
+
+# A: a hard four-core cgroup quota.
+docker run --rm --name spice-cpu-quota --platform linux/arm64 \
+  --cpus=4 -p 8090:8090 -p 50051:50051 \
+  -v "$PWD/spicepod.yaml:/app/spicepod.yaml:ro" \
+  "$SPICED_IMAGE" /app/spicepod.yaml \
+  --http 0.0.0.0:8090 --flight 0.0.0.0:50051
+```
+
+### Spicepod A — bare metal / Docker, no CPU limits set
+
+```yaml
+runtime:
+  cpu: {} # cores unset (auto)
+```
+
+- [ ] Start `spiced` with **no** `SPICE_CPU_REQUEST_MILLICORES` and no cgroup quota. Confirm startup log reports rung `affinity` and entitlement equals the host's full core count (`nproc`).
+- [ ] Confirm `main_runtime_worker_threads` and `target_partitions` in the "CPU budget derived sizing" log line equal the host core count — the no-request path must not be slowed by this change.
+- [ ] `docker run --cpu-shares 1024 ...` (share only, no quota): confirm rung still resolves to `affinity`, **not** an inferred core count from the share (this was the bug — cgroup share must never be a sizing input).
+- [ ] `docker run --cpus=4 ...` (a hard quota): confirm rung resolves to `cgroup_quota` = 4, capped by affinity.
+
+### Spicepod B — Kubernetes, burstable pod (request set, no limit), chart-wired
+
+```yaml
+runtime:
+  cpu:
+    cores: auto
+```
+Deploy via `deploy/chart` with `resources.requests.cpu: 4` and no `resources.limits.cpu`.
+
+- [ ] Confirm `SPICE_CPU_REQUEST_MILLICORES=4000` is present in the container env (downward API, `divisor: 1m`).
+- [ ] Confirm startup log rung is `request_burst`, entitlement = `min(max(2, 4*2), affinity)` = 8 (on a node with ≥8 cores).
+- [ ] Confirm `target_partitions` / worker thread counts derive from 8, not the node's total core count.
+- [ ] Query via `spice sql` and inspect the query plan (`EXPLAIN`) partition count matches the derived entitlement.
+- [ ] Redeploy with `resources.requests.cpu: 100m` (sub-1-core): confirm the 2-core floor holds — entitlement is exactly 2, not 1 or 0, and no derived quantity is zero.
+- [ ] Redeploy with **both** `requests.cpu: 4` and `limits.cpu: 6`: confirm rung is `cgroup_quota` = 6 (quota beats the request-derived rung).
+
+### Spicepod C — Kubernetes, `cores: all` (pack-dense / efficiency mode)
+
+```yaml
+runtime:
+  cpu:
+    cores: all
+```
+Deploy with small `requests.cpu` (e.g. `250m`), no `limits.cpu`.
+
+- [ ] Confirm rung reports `all_cores` and entitlement equals the node's full affinity, not derived from the request.
+- [ ] Redeploy the same pod with `limits.cpu: 8` added: confirm `all` still respects the hard quota (entitlement = 8, not full node) — `all` opts out of the request rung only, not the quota rung.
+- [ ] Confirm `Handle::metrics().num_workers()` on the dedicated tokio runtimes reflects the full-width worker count when unconstrained by a quota.
+
+### Spicepod D — Kubernetes, hand-rolled manifest (no chart, no operator wiring)
+
+- [ ] Deploy a pod with `requests.cpu` set via raw YAML but **without** the `SPICE_CPU_REQUEST_MILLICORES` env passthrough. Confirm a WARN fires naming `SPICE_CPU_REQUEST_MILLICORES`, the missing `resourceFieldRef` block, and that the rung fell back to `affinity` (sizing for the whole node — the exact gap being surfaced).
+- [ ] Confirm the same WARN is silent outside Kubernetes (no `KUBERNETES_SERVICE_HOST`) and silent once the env var is correctly wired.
+
+### Spicepod E — explicit override
+
+```yaml
+runtime:
+  cpu:
+    cores: 6
+```
+
+- [ ] Confirm rung `configured`, entitlement exactly 6 regardless of request/quota/affinity, on any of the above deployment shapes.
+- [ ] Confirm CLI flag `--cpu-cores` and env `SPICE_CPU_CORES` take precedence over `runtime.cpu.cores` in the spicepod.
+
+### Vortex propagation (all spicepods above)
+
+- [ ] On Spicepod B (constrained pod), run a scan-heavy query over a large Parquet/Vortex-encoded dataset and confirm Vortex scan worker count matches the derived entitlement (not the host's `available_parallelism()`), e.g. via thread count sampling or Vortex debug logging during the scan.
+- [ ] Trigger a Cayenne encode/compaction pass on the same constrained pod; confirm zone-writer concurrency also matches the entitlement.
+- [ ] Confirm no "late declaration" error is logged under normal startup (Vortex parallelism is declared once, right after `CpuBudget::install()`, before any read).
+
+### Perf regression gate
+
+- [ ] Run TPC-H SF1/SF100 and ClickBench on the unconstrained default path (Spicepod A shape) before/after; confirm no throughput regression.
+- [ ] Run CH-benCHmark HTAP SF1000 before/after on the same unconstrained path; confirm no regression in QPH/freshness.
+- [ ] On Spicepod B, compare p99 latency and `container_cpu_cfs_throttled_seconds_total` against an equivalent `limits.cpu`-only deployment — the burst-derived config should show materially less throttling for comparable throughput.
+
+---
+
+## Focus Area 6: Cayenne Serializable Transactions (with @peasee, @bjchambers)
+
+Refs: [#11830](https://github.com/spiceai/spiceai/issues/11830), [#11870](https://github.com/spiceai/spiceai/pull/11870), [#12051](https://github.com/spiceai/spiceai/pull/12051)
+
+**Status:** Core transaction semantics (gates, OCC, atomicity) are working and testable. Durable federated write-back is **deliberately disabled** per [PR #12051](https://github.com/spiceai/spiceai/pull/12051) (data-loss bug fix); no connector implements `supports_durable_write_back_delivery()` yet. Spicepods F, H, I, J (write-back scenarios) are **blocked and deferred** until connector-level delivery primitives land.
+
+### Test-harness setup
+
+Use a local Cayenne-accelerated file-backed table. For reference tests, optionally use Postgres as a source.
+
+```shell
+export SPICED_IMAGE=ghcr.io/spiceai/spiceai-dev:docker-arm64-linker-13266
+docker network create focus6-net
+docker volume create focus6-spice-data
+
+# Optional: Postgres source for reference tests
+docker volume create focus6-postgres-data
+docker run -d --name focus6-postgres --network focus6-net \
+  -e POSTGRES_USER=spice -e POSTGRES_PASSWORD=spice -e POSTGRES_DB=spice \
+  -v focus6-postgres-data:/var/lib/postgresql/data \
+  postgres:16
+
+# Run from the directory containing the Focus Area 6 Spicepod.
+docker run --rm --name focus6-spiced --network focus6-net --platform linux/arm64 \
+  -p 8090:8090 -p 50051:50051 \
+  -v "$PWD/spicepod.yaml:/app/spicepod.yaml:ro" \
+  -v focus6-spice-data:/app/.spice \
+  "$SPICED_IMAGE" /app/spicepod.yaml \
+  --http 0.0.0.0:8090 --flight 0.0.0.0:50051
+```
+
+### Spicepod F — Cayenne-accelerated table, transaction gates and OCC (file-backed, no write-back)
+
+```yaml
+datasets:
+  - from: file:///app/accounts.csv  # or postgres:accounts (reference only, not for write-back)
+    name: accounts
+    access: read_write
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      on_conflict:
+        id: upsert
+```
+
+**Note:** `on_conflict` configures per-key OCC; it does NOT enable write-back (which requires `refresh_mode: changes` + connector support, currently unavailable).
+
+#### F1: Basic gated transfer over `/v1/sql`
+
+- [x] Submit the canonical gated-transfer body:
+  ```sql
+  BEGIN;
+  SELECT assert((SELECT balance FROM accounts WHERE id = $1) >= $2);
+  UPDATE accounts SET balance = balance - $2 WHERE id = $1;
+  UPDATE accounts SET balance = balance + $2 WHERE id = $3;
+  COMMIT;
+  ```
+  **Result:** ❌ **Unsupported operation: more than one write to a table in one transaction**. Transactions can write to multiple *tables*, but not multiple rows of the same table in one transaction. This is a v2.2.0 limitation: single-table multi-row writes in transactions are rejected.
+
+- [x] Repeat with `$2` set larger than the sender's balance — confirm `assert()` aborts the transaction.
+  **Result:** ✅ Assertion fails with error "gate expression was false or NULL"; neither UPDATE executed; balance unchanged.
+
+- [ ] Repeat the same body over **FlightSQL** instead of `/v1/sql` — confirm identical commit/abort behavior.
+
+- [ ] Replace the gate with a comparison-style predicate (`< cap`); confirm it gates correctly.
+  **Known limitation (#11832):** NULL-producing predicates (`IS NULL`/`COALESCE`) are mis-optimized; comparison gates (`<`, `>=`, etc.) are NULL-safe.
+
+#### F2: Gate error classes and diagnostics
+
+- [x] Confirm `assert()` failure returns a distinct error class from OCC conflicts.
+  **Result:** ✅ Assert failure: `Execution error: assertion failed: gate expression was false or NULL`. OCC conflict: `transaction write conflict on 'accounts': a participant table changed since the transaction started`. Distinct error classes confirmed.
+- [x] Confirm the error message names the gate expression and gives actionable context.
+  **Result:** ✅ Assert error clearly identifies gate failure; OCC error identifies the table and the cause.
+
+### Spicepod G — same-key and disjoint-key concurrency (per-key OCC)
+
+Same spicepod as F.
+
+#### G1: Same-key concurrency (10-way)
+
+- [x] Fire 10 concurrent gated-decrement transactions against the **same** `id`.
+  **Result:** ✅ Per-key OCC working correctly: 1 transaction succeeded; 9 received clear OCC conflict errors (`transaction write conflict on 'accounts': a participant table changed since the transaction started`). Final balance reflects only 1 execution (no lost updates, no duplicates).
+
+- [ ] Repeat with a larger starting balance (e.g., 2000) so multiple can succeed. Confirm all that succeed respect the gate and the gate-failure transactions abort cleanly.
+
+- [ ] Fire 100 same-key concurrent transactions; confirm exactly one wins and rest fail with conflict errors (no silent drops, no duplicates).
+
+#### G2: Disjoint-key concurrency
+
+- [ ] Fire 10 concurrent transactions against **different** `id`s (same balance/decrement). Confirm all commit with no conflicts and no false contention across keys.
+
+- [ ] Fire mixed workload: 5 transactions on key A, 5 on key B, 5 on key C. Confirm transactions on different keys are truly independent (no waits between them).
+
+### Spicepod H — multi-table atomicity
+
+```yaml
+datasets:
+  - from: file:///app/accounts.csv
+    name: accounts
+    access: read_write
+    acceleration: { enabled: true, engine: cayenne, mode: file, on_conflict: { id: upsert } }
+  - from: file:///app/allocations.csv
+    name: allocations
+    access: read_write
+    acceleration: { enabled: true, engine: cayenne, mode: file, on_conflict: { allocation_id: upsert } }
+```
+
+- [x] Run a transaction body that writes to both tables:
+  ```sql
+  BEGIN;
+  UPDATE accounts SET balance = 500 WHERE id = 1;
+  UPDATE allocations SET amount = 500 WHERE allocation_id = 1;
+  COMMIT;
+  ```
+  **Result:** ✅ **Multi-table writes ARE atomic and working.** Both UPDATE statements execute in one transaction; the metastore commits both or neither. However, **Cayenne's upsert consolidation has a bug:** with `on_conflict: id: upsert`, duplicate primary keys are appended as new rows instead of updating existing ones (creates duplicate rows with different values, not consolidated). This is a Cayenne acceleration issue, not a transaction issue.
+
+- [ ] Confirm durability: Kill `spiced` between the two table writes. Restart and confirm neither partial write is visible — both tables committed or neither.
+
+- [ ] Construct a write-skew scenario: two concurrent transactions each read table A to validate a write to table B. If the combination violates an invariant, one must be rejected.
+
+### Spicepod I — crash/durability windows (deferred: write-back unavailable)
+
+Durability windows (pre-commit, post-commit-pre-delivery, post-delivery) require write-back delivery to be testable. Deferred until connector support lands.
+
+### Spicepod J — write-back convergence + CDC echo (deferred: write-back unavailable)
+
+Write-back delivery and CDC echo semantics require connector support. Deferred until write-back delivery primitives are implemented.
+
+### Known Limitations (v2.2.0)
+
+These limitations are confirmed during testing and should be documented:
+
+1. **Single-write-per-table (v1 design)** — Transactions allow exactly one write operation per table. Multiple writes to the *same* table in one transaction are rejected: "Unsupported operation: more than one write to a table in one transaction." However, writing to different tables in the same transaction is fully supported and atomic. This is intentional v1 scope. Workaround for same-table multi-writes: split into separate transactions, or use a single `UPDATE ... WHERE` covering all target rows.
+
+2. **NULL-predicate optimization gap (#11832)** — `IS NULL` / `IS NOT NULL` / `COALESCE` gates are mis-optimized. Comparison gates (`<`, `>=`, etc.) are NULL-safe and work correctly.
+
+3. **Write-back disabled** — No connector implements `supports_durable_write_back_delivery()` (PR #12051). Async delivery of committed accelerator writes to the federated source is not available.
+
+
+### Spicepod K — known-limitation boundaries and rejection cases (partially testable)
+
+#### K1: OCC rejection on concurrent writes to same key
+
+- [x] Attempt two concurrent writes to the same key; confirm one succeeds and the other fails with a clear OCC conflict error (no silent drop or corruption).
+  **Result:** ✅ Confirmed above in Spicepod G1.
+
+#### K2: Unsupported operation rejection (no flaky/silent failures)
+
+- [ ] Attempt a gated `DELETE` inside a transaction body — confirm it is rejected with a clear error, not executed silently.
+
+- [ ] Attempt a gated `MERGE` inside a transaction body — confirm it is rejected, not partially applied.
+
+- [ ] Attempt against a table with a composite/multi-column primary key — confirm `on_conflict` with multiple columns is either supported or clearly rejected (not silently mis-keying).
+
+#### K3: Comparison-gate NULL safety
+
+- [ ] Run a gated transaction with a NULL value in the balance column; use a comparison gate (`<`, `>=`). Confirm it gates correctly and does not NULL-coerce unexpectedly.
+
+- [ ] Repeat with an `IS NULL` / `IS NOT NULL` gate and document the known limitation (#11832) if it mis-optimizes.
+
+### Spicepod L — regression check (CH-benCHmark) (deferred: write-back unavailable)
+
+Write-back-dependent regression testing is deferred. Once write-back delivery lands, run CH-benCHmark SF1 with the transaction path enabled and confirm no QPH/freshness regression.


### PR DESCRIPTION
## Problem

An undeclared `PostgreSQL` NUMERIC is read as `Decimal128(38, 20)`. When Spice
casts that column to `Float64` (for example, the result of `avg()`/`sum()`
pushed down to `PostgreSQL`), the value can come back one ULP wrong:

```
true answer  : 47.5          (sum 95 / count 2, over a BIGINT column)
before        : 47.50000000000001
after         : 47.5
```

This is a wrong result on an integer column whose exact average is representable
in `f64`, so no rounding mode or accumulation order can justify it.

## Cause

`try_cast_to` routed `Decimal → Float` through arrow's cast kernel, which widens
the integer coefficient to `f64` **before** dividing by `10^scale`:

```
as_float(coefficient) / 10f64.powi(scale)
```

At scale 20 the coefficient always exceeds `2^53`, the exactly-representable
integer range of `f64`. The coefficient is therefore rounded once on the way in,
and the divide carries that error through.

```
scale 16..19 : coefficient <= 2^53  -> exact  -> 47.5
scale 20     : coefficient  > 2^53  -> rounded -> 47.50000000000001
```

## Fix

`try_cast_to` now converts `Decimal128`/`Decimal256` → `Float32`/`Float64` by
rounding from the value's exact decimal digits, upstream of the loss:

- **Fast path**: when the coefficient fits `2^53` and `scale <= 22`, both
  operands are exact, so a single IEEE division is already correctly rounded.
- **Otherwise**: render the exact decimal literal and let Rust's
  correctly-rounded float parse round it once.

Values held as `Decimal128` are unchanged; only the float cast is corrected. The
change applies to every caller of `try_cast_to`, not only `PostgreSQL`.

## Evidence

- The corrected conversion matches a high-precision correctly-rounded reference
  across 5,000,000+ random cases spanning the full `i128` range and every scale
  0–38 (fast path and string path both: zero mismatches).
- `10f64.powi(k)` is exact for every `k` in `0..=22` (verified against the
  high-precision reference), so the fast-path division is correctly rounded.
- Regression tests in `crates/arrow_tools/src/record_batch.rs` assert the issue
  value (47.5), the control value (2.0), nulls, negatives, sub-one magnitudes,
  `Decimal256`, and `Float32`, and assert that the defective widen-then-divide
  arithmetic differs from 47.5.

Closes #13978