### PR TITLE
fix: Keep the caching-eviction sweep planning when a primary_key is declared

### DIFF
--- a/crates/runtime-table/src/accelerated/caching_eviction.rs
+++ b/crates/runtime-table/src/accelerated/caching_eviction.rs
@@ -729,8 +729,27 @@ async fn rank_entries(
         get_df_default_config(),
         default_runtime_env(io_runtime.clone()),
     );
+    // Project away nested columns before aggregating. `read_table` scans the
+    // accelerator's whole schema, which for an HTTP cache includes the
+    // `response_headers` Map stored on every row. The sweep never reads that
+    // Map, but a declared `primary_key` adds functional dependencies that keep
+    // it live into the aggregate, where DataFusion's row format has no encoding
+    // for a Map — so the sweep fails on every tick and the budget is silently
+    // never enforced (#13976). Keeping only the columns `measured_bytes` can
+    // weigh retains exactly what the aggregate reads — the utf8 keys,
+    // `_fetched_at`, and the payload columns a byte budget sums — and drops
+    // every nested column a row format cannot encode, so the sweep plans with
+    // or without a declared key.
+    let projection: Vec<Expr> = schema
+        .fields()
+        .iter()
+        .filter(|field| measured_bytes(field).is_some())
+        .map(|field| col(field.name()))
+        .collect();
+
     let mut df = ctx
         .read_table(Arc::clone(accelerator))?
+        .select(projection)?
         .aggregate(key_columns.iter().map(col).collect(), aggregates)?;
 
     if has_fetched_at {

--- a/crates/runtime-table/src/accelerated/caching_eviction.rs
+++ b/crates/runtime-table/src/accelerated/caching_eviction.rs
@@ -1422,6 +1422,86 @@ mod tests {
         (accelerator, federated)
     }
 
+    /// As [`cache_table`], but the schema carries the `response_headers` Map the
+    /// HTTP connector stores on every row, and the accelerator declares a
+    /// `primary_key` on `request_path`. This is the shape that reproduces
+    /// #13976: the Map is nested, and the primary-key constraint's functional
+    /// dependencies keep it in the ranking aggregate, where a row format cannot
+    /// encode it. Rows must have distinct paths so the key is a valid primary
+    /// key over the fixture data.
+    async fn cache_table_with_headers_and_pk(
+        rows: &[Row],
+    ) -> (Arc<dyn TableProvider>, Arc<FederatedTable>) {
+        use arrow::array::{
+            MapBuilder, MapFieldNames, StringArray, StringBuilder, TimestampNanosecondArray,
+        };
+        use datafusion::common::{Constraint, Constraints};
+        use data_components::arrow::write::MemTable;
+
+        // Build the header Map first so the schema field matches the array's
+        // type exactly — an empty map per row is all the sweep needs to plan.
+        let mut headers = MapBuilder::new(
+            Some(MapFieldNames {
+                entry: "entries".to_string(),
+                key: "keys".to_string(),
+                value: "values".to_string(),
+            }),
+            StringBuilder::new(),
+            StringBuilder::new(),
+        );
+        for _ in rows {
+            headers.append(true).expect("append map entry");
+        }
+        let headers = headers.finish();
+
+        let mut fields = http_cache_schema().fields().to_vec();
+        fields.push(Arc::new(Field::new(
+            RESPONSE_HEADERS_COLUMN,
+            headers.data_type().clone(),
+            true,
+        )));
+        let schema = Arc::new(Schema::new(fields));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.path).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(StringArray::from(
+                    rows.iter()
+                        .map(|r| r.query.unwrap_or(""))
+                        .collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(StringArray::from(vec![""; rows.len()])) as _,
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.content).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(TimestampNanosecondArray::from(
+                    rows.iter()
+                        .map(|r| Some(nanos_ago(r.age)))
+                        .collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(StringArray::from(vec!["public"; rows.len()])) as _,
+                Arc::new(headers) as _,
+            ],
+        )
+        .expect("batch");
+
+        // `request_path` is field 0. A single-column primary key is enough to
+        // add the functional dependencies that trip the sweep.
+        let table = MemTable::try_new(schema, vec![vec![batch]])
+            .expect("mem table")
+            .try_with_constraints(Constraints::new_unverified(vec![Constraint::PrimaryKey(
+                vec![0],
+            )]))
+            .await
+            .expect("primary key constraint");
+        let accelerator = Arc::new(table) as Arc<dyn TableProvider>;
+        let federated = Arc::new(FederatedTable::new_unchecked(Arc::clone(&accelerator)));
+        (accelerator, federated)
+    }
+
     /// The `(request_path, request_query)` pairs still stored, sorted.
     async fn remaining(accelerator: &Arc<dyn TableProvider>) -> Vec<(String, Option<String>)> {
         let ctx = SessionContext::new();
@@ -1727,6 +1807,41 @@ mod tests {
         assert_eq!(
             remaining(&accelerator).await,
             vec![("/fresh".to_string(), None)]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_item_budget_is_enforced_when_a_primary_key_is_declared() {
+        // #13976: a declared `primary_key` used to disable the budget. The
+        // sweep's ranking aggregate scans the accelerator's full schema, which
+        // includes the `response_headers` Map; the primary key's functional
+        // dependencies kept that Map in the aggregate, where a row format cannot
+        // encode it, so the sweep failed on every tick and evicted nothing.
+        // Before the projection fix this call returns zero and the cache keeps
+        // all three entries; with it, the budget is enforced exactly as it is
+        // without a key.
+        let (accelerator, federated) = cache_table_with_headers_and_pk(&[
+            row("/oldest", Duration::from_mins(3)),
+            row("/middle", Duration::from_mins(2)),
+            row("/newest", Duration::from_mins(1)),
+        ])
+        .await;
+
+        let deleted = sweep(
+            &accelerator,
+            &federated,
+            CacheLimits {
+                max_items: Some(2),
+                ..no_expiry()
+            },
+        )
+        .await;
+
+        assert_eq!(deleted, 1, "the item budget must evict one entry");
+        assert_eq!(
+            remaining(&accelerator).await,
+            vec![("/middle".to_string(), None), ("/newest".to_string(), None)],
+            "the least-recently-fetched entry is the one dropped"
         );
     }
 


### PR DESCRIPTION
## Problem

A `refresh_mode: caching` accelerator stops enforcing `caching_max_items` and
`caching_max_size` when the dataset declares a `primary_key`. The cache then
grows without bound. Queries keep succeeding, so the only signal is a repeating
warning in the log:

```
[retention] Failed to resolve what to delete for dataset <name>, so it keeps
whatever is past its retention until the next check. Cause: ...
```

See #13976.

## Observed behaviour

The eviction sweep in `caching_eviction.rs` derives what to evict with one
aggregate per tick: `read_table(accelerator).aggregate(...)`, grouped by the
cache key columns. `read_table` scans the accelerator's full schema, which for
an HTTP cache includes `response_headers` — an Arrow `Map` the connector stores
on every row.

Reproduced by the added test: with the `response_headers` Map present and a
`primary_key` declared on the key column, the sweep aggregate fails with
`Row format support not yet implemented for: [...Map...]`, the retention loop
logs the failure and moves on, and nothing is evicted. Remove the `primary_key`
and the same sweep runs and evicts. So the constraint is what triggers it.

Working explanation (verified black-box, not traced through the optimiser): a
declared `primary_key` adds functional dependencies over the scanned relation.
Without a key, projection pushdown prunes the unread `Map` before execution;
with one, the constraint keeps the `Map` in the plan, where DataFusion's row
format has no encoding for it. Whichever optimiser path retains the column, it
acts on columns present in the aggregate's input relation.

## Fix

Project the sweep to the columns it actually reads before aggregating. The kept
set is exactly the columns `measured_bytes` can weigh — the utf8 keys,
`_fetched_at`, and the payload columns a byte budget sums. Every nested column a
row format cannot encode, including the `Map`, is dropped before it reaches the
plan, so the aggregate never sees it regardless of which optimiser path would
otherwise retain it. The sweep then plans identically with or without a declared
key.

The change is one projection at the single sweep call site. Byte accounting is
unchanged: the payload columns a budget sums are all row-format-safe and stay in
the projection.

## Test plan

- [x] Regression test `the_item_budget_is_enforced_when_a_primary_key_is_declared`:
  a caching accelerator with a `response_headers` Map and a `primary_key` on the
  key column, asserting the sweep still evicts under an item budget. Verified it
  passes with the fix and fails without it (the pre-fix run reproduces the
  `Row format ... Map` sweep failure).
- [x] `spiced_docker_dev.yml` dev image build — passed ([run 34325773237](https://github.com/spiceai/spiceai/actions/runs/34325773237)); image `ghcr.io/spiceai/spiceai-dev:pr-13990-caching-pk` (amd64).
