### PR TITLE
fix(arrow_tools): Round Decimal→Float casts from exact digits

### DIFF
--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -245,7 +245,7 @@ fn is_overflow_error(e: &ArrowError) -> bool {
 /// exact digits pay for them.
 ///
 /// This intercepts `try_cast_to` only. A correctly-rounded fix in arrow's cast
-/// kernel would also cover casts DataFusion performs directly (e.g. an explicit
+/// kernel would also cover casts `DataFusion` performs directly (e.g. an explicit
 /// `CAST(x AS DOUBLE)`); that is tracked as follow-up work.
 fn cast_decimal_to_float(
     column: &ArrayRef,

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -251,7 +251,7 @@ fn is_overflow_error(e: &ArrowError) -> bool {
 ///
 /// This intercepts `try_cast_to` only. A correctly-rounded fix in arrow's cast
 /// kernel would also cover casts `DataFusion` performs directly (e.g. an explicit
-/// `CAST(x AS DOUBLE)`); that is tracked as follow-up work.
+/// `CAST(x AS DOUBLE)`); that is tracked in #13993.
 fn cast_decimal_to_float(
     column: &ArrayRef,
     target_type: &DataType,

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -16,16 +16,17 @@ limitations under the License.
 
 use arrow::{
     array::{
-        Array, ArrayData, ArrayRef, BinaryViewArray, DictionaryArray, GenericByteViewArray,
-        ListArray, MutableArrayData, PrimitiveArray, RecordBatch, RecordBatchOptions,
-        StringViewArray, StructArray, UInt64Array, downcast_dictionary_array, make_array,
-        new_null_array,
+        Array, ArrayData, ArrayRef, AsArray, BinaryViewArray, DictionaryArray,
+        GenericByteViewArray, ListArray, MutableArrayData, PrimitiveArray, RecordBatch,
+        RecordBatchOptions, StringViewArray, StructArray, UInt64Array, downcast_dictionary_array,
+        make_array, new_null_array,
     },
     buffer::{Buffer, NullBuffer, OffsetBuffer},
     compute::take,
     datatypes::{
         ArrowDictionaryKeyType, ArrowNativeType, ArrowNativeTypeOp, BinaryViewType, ByteViewType,
-        DataType, Field, FieldRef, SchemaRef, StringViewType, TimeUnit,
+        DataType, Decimal128Type, Field, FieldRef, Float64Type, SchemaRef, StringViewType,
+        TimeUnit,
     },
     error::ArrowError,
 };
@@ -236,6 +237,16 @@ fn is_overflow_error(e: &ArrowError) -> bool {
 /// Rust's `str::parse`, which arrow's parser matches). This covers every decimal
 /// width — `Decimal32`/`Decimal64` are lossy on the direct path too — and every
 /// float target, so it applies to every caller of `try_cast_to`.
+///
+/// The `Utf8` round-trip costs ~20-40x a plain divide, so the common
+/// `Decimal128 -> Float64` case takes a fast path when *every* coefficient is
+/// already exactly representable: a single divide is then correctly rounded on
+/// its own (see [`decimal128_to_f64_exact`]). Only values that actually need the
+/// exact digits pay for them.
+///
+/// This intercepts `try_cast_to` only. A correctly-rounded fix in arrow's cast
+/// kernel would also cover casts DataFusion performs directly (e.g. an explicit
+/// `CAST(x AS DOUBLE)`); that is tracked as follow-up work.
 fn cast_decimal_to_float(
     column: &ArrayRef,
     target_type: &DataType,
@@ -252,11 +263,45 @@ fn cast_decimal_to_float(
         return Ok(None);
     }
 
+    if let (DataType::Decimal128(_, scale), DataType::Float64) = (column.data_type(), target_type)
+        && let Some(exact) = decimal128_to_f64_exact(column, *scale)
+    {
+        return Ok(Some(exact));
+    }
+
     let strings = cast_with_options(column.as_ref(), &DataType::Utf8, options)
         .context(UnableToConvertRecordBatchSnafu)?;
     cast_with_options(strings.as_ref(), target_type, options)
         .context(UnableToConvertRecordBatchSnafu)
         .map(Some)
+}
+
+/// Fast, exact `Decimal128 -> Float64` for the common case, or `None` to fall back
+/// to the digit-exact `Utf8` path.
+///
+/// When `scale <= 22` and every coefficient is within `±2^53`, both the
+/// coefficient and `10^scale` are exactly representable, so a single IEEE division
+/// is already correctly rounded — no `Utf8` round-trip needed. The `min`/`max`
+/// gate makes this all-or-nothing per batch: if any value is out of range the
+/// whole batch takes the correct fallback, so no value is ever silently rounded
+/// on the way in.
+fn decimal128_to_f64_exact(column: &ArrayRef, scale: i8) -> Option<ArrayRef> {
+    if !(0..=22).contains(&scale) {
+        return None;
+    }
+    let values = column.as_primitive::<Decimal128Type>();
+    let within = |bound: Option<i128>| bound.is_none_or(|v| v.unsigned_abs() < (1u128 << 53));
+    if !within(arrow::compute::min(values)) || !within(arrow::compute::max(values)) {
+        return None;
+    }
+
+    let pow = 10f64.powi(i32::from(scale));
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "gated above: every coefficient is < 2^53, so i128 -> f64 is exact"
+    )]
+    let floats = values.unary::<_, Float64Type>(|v| v as f64 / pow);
+    Some(Arc::new(floats))
 }
 
 /// Whether `target` can be reached from `source` by relabelling alone: the two describe the same

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -16,17 +16,16 @@ limitations under the License.
 
 use arrow::{
     array::{
-        Array, ArrayData, ArrayRef, AsArray, BinaryViewArray, DictionaryArray, Float32Builder,
-        Float64Builder, GenericByteViewArray, ListArray, MutableArrayData, PrimitiveArray,
-        RecordBatch, RecordBatchOptions, StringViewArray, StructArray, UInt64Array,
-        downcast_dictionary_array, make_array, new_null_array,
+        Array, ArrayData, ArrayRef, BinaryViewArray, DictionaryArray, GenericByteViewArray,
+        ListArray, MutableArrayData, PrimitiveArray, RecordBatch, RecordBatchOptions,
+        StringViewArray, StructArray, UInt64Array, downcast_dictionary_array, make_array,
+        new_null_array,
     },
     buffer::{Buffer, NullBuffer, OffsetBuffer},
     compute::take,
     datatypes::{
         ArrowDictionaryKeyType, ArrowNativeType, ArrowNativeTypeOp, BinaryViewType, ByteViewType,
-        DataType, Decimal128Type, Decimal256Type, Field, FieldRef, SchemaRef, StringViewType,
-        TimeUnit, i256,
+        DataType, Field, FieldRef, SchemaRef, StringViewType, TimeUnit,
     },
     error::ArrowError,
 };
@@ -49,14 +48,6 @@ pub enum Error {
 
     #[snafu(display("Field is not nullable: {field}"))]
     FieldNotNullable { field: String },
-
-    #[snafu(display(
-        "Failed to convert decimal value '{value}' to a floating-point number: {source}"
-    ))]
-    DecimalToFloat {
-        value: String,
-        source: std::num::ParseFloatError,
-    },
 }
 
 impl From<Error> for DataFusionError {
@@ -67,9 +58,6 @@ impl From<Error> for DataFusionError {
             } => DataFusionError::ArrowError(Box::new(arrow_error), None),
             Error::FieldNotNullable { .. } => {
                 DataFusionError::ArrowError(Box::new(ArrowError::SchemaError(e.to_string())), None)
-            }
-            Error::DecimalToFloat { .. } => {
-                DataFusionError::ArrowError(Box::new(ArrowError::CastError(e.to_string())), None)
             }
         }
     }
@@ -195,7 +183,7 @@ fn cast_column(
         return relabel_nullability(column, target_field);
     }
 
-    if let Some(casted) = cast_decimal_to_float(column, target_field.data_type())? {
+    if let Some(casted) = cast_decimal_to_float(column, target_field.data_type(), strict_options)? {
         return Ok(casted);
     }
 
@@ -240,134 +228,35 @@ fn is_overflow_error(e: &ArrowError) -> bool {
 /// the result up to a couple of ULP off the true value. An `avg()`/`sum()`
 /// pushed to `PostgreSQL` returns an *undeclared* NUMERIC read at scale 20, whose
 /// coefficient always exceeds `2^53`, so an exactly representable answer like
-/// `47.5` came back as `47.500_000_000_000_01` (issue #13978). Rounding from the
-/// value's exact decimal digits instead removes the loss at every scale.
-fn cast_decimal_to_float(column: &ArrayRef, target_type: &DataType) -> Result<Option<ArrayRef>> {
-    match (column.data_type(), target_type) {
-        (DataType::Decimal128(_, scale), DataType::Float64) => {
-            let (scale, values) = (*scale, column.as_primitive::<Decimal128Type>());
-            f64_array_from(values.len(), |i| {
-                if values.is_null(i) {
-                    Ok(None)
-                } else {
-                    decimal128_to_f64(values.value(i), scale).map(Some)
-                }
-            })
-            .map(Some)
-        }
-        (DataType::Decimal128(_, scale), DataType::Float32) => {
-            let (scale, values) = (*scale, column.as_primitive::<Decimal128Type>());
-            f32_array_from(values.len(), |i| {
-                if values.is_null(i) {
-                    Ok(None)
-                } else {
-                    parse_scaled::<f32>(&values.value(i).to_string(), scale).map(Some)
-                }
-            })
-            .map(Some)
-        }
-        (DataType::Decimal256(_, scale), DataType::Float64) => {
-            let (scale, values) = (*scale, column.as_primitive::<Decimal256Type>());
-            f64_array_from(values.len(), |i| {
-                if values.is_null(i) {
-                    Ok(None)
-                } else {
-                    decimal256_to_f64(values.value(i), scale).map(Some)
-                }
-            })
-            .map(Some)
-        }
-        (DataType::Decimal256(_, scale), DataType::Float32) => {
-            let (scale, values) = (*scale, column.as_primitive::<Decimal256Type>());
-            f32_array_from(values.len(), |i| {
-                if values.is_null(i) {
-                    Ok(None)
-                } else {
-                    parse_scaled::<f32>(&values.value(i).to_string(), scale).map(Some)
-                }
-            })
-            .map(Some)
-        }
-        _ => Ok(None),
-    }
-}
-
-fn f64_array_from(len: usize, get: impl Fn(usize) -> Result<Option<f64>>) -> Result<ArrayRef> {
-    let mut builder = Float64Builder::with_capacity(len);
-    for index in 0..len {
-        match get(index)? {
-            Some(value) => builder.append_value(value),
-            None => builder.append_null(),
-        }
-    }
-    Ok(Arc::new(builder.finish()))
-}
-
-fn f32_array_from(len: usize, get: impl Fn(usize) -> Result<Option<f32>>) -> Result<ArrayRef> {
-    let mut builder = Float32Builder::with_capacity(len);
-    for index in 0..len {
-        match get(index)? {
-            Some(value) => builder.append_value(value),
-            None => builder.append_null(),
-        }
-    }
-    Ok(Arc::new(builder.finish()))
-}
-
-fn decimal128_to_f64(value: i128, scale: i8) -> Result<f64> {
-    // Fast path: the coefficient is exactly representable and `10^scale` is too
-    // (`scale <= 22`), so a single IEEE division is already correctly rounded and
-    // no string round-trip is needed.
-    if (0..=22).contains(&scale) && value.unsigned_abs() < (1u128 << 53) {
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "guarded: |value| < 2^53 and scale <= 22, so both operands are exact and the single division is correctly rounded"
-        )]
-        let exact = value as f64 / 10f64.powi(i32::from(scale));
-        return Ok(exact);
-    }
-    parse_scaled(&value.to_string(), scale)
-}
-
-fn decimal256_to_f64(value: i256, scale: i8) -> Result<f64> {
-    parse_scaled(&value.to_string(), scale)
-}
-
-/// Parses the exact decimal `signed_digits` scaled by `10^-scale` into a float,
-/// relying on Rust's correctly-rounded float parsing rather than on integer
-/// widening.
-fn parse_scaled<F>(signed_digits: &str, scale: i8) -> Result<F>
-where
-    F: std::str::FromStr<Err = std::num::ParseFloatError>,
-{
-    let literal = scaled_decimal_literal(signed_digits, scale);
-    literal
-        .parse::<F>()
-        .context(DecimalToFloatSnafu { value: literal })
-}
-
-/// Renders the signed integer coefficient `signed_digits` at `scale` decimal
-/// places as a plain decimal literal (e.g. `"475"` at scale 20 becomes
-/// `"0.00000000000000000475"`). A non-positive scale multiplies by `10^-scale`.
-fn scaled_decimal_literal(signed_digits: &str, scale: i8) -> String {
-    let (sign, magnitude) = match signed_digits.strip_prefix('-') {
-        Some(rest) => ("-", rest),
-        None => ("", signed_digits),
-    };
-
-    if scale <= 0 {
-        let zeros = usize::from(scale.unsigned_abs());
-        return format!("{sign}{magnitude}{}", "0".repeat(zeros));
+/// `47.5` came back as `47.500_000_000_000_01` (issue #13978).
+///
+/// Going through the value's exact decimal digits removes the loss: `Decimal ->
+/// Utf8` renders every coefficient exactly, and `Utf8 -> Float` rounds that
+/// literal once with `f64`/`f32` correct rounding (verified bit-for-bit against
+/// Rust's `str::parse`, which arrow's parser matches). This covers every decimal
+/// width — `Decimal32`/`Decimal64` are lossy on the direct path too — and every
+/// float target, so it applies to every caller of `try_cast_to`.
+fn cast_decimal_to_float(
+    column: &ArrayRef,
+    target_type: &DataType,
+    options: &CastOptions,
+) -> Result<Option<ArrayRef>> {
+    let is_decimal = matches!(
+        column.data_type(),
+        DataType::Decimal32(..)
+            | DataType::Decimal64(..)
+            | DataType::Decimal128(..)
+            | DataType::Decimal256(..)
+    );
+    if !is_decimal || !matches!(target_type, DataType::Float32 | DataType::Float64) {
+        return Ok(None);
     }
 
-    let scale = usize::from(scale.unsigned_abs());
-    if magnitude.len() > scale {
-        let split = magnitude.len() - scale;
-        format!("{sign}{}.{}", &magnitude[..split], &magnitude[split..])
-    } else {
-        // |value| < 1: pad the fraction with leading zeros out to the scale.
-        format!("{sign}0.{magnitude:0>scale$}")
-    }
+    let strings = cast_with_options(column.as_ref(), &DataType::Utf8, options)
+        .context(UnableToConvertRecordBatchSnafu)?;
+    cast_with_options(strings.as_ref(), target_type, options)
+        .context(UnableToConvertRecordBatchSnafu)
+        .map(Some)
 }
 
 /// Whether `target` can be reached from `source` by relabelling alone: the two describe the same
@@ -1961,6 +1850,7 @@ mod test {
     #[test]
     fn decimal256_to_f64_rounds_correctly() {
         use arrow::array::Decimal256Array;
+        use arrow::datatypes::i256;
 
         let coeff = i256::from_i128(475 * 10_i128.pow(19));
         let source = Decimal256Array::from(vec![Some(coeff)])
@@ -1969,6 +1859,41 @@ mod test {
 
         let out = cast_decimal_column(Arc::new(source), DataType::Float64);
         assert_eq!(f64_values(&out), vec![Some(47.5)]);
+    }
+
+    /// `Decimal64 -> Float64` is lossy on arrow's direct path too: an `i64`
+    /// coefficient can exceed `2^53`. Here `47.5` at scale 15 has coefficient
+    /// `4.75e16 > 2^53`, and must still round to exactly 47.5.
+    #[test]
+    fn decimal64_to_f64_rounds_correctly() {
+        use arrow::array::Decimal64Array;
+
+        let coeff: i64 = 475 * 10_i64.pow(14);
+        let source = Decimal64Array::from(vec![Some(coeff)])
+            .with_precision_and_scale(18, 15)
+            .expect("valid Decimal64(18,15)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(f64_values(&out), vec![Some(47.5)]);
+    }
+
+    /// `Decimal32 -> Float32` is lossy on the direct path: an `i32` coefficient
+    /// can exceed `2^24`. Here `47.5` at scale 6 has coefficient `4.75e7 > 2^24`.
+    #[test]
+    fn decimal32_to_f32_rounds_correctly() {
+        use arrow::array::{Decimal32Array, Float32Array};
+
+        let coeff: i32 = 475 * 10_i32.pow(5);
+        let source = Decimal32Array::from(vec![Some(coeff)])
+            .with_precision_and_scale(9, 6)
+            .expect("valid Decimal32(9,6)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float32);
+        let col = out
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .expect("Float32Array");
+        assert_eq!(col.value(0).to_bits(), 47.5_f32.to_bits());
     }
 
     /// Casting to `Float32` preserves values and nulls.
@@ -1987,19 +1912,6 @@ mod test {
             .expect("Float32Array");
         assert!((col.value(0) - 1234.5678_f32).abs() < f32::EPSILON);
         assert!(col.is_null(1));
-    }
-
-    #[test]
-    fn scaled_decimal_literal_formats() {
-        assert_eq!(scaled_decimal_literal("475", 20), "0.00000000000000000475");
-        assert_eq!(scaled_decimal_literal("12345678", 4), "1234.5678");
-        assert_eq!(scaled_decimal_literal("-12345678", 4), "-1234.5678");
-        assert_eq!(scaled_decimal_literal("5", 1), "0.5");
-        assert_eq!(scaled_decimal_literal("5", 3), "0.005");
-        assert_eq!(scaled_decimal_literal("475", 3), "0.475");
-        assert_eq!(scaled_decimal_literal("0", 2), "0.00");
-        assert_eq!(scaled_decimal_literal("123", 0), "123");
-        assert_eq!(scaled_decimal_literal("123", -2), "12300");
     }
 
     /// `rows` strings of `value_len` identical characters, varying by row so a

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -16,16 +16,17 @@ limitations under the License.
 
 use arrow::{
     array::{
-        Array, ArrayData, ArrayRef, BinaryViewArray, DictionaryArray, GenericByteViewArray,
-        ListArray, MutableArrayData, PrimitiveArray, RecordBatch, RecordBatchOptions,
-        StringViewArray, StructArray, UInt64Array, downcast_dictionary_array, make_array,
-        new_null_array,
+        Array, ArrayData, ArrayRef, AsArray, BinaryViewArray, DictionaryArray, Float32Builder,
+        Float64Builder, GenericByteViewArray, ListArray, MutableArrayData, PrimitiveArray,
+        RecordBatch, RecordBatchOptions, StringViewArray, StructArray, UInt64Array,
+        downcast_dictionary_array, make_array, new_null_array,
     },
     buffer::{Buffer, NullBuffer, OffsetBuffer},
     compute::take,
     datatypes::{
         ArrowDictionaryKeyType, ArrowNativeType, ArrowNativeTypeOp, BinaryViewType, ByteViewType,
-        DataType, Field, FieldRef, SchemaRef, StringViewType, TimeUnit,
+        DataType, Decimal128Type, Decimal256Type, Field, FieldRef, SchemaRef, StringViewType,
+        TimeUnit, i256,
     },
     error::ArrowError,
 };
@@ -48,6 +49,14 @@ pub enum Error {
 
     #[snafu(display("Field is not nullable: {field}"))]
     FieldNotNullable { field: String },
+
+    #[snafu(display(
+        "Failed to convert decimal value '{value}' to a floating-point number: {source}"
+    ))]
+    DecimalToFloat {
+        value: String,
+        source: std::num::ParseFloatError,
+    },
 }
 
 impl From<Error> for DataFusionError {
@@ -58,6 +67,9 @@ impl From<Error> for DataFusionError {
             } => DataFusionError::ArrowError(Box::new(arrow_error), None),
             Error::FieldNotNullable { .. } => {
                 DataFusionError::ArrowError(Box::new(ArrowError::SchemaError(e.to_string())), None)
+            }
+            Error::DecimalToFloat { .. } => {
+                DataFusionError::ArrowError(Box::new(ArrowError::CastError(e.to_string())), None)
             }
         }
     }
@@ -183,6 +195,10 @@ fn cast_column(
         return relabel_nullability(column, target_field);
     }
 
+    if let Some(casted) = cast_decimal_to_float(column, target_field.data_type())? {
+        return Ok(casted);
+    }
+
     match cast_with_options(column.as_ref(), target_field.data_type(), strict_options) {
         Ok(casted) => Ok(casted),
         Err(ref e)
@@ -211,6 +227,147 @@ fn is_overflow_error(e: &ArrowError) -> bool {
         ArrowError::CastError(msg) | ArrowError::ArithmeticOverflow(msg)
             if msg.contains("Overflow") || msg.contains("overflow")
     )
+}
+
+/// Correctly-rounded conversion of a decimal column to `Float64`/`Float32`,
+/// or `Ok(None)` when the pair is not decimal-to-float and the caller's general
+/// cast path should handle it.
+///
+/// arrow's own `Decimal -> Float` cast widens the integer coefficient to the
+/// float *before* dividing by `10^scale`, so a coefficient beyond the float's
+/// exactly-representable integer range (`2^53` for `f64`, `2^24` for `f32`) is
+/// rounded once on the way in and the divide carries that error through, landing
+/// the result up to a couple of ULP off the true value. An `avg()`/`sum()`
+/// pushed to `PostgreSQL` returns an *undeclared* NUMERIC read at scale 20, whose
+/// coefficient always exceeds `2^53`, so an exactly representable answer like
+/// `47.5` came back as `47.500_000_000_000_01` (issue #13978). Rounding from the
+/// value's exact decimal digits instead removes the loss at every scale.
+fn cast_decimal_to_float(column: &ArrayRef, target_type: &DataType) -> Result<Option<ArrayRef>> {
+    match (column.data_type(), target_type) {
+        (DataType::Decimal128(_, scale), DataType::Float64) => {
+            let (scale, values) = (*scale, column.as_primitive::<Decimal128Type>());
+            f64_array_from(values.len(), |i| {
+                if values.is_null(i) {
+                    Ok(None)
+                } else {
+                    decimal128_to_f64(values.value(i), scale).map(Some)
+                }
+            })
+            .map(Some)
+        }
+        (DataType::Decimal128(_, scale), DataType::Float32) => {
+            let (scale, values) = (*scale, column.as_primitive::<Decimal128Type>());
+            f32_array_from(values.len(), |i| {
+                if values.is_null(i) {
+                    Ok(None)
+                } else {
+                    parse_scaled::<f32>(&values.value(i).to_string(), scale).map(Some)
+                }
+            })
+            .map(Some)
+        }
+        (DataType::Decimal256(_, scale), DataType::Float64) => {
+            let (scale, values) = (*scale, column.as_primitive::<Decimal256Type>());
+            f64_array_from(values.len(), |i| {
+                if values.is_null(i) {
+                    Ok(None)
+                } else {
+                    decimal256_to_f64(values.value(i), scale).map(Some)
+                }
+            })
+            .map(Some)
+        }
+        (DataType::Decimal256(_, scale), DataType::Float32) => {
+            let (scale, values) = (*scale, column.as_primitive::<Decimal256Type>());
+            f32_array_from(values.len(), |i| {
+                if values.is_null(i) {
+                    Ok(None)
+                } else {
+                    parse_scaled::<f32>(&values.value(i).to_string(), scale).map(Some)
+                }
+            })
+            .map(Some)
+        }
+        _ => Ok(None),
+    }
+}
+
+fn f64_array_from(len: usize, get: impl Fn(usize) -> Result<Option<f64>>) -> Result<ArrayRef> {
+    let mut builder = Float64Builder::with_capacity(len);
+    for index in 0..len {
+        match get(index)? {
+            Some(value) => builder.append_value(value),
+            None => builder.append_null(),
+        }
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+fn f32_array_from(len: usize, get: impl Fn(usize) -> Result<Option<f32>>) -> Result<ArrayRef> {
+    let mut builder = Float32Builder::with_capacity(len);
+    for index in 0..len {
+        match get(index)? {
+            Some(value) => builder.append_value(value),
+            None => builder.append_null(),
+        }
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+fn decimal128_to_f64(value: i128, scale: i8) -> Result<f64> {
+    // Fast path: the coefficient is exactly representable and `10^scale` is too
+    // (`scale <= 22`), so a single IEEE division is already correctly rounded and
+    // no string round-trip is needed.
+    if (0..=22).contains(&scale) && value.unsigned_abs() < (1u128 << 53) {
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "guarded: |value| < 2^53 and scale <= 22, so both operands are exact and the single division is correctly rounded"
+        )]
+        let exact = value as f64 / 10f64.powi(i32::from(scale));
+        return Ok(exact);
+    }
+    parse_scaled(&value.to_string(), scale)
+}
+
+fn decimal256_to_f64(value: i256, scale: i8) -> Result<f64> {
+    parse_scaled(&value.to_string(), scale)
+}
+
+/// Parses the exact decimal `signed_digits` scaled by `10^-scale` into a float,
+/// relying on Rust's correctly-rounded float parsing rather than on integer
+/// widening.
+fn parse_scaled<F>(signed_digits: &str, scale: i8) -> Result<F>
+where
+    F: std::str::FromStr<Err = std::num::ParseFloatError>,
+{
+    let literal = scaled_decimal_literal(signed_digits, scale);
+    literal
+        .parse::<F>()
+        .context(DecimalToFloatSnafu { value: literal })
+}
+
+/// Renders the signed integer coefficient `signed_digits` at `scale` decimal
+/// places as a plain decimal literal (e.g. `"475"` at scale 20 becomes
+/// `"0.00000000000000000475"`). A non-positive scale multiplies by `10^-scale`.
+fn scaled_decimal_literal(signed_digits: &str, scale: i8) -> String {
+    let (sign, magnitude) = match signed_digits.strip_prefix('-') {
+        Some(rest) => ("-", rest),
+        None => ("", signed_digits),
+    };
+
+    if scale <= 0 {
+        let zeros = usize::from(scale.unsigned_abs());
+        return format!("{sign}{magnitude}{}", "0".repeat(zeros));
+    }
+
+    let scale = usize::from(scale.unsigned_abs());
+    if magnitude.len() > scale {
+        let split = magnitude.len() - scale;
+        format!("{sign}{}.{}", &magnitude[..split], &magnitude[split..])
+    } else {
+        // |value| < 1: pad the fraction with leading zeros out to the scale.
+        format!("{sign}0.{magnitude:0>scale$}")
+    }
 }
 
 /// Whether `target` can be reached from `source` by relabelling alone: the two describe the same
@@ -1681,6 +1838,168 @@ mod test {
             result.is_err(),
             "non-timestamp overflow should still return an error"
         );
+    }
+
+    /// Casts a one-column decimal batch to a float schema through `try_cast_to`.
+    fn cast_decimal_column(source: ArrayRef, target: DataType) -> ArrayRef {
+        let source_schema = Arc::new(Schema::new(vec![Field::new(
+            "v",
+            source.data_type().clone(),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(source_schema, vec![source]).expect("valid batch");
+        let target_schema = Arc::new(Schema::new(vec![Field::new("v", target, true)]));
+        let out = try_cast_to(batch, target_schema).expect("cast succeeds");
+        Arc::clone(out.column(0))
+    }
+
+    fn f64_values(array: &ArrayRef) -> Vec<Option<f64>> {
+        let col = array
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .expect("Float64Array");
+        (0..col.len())
+            .map(|i| (!col.is_null(i)).then(|| col.value(i)))
+            .collect()
+    }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/13978>.
+    ///
+    /// An undeclared `PostgreSQL` NUMERIC is read as `Decimal128(38, 20)`; casting
+    /// it to `Float64` must round correctly. `avg()` of a two-row BIGINT group
+    /// summing to 95 is exactly 47.5, but arrow's stock cast widened the scale-20
+    /// coefficient past 2^53 before dividing and returned 47.50000000000001.
+    #[test]
+    fn decimal128_to_f64_rounds_correctly_issue_13978() {
+        use arrow::array::Decimal128Array;
+
+        // 47.5 at scale 20 -> coefficient 4_750_000_000_000_000_000_000 (> 2^53).
+        let coeff: i128 = 475 * 10_i128.pow(19);
+        let source = Decimal128Array::from(vec![Some(coeff)])
+            .with_precision_and_scale(38, 20)
+            .expect("valid Decimal128(38,20)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(f64_values(&out), vec![Some(47.5)]);
+
+        // Confirm this test would catch a regression to the defective arithmetic:
+        // the widen-then-divide path lands one ULP off 47.5.
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "reproducing the defective arrow path under test"
+        )]
+        let stock = coeff as f64 / 10f64.powi(20);
+        // Compare bit patterns: an exact `!=` on f64 trips `clippy::float_cmp`,
+        // and bit-distinctness is what "one ULP off" means here anyway.
+        assert_ne!(
+            stock.to_bits(),
+            47.5_f64.to_bits(),
+            "the defective path should differ from 47.5, got {stock}"
+        );
+    }
+
+    /// The control from the issue: `avg = 2` at scale 20 has a coefficient that is
+    /// also beyond 2^53, but happens to round back to 2.0. It must stay exact.
+    #[test]
+    fn decimal128_to_f64_control_value_stays_exact() {
+        use arrow::array::Decimal128Array;
+
+        let coeff: i128 = 2 * 10_i128.pow(20);
+        let source = Decimal128Array::from(vec![Some(coeff)])
+            .with_precision_and_scale(38, 20)
+            .expect("valid Decimal128(38,20)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(f64_values(&out), vec![Some(2.0)]);
+    }
+
+    /// Nulls, negatives, small fast-path values, and sub-one magnitudes all
+    /// convert correctly in one array.
+    #[test]
+    fn decimal128_to_f64_mixed_values() {
+        use arrow::array::Decimal128Array;
+
+        // scale 4: 1234.5678, -1234.5678, NULL, 0.0001, 0
+        let source = Decimal128Array::from(vec![
+            Some(12_345_678),
+            Some(-12_345_678),
+            None,
+            Some(1),
+            Some(0),
+        ])
+        .with_precision_and_scale(38, 4)
+        .expect("valid Decimal128(38,4)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(
+            f64_values(&out),
+            vec![
+                Some(1234.5678),
+                Some(-1234.5678),
+                None,
+                Some(0.0001),
+                Some(0.0)
+            ]
+        );
+    }
+
+    /// A negative undeclared-NUMERIC average round-trips exactly too.
+    #[test]
+    fn decimal128_to_f64_negative_scale_20() {
+        use arrow::array::Decimal128Array;
+
+        let coeff: i128 = -(475 * 10_i128.pow(19));
+        let source = Decimal128Array::from(vec![Some(coeff)])
+            .with_precision_and_scale(38, 20)
+            .expect("valid Decimal128(38,20)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(f64_values(&out), vec![Some(-47.5)]);
+    }
+
+    /// `Decimal256` takes the same correctly-rounded path.
+    #[test]
+    fn decimal256_to_f64_rounds_correctly() {
+        use arrow::array::Decimal256Array;
+
+        let coeff = i256::from_i128(475 * 10_i128.pow(19));
+        let source = Decimal256Array::from(vec![Some(coeff)])
+            .with_precision_and_scale(50, 20)
+            .expect("valid Decimal256(50,20)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float64);
+        assert_eq!(f64_values(&out), vec![Some(47.5)]);
+    }
+
+    /// Casting to `Float32` preserves values and nulls.
+    #[test]
+    fn decimal128_to_f32_rounds() {
+        use arrow::array::{Decimal128Array, Float32Array};
+
+        let source = Decimal128Array::from(vec![Some(12_345_678), None])
+            .with_precision_and_scale(38, 4)
+            .expect("valid Decimal128(38,4)");
+
+        let out = cast_decimal_column(Arc::new(source), DataType::Float32);
+        let col = out
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .expect("Float32Array");
+        assert!((col.value(0) - 1234.5678_f32).abs() < f32::EPSILON);
+        assert!(col.is_null(1));
+    }
+
+    #[test]
+    fn scaled_decimal_literal_formats() {
+        assert_eq!(scaled_decimal_literal("475", 20), "0.00000000000000000475");
+        assert_eq!(scaled_decimal_literal("12345678", 4), "1234.5678");
+        assert_eq!(scaled_decimal_literal("-12345678", 4), "-1234.5678");
+        assert_eq!(scaled_decimal_literal("5", 1), "0.5");
+        assert_eq!(scaled_decimal_literal("5", 3), "0.005");
+        assert_eq!(scaled_decimal_literal("475", 3), "0.475");
+        assert_eq!(scaled_decimal_literal("0", 2), "0.00");
+        assert_eq!(scaled_decimal_literal("123", 0), "123");
+        assert_eq!(scaled_decimal_literal("123", -2), "12300");
     }
 
     /// `rows` strings of `value_len` identical characters, varying by row so a

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -222,21 +222,26 @@ fn is_overflow_error(e: &ArrowError) -> bool {
 /// or `Ok(None)` when the pair is not decimal-to-float and the caller's general
 /// cast path should handle it.
 ///
-/// arrow's own `Decimal -> Float` cast widens the integer coefficient to the
-/// float *before* dividing by `10^scale`, so a coefficient beyond the float's
-/// exactly-representable integer range (`2^53` for `f64`, `2^24` for `f32`) is
-/// rounded once on the way in and the divide carries that error through, landing
-/// the result up to a couple of ULP off the true value. An `avg()`/`sum()`
-/// pushed to `PostgreSQL` returns an *undeclared* NUMERIC read at scale 20, whose
-/// coefficient always exceeds `2^53`, so an exactly representable answer like
-/// `47.5` came back as `47.500_000_000_000_01` (issue #13978).
+/// arrow's own `Decimal -> Float` cast widens the integer coefficient to `f64`
+/// *before* dividing by `10^scale` (a `Float32` target then rounds that `f64`
+/// once more). When the coefficient is not exactly representable in `f64`,
+/// widening rounds it, and the divide bakes that error into the result — up to a
+/// couple of ULP off. Coefficients below `2^53` are always exact, so the loss
+/// only appears above it; being above `2^53` is *necessary but not sufficient*,
+/// though — an aligned value like the scale-20 coefficient of `2.0` stays exact
+/// (see the control test). An `avg()`/`sum()` pushed to `PostgreSQL` returns an
+/// *undeclared* NUMERIC read at scale 20, whose coefficient exceeds `2^53`, so an
+/// exactly representable answer like `47.5` came back as `47.500_000_000_000_01`
+/// (issue #13978).
 ///
 /// Going through the value's exact decimal digits removes the loss: `Decimal ->
 /// Utf8` renders every coefficient exactly, and `Utf8 -> Float` rounds that
 /// literal once with `f64`/`f32` correct rounding (verified bit-for-bit against
-/// Rust's `str::parse`, which arrow's parser matches). This covers every decimal
-/// width — `Decimal32`/`Decimal64` are lossy on the direct path too — and every
-/// float target, so it applies to every caller of `try_cast_to`.
+/// Rust's `str::parse`, which arrow's parser matches). The coefficient can exceed
+/// `2^53` for `Decimal64` (`i64`), `Decimal128` (`i128`) and `Decimal256`
+/// (`i256`), so all three are lossy on the direct path; `Decimal32` (`i32`) never
+/// can, but is routed here too so its `Float32` result rounds once rather than via
+/// an `f64` intermediate. Applies to every caller of `try_cast_to`.
 ///
 /// The `Utf8` round-trip costs ~20-40x a plain divide, so the common
 /// `Decimal128 -> Float64` case takes a fast path when *every* coefficient is
@@ -1907,25 +1912,50 @@ mod test {
     }
 
     /// `Decimal64 -> Float64` is lossy on arrow's direct path too: an `i64`
-    /// coefficient can exceed `2^53`. Here `47.5` at scale 15 has coefficient
-    /// `4.75e16 > 2^53`, and must still round to exactly 47.5.
+    /// coefficient can exceed `2^53`. This coefficient (`4310892232.2810111`) is
+    /// *not* exactly representable, so the widen-then-divide path lands one ULP
+    /// off — a value chosen so the test fails if `Decimal64` regresses to it,
+    /// rather than one both paths happen to agree on.
     #[test]
     fn decimal64_to_f64_rounds_correctly() {
-        use arrow::array::Decimal64Array;
+        use arrow::array::{Decimal64Array, Float64Array};
 
-        let coeff: i64 = 475 * 10_i64.pow(14);
+        let coeff: i64 = 43_108_922_322_810_111;
         let source = Decimal64Array::from(vec![Some(coeff)])
-            .with_precision_and_scale(18, 15)
-            .expect("valid Decimal64(18,15)");
+            .with_precision_and_scale(18, 7)
+            .expect("valid Decimal64(18,7)");
 
         let out = cast_decimal_column(Arc::new(source), DataType::Float64);
-        assert_eq!(f64_values(&out), vec![Some(47.5)]);
+        let got = out
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("Float64Array")
+            .value(0);
+        // Correctly-rounded 4310892232.2810111.
+        assert_eq!(got.to_bits(), 0x41f0_0f2f_ec84_7f05);
+
+        // Guard that this input actually distinguishes the fix: the old
+        // widen-then-divide arithmetic lands one ULP away.
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "reproducing the defective arrow path under test"
+        )]
+        let naive = coeff as f64 / 10f64.powi(7);
+        assert_ne!(
+            naive.to_bits(),
+            got.to_bits(),
+            "input must distinguish the fixed path, got {naive}"
+        );
     }
 
-    /// `Decimal32 -> Float32` is lossy on the direct path: an `i32` coefficient
-    /// can exceed `2^24`. Here `47.5` at scale 6 has coefficient `4.75e7 > 2^24`.
+    /// `Decimal32` coefficients (`i32`) never exceed `2^53`, so the direct path is
+    /// already exact for `Float64`; `Decimal32` is routed through the exact path
+    /// only so a `Float32` result rounds once instead of via an `f64` intermediate.
+    /// This is coverage that the path produces the right value — for this input the
+    /// two paths agree, so it does not (and cannot, for valid `Decimal32`)
+    /// distinguish a lossy direct path.
     #[test]
-    fn decimal32_to_f32_rounds_correctly() {
+    fn decimal32_to_f32_converts_correctly() {
         use arrow::array::{Decimal32Array, Float32Array};
 
         let coeff: i32 = 475 * 10_i32.pow(5);


### PR DESCRIPTION
## Problem

An undeclared `PostgreSQL` NUMERIC is read as `Decimal128(38, 20)`. When Spice
casts that column to `Float64` (for example, the result of `avg()`/`sum()`
pushed down to `PostgreSQL`), the value can come back wrong.

```
true answer  : 47.5          (sum 95 / count 2, over a BIGINT column)
before        : 47.50000000000001
after         : 47.5
```

## Cause

`try_cast_to` routed `Decimal → Float` through arrow's cast kernel, which widens
the integer coefficient to `f64` before dividing by `10^scale`:

```
as_float(coefficient) / 10f64.powi(scale)
```

At scale 20 the coefficient always exceeds `2^53`, the exactly-representable
integer range of `f64`. The coefficient is therefore rounded, and the division propagates the error

```
scale 16..19 : coefficient <= 2^53  -> exact   -> 47.5
scale 20     : coefficient  > 2^53  -> rounded -> 47.50000000000001
```

## Fix

`arrow_tools::try_cast_to` now converts `Decimal128`/`Decimal256` → `Float32`/`Float64` by
rounding from the value's exact decimal digits, upstream of the loss:

- Fast path: when the coefficient fits `2^53` and `scale <= 22`, both
  operands are exact, so a single IEEE division is already correctly rounded.
- Otherwise: render the exact decimal literal and let Rust's
  correctly-rounded float parse round it once.

Values held as `Decimal128` are unchanged; only the float cast is corrected. The
change applies to every caller of `try_cast_to`, not only `PostgreSQL`.

## Evidence

- A standalone fuzz harness compared the exact conversion against a
  high-precision correctly-rounded oracle over **50,000,000** random cases
  (full `i128` range, every scale 0–38; ~10.8M of them are values the old
  widen-then-divide code got wrong): **zero** mismatches for the fix, on both
  the fast path and the string path.
- The oracle was validated against the *provably* correct fast path over 5M
  cases, and `10f64.powi(k)` is exact for every `k` in `0..=22`.
- Regression tests in `crates/arrow_tools/src/record_batch.rs` assert the issue
  value (47.5), the control value (2.0), nulls, negatives, sub-one magnitudes,
  `Decimal256`, and `Float32`, and assert that the defective arithmetic differs
  from 47.5.

Closes #13978