### PR TITLE
fix: restore installer release lookup and test coverage on 2.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/install_scripts_test.yml
+++ b/.github/workflows/install_scripts_test.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'install/**'
       - 'test/scripts/install-scripts-test.sh'
+      - 'test/scripts/install-download-test.py'
       - '.github/workflows/install_scripts_test.yml'
   push:
     branches:
@@ -17,6 +18,7 @@ on:
     paths:
       - 'install/**'
       - 'test/scripts/install-scripts-test.sh'
+      - 'test/scripts/install-download-test.py'
       - '.github/workflows/install_scripts_test.yml'
   workflow_dispatch:
 
@@ -358,6 +360,9 @@ jobs:
             echo "ERROR: Alternative HTTP client is still available"
             exit 1
           fi
+
+      - name: Test runtime download retries with ${{ matrix.client }}
+        run: python3 test/scripts/install-download-test.py --client "${{ matrix.client }}"
 
       - name: Test install.sh with ${{ matrix.client }}
         env:

--- a/.github/workflows/install_scripts_test.yml
+++ b/.github/workflows/install_scripts_test.yml
@@ -20,6 +20,12 @@ on:
       - '.github/workflows/install_scripts_test.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -207,7 +213,6 @@ jobs:
 
       - name: Test install-spiced.sh with custom directory
         env:
-          VARIANT: models
           SPICED_INSTALL_DIR: ${{ github.workspace }}/custom-spiced-bin
         run: |
           mkdir -p "$SPICED_INSTALL_DIR"
@@ -235,23 +240,14 @@ jobs:
           - os: linux-x64
             runner: ubuntu-24.04
             variant: ''
-          - os: linux-x64
-            runner: ubuntu-24.04
-            variant: models
           # Linux ARM64 variants
           - os: linux-arm64
             runner: ubuntu-24.04-arm
             variant: ''
-          - os: linux-arm64
-            runner: ubuntu-24.04-arm
-            variant: models
           # macOS ARM64 variants
           - os: macos-arm64
             runner: macos-latest
             variant: ''
-          - os: macos-arm64
-            runner: macos-latest
-            variant: models
           - os: macos-arm64
             runner: macos-latest
             variant: metal
@@ -264,12 +260,12 @@ jobs:
       - name: Test install-spiced.sh with variant '${{ matrix.variant }}'
         env:
           VARIANT: ${{ matrix.variant }}
-          SPICED_INSTALL_DIR: ${{ github.workspace }}/bin
+          SPICED_INSTALL_DIR: ${{ runner.temp }}/spiced-bin
         run: |
-          mkdir -p bin
+          mkdir -p "$SPICED_INSTALL_DIR"
           chmod +x install/install-spiced.sh
           ./install/install-spiced.sh
-          ./bin/spiced --version
+          "$SPICED_INSTALL_DIR/spiced" --version
 
   # Test specific version installation
   test-specific-version:
@@ -295,27 +291,30 @@ jobs:
         id: get_version
         run: |
           # Get the latest release tag and strip the 'v' prefix (scripts add it back)
-          VERSION=$(curl -sS "https://api.github.com/repos/spiceai/spiceai/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*: "v\?\(.*\)",/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          VERSION=$(gh api repos/spiceai/spiceai/releases/latest --jq '.tag_name')
+          VERSION=${VERSION#v}
+          test -n "$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Testing with version: $VERSION"
 
       - name: Test install.sh with specific version
         env:
           SPICE_CLI_INSTALL_DIR: ${{ github.workspace }}/bin-cli
+          RELEASE_VERSION: ${{ steps.get_version.outputs.version }}
         run: |
           mkdir -p "$SPICE_CLI_INSTALL_DIR"
           chmod +x install/install.sh
-          ./install/install.sh ${{ steps.get_version.outputs.version }}
+          ./install/install.sh "$RELEASE_VERSION"
           "$SPICE_CLI_INSTALL_DIR/spice" version
 
       - name: Test install-spiced.sh with specific version
         env:
-          VARIANT: models
           SPICED_INSTALL_DIR: ${{ github.workspace }}/bin-spiced
+          RELEASE_VERSION: ${{ steps.get_version.outputs.version }}
         run: |
           mkdir -p "$SPICED_INSTALL_DIR"
           chmod +x install/install-spiced.sh
-          ./install/install-spiced.sh ${{ steps.get_version.outputs.version }}
+          ./install/install-spiced.sh "$RELEASE_VERSION"
           "$SPICED_INSTALL_DIR/spiced" --version
 
   # Test HTTP client fallback (curl vs wget)
@@ -335,26 +334,34 @@ jobs:
       - name: Remove alternative HTTP client
         run: |
           if [ "${{ matrix.client }}" = "curl" ]; then
-            # Hide wget so script must use curl
-            sudo mv /usr/bin/wget /usr/bin/wget.bak 2>/dev/null || true
+            alternate=wget
           else
-            # Hide curl so script must use wget
-            sudo mv /usr/bin/curl /usr/bin/curl.bak 2>/dev/null || true
+            alternate=curl
           fi
+          while command -v "$alternate" >/dev/null 2>&1; do
+            client_path=$(command -v "$alternate")
+            sudo mv "$client_path" "$client_path.install-test-backup"
+            echo "$client_path" >> "${{ runner.temp }}/hidden-http-clients"
+            hash -r
+          done
 
       - name: Verify only ${{ matrix.client }} is available
         run: |
           if [ "${{ matrix.client }}" = "curl" ]; then
-            which curl
-            ! which wget || echo "wget still available (ok if it fails)"
+            command -v curl
+            alternate=wget
           else
-            which wget
-            ! which curl || echo "curl still available (ok if it fails)"
+            command -v wget
+            alternate=curl
+          fi
+          if command -v "$alternate"; then
+            echo "ERROR: Alternative HTTP client is still available"
+            exit 1
           fi
 
       - name: Test install.sh with ${{ matrix.client }}
         env:
-          SPICE_CLI_INSTALL_DIR: ${{ github.workspace }}/bin
+          SPICE_CLI_INSTALL_DIR: ${{ runner.temp }}/spice-bin
         run: |
           mkdir -p "$SPICE_CLI_INSTALL_DIR"
           chmod +x install/install.sh
@@ -364,13 +371,20 @@ jobs:
       - name: Restore HTTP clients
         if: always()
         run: |
-          sudo mv /usr/bin/wget.bak /usr/bin/wget 2>/dev/null || true
-          sudo mv /usr/bin/curl.bak /usr/bin/curl 2>/dev/null || true
+          if [ -f "${{ runner.temp }}/hidden-http-clients" ]; then
+            while IFS= read -r client_path; do
+              sudo mv "$client_path.install-test-backup" "$client_path"
+            done < "${{ runner.temp }}/hidden-http-clients"
+          fi
 
   # Test error handling
   test-error-handling:
-    name: Error Handling
-    runs-on: ubuntu-24.04
+    name: Error Handling (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -380,11 +394,11 @@ jobs:
       - name: Test invalid version handling
         run: |
           chmod +x install/install-spiced.sh
-          export SPICED_INSTALL_DIR="${{ github.workspace }}/bin"
+          export SPICED_INSTALL_DIR="${{ runner.temp }}/spiced-bin"
           mkdir -p "$SPICED_INSTALL_DIR"
 
           # This should fail gracefully with a non-existent version
-          if ./install/install-spiced.sh v0.0.0-nonexistent 2>&1; then
+          if ./install/install-spiced.sh 0.0.0-nonexistent 2>&1; then
             echo "ERROR: Script should have failed for non-existent version"
             exit 1
           else
@@ -395,16 +409,18 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           chmod +x install/install-spiced.sh
-          export SPICED_INSTALL_DIR="${{ github.workspace }}/bin"
+          export SPICED_INSTALL_DIR="${{ runner.temp }}/spiced-bin"
           export VARIANT="cuda"
           export CUDA_VERSION="90"
           mkdir -p "$SPICED_INSTALL_DIR"
 
           # This should fail on macOS
-          if ./install/install-spiced.sh 2>&1; then
+          if ./install/install-spiced.sh > "${{ runner.temp }}/cuda-rejection.log" 2>&1; then
             echo "ERROR: CUDA variant should not be allowed on macOS"
             exit 1
           else
+            cat "${{ runner.temp }}/cuda-rejection.log"
+            grep -F "CUDA variants are only supported on Linux" "${{ runner.temp }}/cuda-rejection.log"
             echo "✓ Script correctly rejected CUDA variant on macOS"
           fi
 
@@ -412,6 +428,8 @@ jobs:
   test-windows-wsl:
     name: Windows WSL (${{ matrix.distro }})
     runs-on: windows-latest
+    env:
+      WSLENV: GITHUB_TOKEN/u
     strategy:
       fail-fast: false
       matrix:
@@ -423,10 +441,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup WSL
-        uses: Vampire/setup-wsl@2d33ce25ddebc8780792ec86a25a0557e1c7de96 # v6
+        uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7
         with:
           distribution: ${{ matrix.distro }}
-          additional-packages: curl wget
+          additional-packages: curl wget python3
 
       - name: Run install script tests in WSL
         shell: wsl-bash {0}
@@ -450,8 +468,6 @@ jobs:
 
       - name: Test install-spiced.sh in WSL
         shell: wsl-bash {0}
-        env:
-          VARIANT: models
         run: |
           chmod +x install/install-spiced.sh
           export SPICED_INSTALL_DIR="$HOME/bin"

--- a/.github/workflows/install_scripts_test.yml
+++ b/.github/workflows/install_scripts_test.yml
@@ -368,6 +368,20 @@ jobs:
           ./install/install.sh
           "$SPICE_CLI_INSTALL_DIR/spice" version
 
+      - name: Reject invalid release credentials with ${{ matrix.client }}
+        env:
+          GITHUB_TOKEN: invalid-installer-test-token
+          LC_ALL: C
+          SPICED_INSTALL_DIR: ${{ runner.temp }}/spiced-bin
+        run: |
+          if bash install/install-spiced.sh > "${{ runner.temp }}/invalid-token.log" 2>&1; then
+            echo "ERROR: Runtime installer accepted invalid release credentials"
+            exit 1
+          fi
+          cat "${{ runner.temp }}/invalid-token.log"
+          grep -E '(^|[^0-9])401([^0-9]|$)|Username/Password Authentication Failed\.' "${{ runner.temp }}/invalid-token.log"
+          grep -F "Failed to get latest release information" "${{ runner.temp }}/invalid-token.log"
+
       - name: Test install-spiced.sh with ${{ matrix.client }}
         env:
           SPICED_INSTALL_DIR: ${{ runner.temp }}/spiced-bin

--- a/.github/workflows/install_scripts_test.yml
+++ b/.github/workflows/install_scripts_test.yml
@@ -29,6 +29,9 @@ jobs:
   test-install-scripts:
     name: Test Install Scripts (${{ matrix.os }}, ${{ matrix.shell }})
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }} {0}
     strategy:
       fail-fast: false
       matrix:
@@ -65,18 +68,21 @@ jobs:
 
       - name: Install zsh (Ubuntu)
         if: contains(matrix.os, 'linux') && matrix.shell == 'zsh'
+        shell: bash
         run: sudo apt-get update && sudo apt-get install -y zsh
 
       - name: Run install script tests
-        shell: ${{ matrix.shell }} {0}
         run: |
           chmod +x test/scripts/install-scripts-test.sh
-          ${{ matrix.shell }} test/scripts/install-scripts-test.sh --live
+          bash test/scripts/install-scripts-test.sh --live
 
   # Test shell detection and PATH configuration
   test-shell-detection:
     name: Shell Detection (${{ matrix.os }}, ${{ matrix.shell }})
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }} {0}
     strategy:
       fail-fast: false
       matrix:
@@ -107,10 +113,10 @@ jobs:
 
       - name: Install zsh (Ubuntu)
         if: contains(matrix.os, 'linux') && matrix.shell == 'zsh'
+        shell: bash
         run: sudo apt-get update && sudo apt-get install -y zsh
 
       - name: Create shell profile
-        shell: ${{ matrix.shell }} {0}
         run: |
           if [ "${{ matrix.shell }}" = "bash" ]; then
             touch ~/.bashrc
@@ -120,7 +126,6 @@ jobs:
           fi
 
       - name: Test install.sh with shell detection
-        shell: ${{ matrix.shell }} {0}
         env:
           SHELL: /bin/${{ matrix.shell }}
         run: |
@@ -143,7 +148,6 @@ jobs:
           "$HOME/.spice/bin/spice" version
 
       - name: Verify PATH instructions
-        shell: ${{ matrix.shell }} {0}
         run: |
           # Check that the shell profile was updated with PATH
           profile_file=""

--- a/.github/workflows/install_scripts_test.yml
+++ b/.github/workflows/install_scripts_test.yml
@@ -368,6 +368,14 @@ jobs:
           ./install/install.sh
           "$SPICE_CLI_INSTALL_DIR/spice" version
 
+      - name: Test install-spiced.sh with ${{ matrix.client }}
+        env:
+          SPICED_INSTALL_DIR: ${{ runner.temp }}/spiced-bin
+        run: |
+          mkdir -p "$SPICED_INSTALL_DIR"
+          bash install/install-spiced.sh
+          "$SPICED_INSTALL_DIR/spiced" --version
+
       - name: Restore HTTP clients
         if: always()
         run: |

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -140,12 +140,28 @@ checkHttpRequestCLI() {
 getLatestRelease() {
     local spiceReleaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest"
     local latest_release=""
+    local response=""
+    local headers=()
 
     if [ "$SPICE_HTTP_REQUEST_CLI" == "curl" ]; then
-        latest_release=$(curl -s "$spiceReleaseUrl" | grep \"tag_name\" | awk 'NR==1{print $2}' |  sed -n 's/"\(.*\)",/\1/p')
+        if [ -n "${GITHUB_TOKEN:-}" ]; then
+            headers=(-H "Authorization: Bearer $GITHUB_TOKEN")
+        fi
+        response=$(curl -fsS "${headers[@]}" "$spiceReleaseUrl") || {
+            echo "Failed to get latest release information"
+            exit 1
+        }
     else
-        latest_release=$(wget -q --header="Accept: application/json" -O - "$spiceReleaseUrl" | grep \"tag_name\" | awk 'NR==1{print $2}' |  sed -n 's/"\(.*\)",/\1/p')
+        if [ -n "${GITHUB_TOKEN:-}" ]; then
+            headers=(--header="Authorization: Bearer $GITHUB_TOKEN")
+        fi
+        response=$(wget -nv "${headers[@]}" --header="Accept: application/json" -O - "$spiceReleaseUrl") || {
+            echo "Failed to get latest release information"
+            exit 1
+        }
     fi
+
+    latest_release=$(printf '%s\n' "$response" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
     if [ -z "$latest_release" ]; then
         echo "Failed to get latest release information"

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -180,14 +180,14 @@ downloadWithRetry() {
         echo "Download attempt $attempt of $MAX_RETRIES..."
         
         if [ "$SPICE_HTTP_REQUEST_CLI" == "curl" ]; then
-            if curl -H "Accept:application/octet-stream" -SsL "$url" -o "$output" 2>/dev/null; then
-                if [ -f "$output" ]; then
+            if curl --fail -H "Accept:application/octet-stream" -SsL "$url" -o "$output" 2>/dev/null; then
+                if [ -f "$output" ] && tar -tzf "$output" >/dev/null 2>&1; then
                     return 0
                 fi
             fi
         else
             if wget -q --auth-no-challenge --header='Accept:application/octet-stream' "$url" -O "$output" 2>/dev/null; then
-                if [ -f "$output" ]; then
+                if [ -f "$output" ] && tar -tzf "$output" >/dev/null 2>&1; then
                     return 0
                 fi
             fi

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -175,19 +175,22 @@ downloadWithRetry() {
     local url="$1"
     local output="$2"
     local attempt=1
+    local archive_contents
     
     while [ $attempt -le $MAX_RETRIES ]; do
         echo "Download attempt $attempt of $MAX_RETRIES..."
         
         if [ "$SPICE_HTTP_REQUEST_CLI" == "curl" ]; then
             if curl --fail -H "Accept:application/octet-stream" -SsL "$url" -o "$output" 2>/dev/null; then
-                if [ -f "$output" ] && tar -tzf "$output" >/dev/null 2>&1; then
+                if [ -f "$output" ] && archive_contents=$(tar -tzf "$output" 2>/dev/null) &&
+                    printf '%s\n' "$archive_contents" | grep -Fxq -e "$SPICED_FILENAME" -e "./$SPICED_FILENAME"; then
                     return 0
                 fi
             fi
         else
             if wget -q --auth-no-challenge --header='Accept:application/octet-stream' "$url" -O "$output" 2>/dev/null; then
-                if [ -f "$output" ] && tar -tzf "$output" >/dev/null 2>&1; then
+                if [ -f "$output" ] && archive_contents=$(tar -tzf "$output" 2>/dev/null) &&
+                    printf '%s\n' "$archive_contents" | grep -Fxq -e "$SPICED_FILENAME" -e "./$SPICED_FILENAME"; then
                     return 0
                 fi
             fi

--- a/test/scripts/install-download-test.py
+++ b/test/scripts/install-download-test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Exercise runtime download retries against a local HTTP server."""
+
+import argparse
+import io
+import json
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+def archive_bytes():
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as archive:
+        content = b"installer download fixture\n"
+        entry = tarfile.TarInfo("fixture.txt")
+        entry.size = len(content)
+        archive.addfile(entry, io.BytesIO(content))
+    return output.getvalue()
+
+
+def run_case(preamble, client, responses, expected_requests, expected_success):
+    class Handler(BaseHTTPRequestHandler):
+        requests = 0
+
+        def do_GET(self):
+            status, body = responses[min(type(self).requests, len(responses) - 1)]
+            type(self).requests += 1
+            self.send_response(status)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "download.tar.gz"
+            script = preamble + '''
+SPICE_HTTP_REQUEST_CLI="$1"
+MAX_RETRIES=3
+RETRY_DELAY=0
+downloadWithRetry "$2" "$3"
+'''
+            result = subprocess.run(
+                [
+                    "bash", "-c", script, "installer-download-test", client,
+                    f"http://127.0.0.1:{server.server_port}/runtime.tar.gz", str(output),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+            )
+            success = result.returncode == 0
+            assert success == expected_success, result.stdout + result.stderr
+            assert Handler.requests == expected_requests, (
+                f"Expected {expected_requests} requests, got {Handler.requests} "
+                f"(installer exit={result.returncode})"
+            )
+            if success:
+                with tarfile.open(output, "r:gz") as archive:
+                    assert archive.getnames() == ["fixture.txt"], "Unexpected archive contents"
+            return {"requests": Handler.requests, "exit_code": result.returncode}
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--client", choices=["curl", "wget"], required=True)
+    parser.add_argument(
+        "--installer",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "install/install-spiced.sh",
+    )
+    args = parser.parse_args()
+    preamble, marker, _main = args.installer.read_text().partition("\n# main\n")
+    assert marker, "Installer main marker is missing"
+    valid = archive_bytes()
+    cases = {
+        "valid_archive": ([(200, valid)], 1, True),
+        "http_error_then_archive": (
+            [(503, b"unavailable"), (503, b"unavailable"), (200, valid)], 3, True,
+        ),
+        "invalid_archive_then_archive": (
+            [(200, b"invalid"), (200, b"invalid"), (200, valid)], 3, True,
+        ),
+        "truncated_archive_then_archive": (
+            [(200, valid[:20]), (200, valid[:20]), (200, valid)], 3, True,
+        ),
+        "invalid_archive_exhausts_retries": ([(200, b"invalid")], 3, False),
+    }
+    for name, (responses, requests, success) in cases.items():
+        result = run_case(preamble, args.client, responses, requests, success)
+        print(json.dumps({"client": args.client, "case": name, **result}), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/scripts/install-download-test.py
+++ b/test/scripts/install-download-test.py
@@ -12,11 +12,12 @@ import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
-def archive_bytes():
+def archive_bytes(filename="spiced"):
     output = io.BytesIO()
     with tarfile.open(fileobj=output, mode="w:gz") as archive:
         content = b"installer download fixture\n"
-        entry = tarfile.TarInfo("fixture.txt")
+        entry = tarfile.TarInfo(filename)
+        entry.mode = 0o755
         entry.size = len(content)
         archive.addfile(entry, io.BytesIO(content))
     return output.getvalue()
@@ -67,7 +68,7 @@ downloadWithRetry "$2" "$3"
             )
             if success:
                 with tarfile.open(output, "r:gz") as archive:
-                    assert archive.getnames() == ["fixture.txt"], "Unexpected archive contents"
+                    assert [name.removeprefix("./") for name in archive.getnames()] == ["spiced"], "Unexpected archive contents"
             return {"requests": Handler.requests, "exit_code": result.returncode}
     finally:
         server.shutdown()
@@ -89,6 +90,11 @@ def main():
     valid = archive_bytes()
     cases = {
         "valid_archive": ([(200, valid)], 1, True),
+        "dot_prefixed_archive": ([(200, archive_bytes("./spiced"))], 1, True),
+        "missing_runtime_then_archive": (
+            [(200, archive_bytes("README")), (200, archive_bytes("README")), (200, valid)], 3, True,
+        ),
+        "missing_runtime_exhausts_retries": ([(200, archive_bytes("README"))], 3, False),
         "http_error_then_archive": (
             [(503, b"unavailable"), (503, b"unavailable"), (200, valid)], 3, True,
         ),

--- a/test/scripts/install-scripts-test.sh
+++ b/test/scripts/install-scripts-test.sh
@@ -312,15 +312,16 @@ test_artifacts_exist_in_latest_release() {
         "spice_linux_x86_64.tar.gz"
         "spice_linux_aarch64.tar.gz"
         "spice_darwin_aarch64.tar.gz"
+        "spice.exe_windows_x86_64.tar.gz"
         "spiced_linux_x86_64.tar.gz"
         "spiced_linux_aarch64.tar.gz"
         "spiced_darwin_aarch64.tar.gz"
-        "spiced_models_linux_x86_64.tar.gz"
-        "spiced_models_linux_aarch64.tar.gz"
-        "spiced_models_darwin_aarch64.tar.gz"
         "spiced_metal_darwin_aarch64.tar.gz"
-        "spiced.exe_windows_x86_64.tar.gz"
-        "spiced.exe_models_windows_x86_64.tar.gz"
+        "spiced_cuda_80_linux_x86_64.tar.gz"
+        "spiced_cuda_86_linux_x86_64.tar.gz"
+        "spiced_cuda_87_linux_x86_64.tar.gz"
+        "spiced_cuda_89_linux_x86_64.tar.gz"
+        "spiced_cuda_90_linux_x86_64.tar.gz"
     )
     
     local missing=0
@@ -684,7 +685,7 @@ test_live_download_url_resolves() {
     [[ "$response" == "200" ]]
 }
 
-test_live_spiced_models_linux_downloadable() {
+test_live_spiced_linux_downloadable() {
     if [[ "$LIVE_TESTS" != "true" ]]; then
         return 0
     fi
@@ -696,7 +697,7 @@ test_live_spiced_models_linux_downloadable() {
         return 1
     fi
     
-    local url="https://github.com/spiceai/spiceai/releases/download/${tag}/spiced_models_linux_x86_64.tar.gz"
+    local url="https://github.com/spiceai/spiceai/releases/download/${tag}/spiced_linux_x86_64.tar.gz"
     local response
     response=$(curl -sS -o /dev/null -w "%{http_code}" -L "$url" 2>/dev/null || echo "000")
     
@@ -982,7 +983,7 @@ run_all_tests() {
         echo "--- Live Network Tests ---"
         run_test "Latest release accessible" test_live_latest_release_accessible
         run_test "Download URL resolves" test_live_download_url_resolves
-        run_test "spiced_models_linux downloadable" test_live_spiced_models_linux_downloadable
+        run_test "spiced_linux downloadable" test_live_spiced_linux_downloadable
         run_test "All expected artifacts exist" test_artifacts_exist_in_latest_release
         echo ""
     fi

--- a/test/scripts/install-scripts-test.sh
+++ b/test/scripts/install-scripts-test.sh
@@ -602,36 +602,35 @@ test_cuda_version_invalid() {
 # Default Value Tests
 # =============================================================================
 
-test_default_variant_is_models() {
-    # Source the script in a subshell and check VARIANT default
+read_spiced_variant() {
+    local installer_preamble
+    installer_preamble=$(awk '
+        /^# main$/ { found = 1; exit }
+        { print }
+        END { if (!found) exit 1 }
+    ' "$INSTALL_SPICED_SCRIPT") || return 1
+    bash -c "$installer_preamble"$'\nprintf "%s" "$VARIANT"\n'
+}
+
+test_default_variant_is_empty() {
     local variant
-    variant=$(bash -c 'source /dev/stdin <<< "
-        : \${VARIANT:=\"models\"}
-        echo \$VARIANT
-    "')
-    [[ "$variant" == "models" ]]
+    variant=$(
+        unset VARIANT
+        read_spiced_variant
+    ) || return 1
+    [[ -z "$variant" ]]
 }
 
 test_variant_can_be_overridden() {
     local variant
-    variant=$(VARIANT="metal" bash -c '
-        : ${VARIANT:="models"}
-        echo $VARIANT
-    ')
+    variant=$(VARIANT="metal" read_spiced_variant) || return 1
     [[ "$variant" == "metal" ]]
 }
 
 test_variant_can_be_empty() {
     local variant
-    variant=$(VARIANT="" bash -c '
-        : ${VARIANT:="models"}
-        echo $VARIANT
-    ')
-    # When VARIANT is set to empty, :="models" will still set it to models
-    # because := checks for unset OR empty. To allow empty, use := vs :-
-    # The current script uses := so empty becomes "models"
-    # This test validates the current behavior
-    [[ "$variant" == "models" ]]
+    variant=$(VARIANT="" read_spiced_variant) || return 1
+    [[ -z "$variant" ]]
 }
 
 # =============================================================================
@@ -861,7 +860,7 @@ run_all_tests() {
     # Artifact Naming - Linux x86_64
     echo "--- Artifact Naming: Linux x86_64 ---"
     run_test "Linux x86_64 default artifact name" test_artifact_name_linux_x86_64_default
-    run_test "Linux x86_64 models artifact name" test_artifact_name_linux_x86_64_models
+    run_test "Legacy Linux x86_64 models artifact name" test_artifact_name_linux_x86_64_models
     run_test "Linux x86_64 CUDA 90 artifact name" test_artifact_name_linux_x86_64_cuda_90
     run_test "Linux x86_64 CUDA 89 artifact name" test_artifact_name_linux_x86_64_cuda_89
     run_test "Linux x86_64 CUDA 87 artifact name" test_artifact_name_linux_x86_64_cuda_87
@@ -872,20 +871,20 @@ run_all_tests() {
     # Artifact Naming - Linux aarch64
     echo "--- Artifact Naming: Linux aarch64 ---"
     run_test "Linux aarch64 default artifact name" test_artifact_name_linux_aarch64_default
-    run_test "Linux aarch64 models artifact name" test_artifact_name_linux_aarch64_models
+    run_test "Legacy Linux aarch64 models artifact name" test_artifact_name_linux_aarch64_models
     echo ""
     
     # Artifact Naming - macOS
     echo "--- Artifact Naming: macOS (darwin) ---"
     run_test "Darwin aarch64 default artifact name" test_artifact_name_darwin_aarch64_default
-    run_test "Darwin aarch64 models artifact name" test_artifact_name_darwin_aarch64_models
+    run_test "Legacy Darwin aarch64 models artifact name" test_artifact_name_darwin_aarch64_models
     run_test "Darwin aarch64 metal artifact name" test_artifact_name_darwin_aarch64_metal
     echo ""
     
     # Artifact Naming - Windows
     echo "--- Artifact Naming: Windows ---"
-    run_test "Windows x86_64 default artifact name" test_artifact_name_windows_x86_64_default
-    run_test "Windows x86_64 models artifact name" test_artifact_name_windows_x86_64_models
+    run_test "Legacy Windows x86_64 runtime artifact name" test_artifact_name_windows_x86_64_default
+    run_test "Legacy Windows x86_64 models artifact name" test_artifact_name_windows_x86_64_models
     echo ""
     
     # Artifact Naming - Spice CLI
@@ -948,7 +947,7 @@ run_all_tests() {
     
     # Default Values
     echo "--- Default Values ---"
-    run_test "Default variant is models" test_default_variant_is_models
+    run_test "Default variant has no archive suffix" test_default_variant_is_empty
     run_test "Variant can be overridden" test_variant_can_be_overridden
     run_test "Empty variant behavior" test_variant_can_be_empty
     echo ""
@@ -977,7 +976,7 @@ run_all_tests() {
     echo "--- Documentation ---"
     run_test "Naming convention documented" test_spiced_naming_convention_documented
     run_test "Empty variant documented" test_spiced_variant_empty_documented
-    run_test "Models variant documented" test_spiced_variant_models_documented
+    run_test "Model support documented" test_spiced_variant_models_documented
     run_test "Metal variant documented" test_spiced_variant_metal_documented
     run_test "CUDA variant documented" test_spiced_variant_cuda_documented
     echo ""

--- a/test/scripts/install-scripts-test.sh
+++ b/test/scripts/install-scripts-test.sh
@@ -12,7 +12,7 @@
 #   ./test/scripts/install-scripts-test.sh [--live] [--verbose]
 #
 # Options:
-#   --live      Run live download tests (requires network, slower)
+#   --live      Run live download tests (requires network and Python 3, slower)
 #   --verbose   Show detailed output for each test
 #
 # Exit codes:
@@ -48,6 +48,14 @@ NC='\033[0m' # No Color
 # =============================================================================
 # Utility Functions
 # =============================================================================
+
+github_api() {
+    local headers=(-H "Accept: application/vnd.github+json")
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        headers+=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    fi
+    curl --fail --silent --show-error "${headers[@]}" "$@"
+}
 
 log_info() {
     echo -e "${BLUE}[INFO]${NC} $*"
@@ -300,7 +308,8 @@ test_artifacts_exist_in_latest_release() {
     fi
     
     local release_assets
-    release_assets=$(curl -sS "https://api.github.com/repos/spiceai/spiceai/releases/latest" | grep '"name":' | grep -E "spice.*\.tar\.gz" || true)
+    release_assets=$(github_api "https://api.github.com/repos/spiceai/spiceai/releases/latest" |
+        python3 -c 'import json, sys; print(json.dumps([asset["name"] for asset in json.load(sys.stdin)["assets"]]))') || return 1
     
     if [[ -z "$release_assets" ]]; then
         log_verbose "Could not fetch release assets"
@@ -659,7 +668,8 @@ test_live_latest_release_accessible() {
     fi
     
     local response
-    response=$(curl -sS -o /dev/null -w "%{http_code}" "https://api.github.com/repos/spiceai/spiceai/releases/latest")
+    response=$(github_api -o /dev/null -w "%{http_code}" "https://api.github.com/repos/spiceai/spiceai/releases/latest") || return 1
+    log_verbose "Latest release HTTP status: $response"
     [[ "$response" == "200" ]]
 }
 
@@ -670,14 +680,15 @@ test_live_download_url_resolves() {
     
     # Get latest release tag
     local tag
-    tag=$(curl -sS "https://api.github.com/repos/spiceai/spiceai/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*: "\(.*\)",/\1/')
+    tag=$(github_api "https://api.github.com/repos/spiceai/spiceai/releases/latest" |
+        python3 -c 'import json, sys; print(json.load(sys.stdin)["tag_name"])') || return 1
     
     if [[ -z "$tag" ]]; then
         log_verbose "Could not get latest tag"
         return 1
     fi
     
-    # Check if a known artifact URL returns 302 (redirect to download)
+    # Follow the asset redirect and require a successful download.
     local url="https://github.com/spiceai/spiceai/releases/download/${tag}/spice_linux_x86_64.tar.gz"
     local response
     response=$(curl -sS -o /dev/null -w "%{http_code}" -L "$url" 2>/dev/null || echo "000")
@@ -691,7 +702,8 @@ test_live_spiced_linux_downloadable() {
     fi
     
     local tag
-    tag=$(curl -sS "https://api.github.com/repos/spiceai/spiceai/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*: "\(.*\)",/\1/')
+    tag=$(github_api "https://api.github.com/repos/spiceai/spiceai/releases/latest" |
+        python3 -c 'import json, sys; print(json.load(sys.stdin)["tag_name"])') || return 1
     
     if [[ -z "$tag" ]]; then
         return 1


### PR DESCRIPTION
## WHAT

Restore installer execution and coverage across Linux, macOS and Windows, including authenticated release lookup and download retries.

## WHY

Installer jobs failed on shell validation, obsolete archives, release lookup, Windows line endings and invalid download responses.

## HOW

Installer jobs use valid shell defaults, isolated paths and supported default/Metal artifacts. Runtime downloads authenticate through curl or wget and retry HTTP errors, corrupt archives and archives missing the root `spiced` executable. WSL uses pinned setup-wsl v7 and LF checkouts.

Validation:

- [The final-head installer matrix](https://github.com/spiceai/spiceai/actions/runs/34493280296) passes all 31 jobs. The Bash harness passes 73 local and 77 live checks, including all 13 published CLI/runtime archives.
- Both HTTP clients reject an invalid GitHub token and then install with the valid job token. A local HTTP server reproduces `Expected 3 requests, got 1 (installer exit=0)` for invalid archives before the fix; all eight scenarios per client pass afterward, covering recovery and retry exhaustion.
- Actionlint exits `0` after reproducing four invalid matrix-context errors on the baseline.

[The full installer lifecycle](https://github.com/spiceai/spiceai/actions/runs/34502636333) passes on hosted Linux x64, Linux ARM64, macOS ARM64 and Windows WSL: install v2.3.0, start and verify health/version, install v1.11.4, upgrade CLI/runtime to v2.0.0-rc.2, restart and clean up. The run fetches installer source at 77fdb20b55e91294f24148174fd073d317946a5c; the installer scripts and lifecycle workflow are identical on the release/2.3 fix.
