### PR TITLE
docs: update security support and roadmap after v2.3.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,21 @@
 
 ## Supported Versions
 
-Spice.ai has released 2.2.0 🎉
+Spice.ai has released 2.3.0 🎉
 
 In the latest major version, the last 2 minor version series are supported for security updates.
 
 | Version | Supported          |
 |---------|--------------------|
+| 2.3.0   | :white_check_mark: |
 | 2.2.1   | :white_check_mark: |
 | 2.2.0   | :white_check_mark: |
-| 2.1.5   | :white_check_mark: |
-| 2.1.4   | :white_check_mark: |
-| 2.1.3   | :white_check_mark: |
-| 2.1.2   | :white_check_mark: |
-| 2.1.1   | :white_check_mark: |
-| 2.1.0   | :white_check_mark: |
+| 2.1.5   | :x:                |
+| 2.1.4   | :x:                |
+| 2.1.3   | :x:                |
+| 2.1.2   | :x:                |
+| 2.1.1   | :x:                |
+| 2.1.0   | :x:                |
 | 2.0.1   | :x:                |
 | 2.0.0   | :x:                |
 | 1.11.6  | :x:                |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,10 +17,12 @@ To propose features or report issues, please [file an issue](https://github.com/
 
 ### [v2.4](https://github.com/spiceai/spiceai/milestone/101) (October 2026)
 
-**Focus:** Distributed Search, Enterprise Security, Compliance, & Governance.
+**Focus:** Schema Registry, Write-Back Acceleration, Distributed Search, Enterprise Security, Compliance, & Governance.
 
 **DataFusion:** v56
 
+- **Schema Registry (Initial)**: Versioning and backward compatibility checks.
+- **Write-Back Acceleration DML**: Full UPDATE/DELETE DML on write-through accelerated tables.
 - **Distributed Search (Alpha)**: Federated vector and full-text search across multiple nodes, with FTS indexes available in distributed query mode.
 - **Distributed Search Scale-Out**: Search query partitioning and relative score fusion across distributed nodes.
 - **Distributed Cayenne Catalog**: Cayenne catalog with full distributed query and acceleration support.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,15 +15,6 @@ To propose features or report issues, please [file an issue](https://github.com/
 
 ## Release Timeline
 
-### [v2.3](https://github.com/spiceai/spiceai/milestone/100) (September 2026)
-
-**Focus:** Schema Registry & Write-Back Acceleration.
-
-**DataFusion:** v55
-
-- **Schema Registry (Initial)**: Versioning and backward compatibility checks.
-- **Write-Back Acceleration DML**: Full UPDATE/DELETE DML on write-through accelerated tables.
-
 ### [v2.4](https://github.com/spiceai/spiceai/milestone/101) (October 2026)
 
 **Focus:** Distributed Search, Enterprise Security, Compliance, & Governance.


### PR DESCRIPTION
## WHAT

Update security support for the published [v2.3.0 release](https://github.com/spiceai/spiceai/releases/tag/v2.3.0) and carry unfinished v2.3 roadmap items into v2.4.

## WHY

The roadmap must retain unshipped commitments, and the security policy supports the two latest minor series, 2.3.x and 2.2.x.

## HOW

Place Schema Registry (Initial) and Write-Back Acceleration DML under v2.4 alongside its existing scope, and remove v2.3 from the upcoming timeline. Add 2.3.0 as supported and mark 2.1.x unsupported. This completes the policy follow-up in #13969. Validation confirmed both roadmap commitments retain their original wording under v2.4 and later release entries are unchanged.
