### PR TITLE
ci: honor configured load scale factors and query overrides on 2.3

### DIFF
--- a/.github/actions/setup-testoperator-data/action.yml
+++ b/.github/actions/setup-testoperator-data/action.yml
@@ -30,7 +30,17 @@ runs:
           echo "Error: scale_factor must be a positive number"
           exit 1
         fi
-        echo "directory_scale=${SCALE_FACTOR//./_}" >> "$GITHUB_OUTPUT"
+        scale_factor="$SCALE_FACTOR"
+        while [[ "$scale_factor" == 0[0-9]* ]]; do
+          scale_factor="${scale_factor#0}"
+        done
+        if [[ "$scale_factor" == *.* ]]; then
+          while [[ "$scale_factor" == *0 ]]; do
+            scale_factor="${scale_factor%0}"
+          done
+          scale_factor="${scale_factor%.}"
+        fi
+        echo "directory_scale=${scale_factor//./_}" >> "$GITHUB_OUTPUT"
 
     - name: Prepare file-based data directory (Linux/macOS)
       if: runner.os != 'Windows'

--- a/.github/actions/setup-testoperator-data/action.yml
+++ b/.github/actions/setup-testoperator-data/action.yml
@@ -12,10 +12,26 @@ inputs:
       - 'tpcds'
       - 'clickbench'
       - 'scenario'
+  scale_factor:
+    description: 'Scale factor of the fixture data'
+    required: false
+    default: '1'
 
 runs:
   using: 'composite'
   steps:
+    - name: Select fixture scale
+      id: scale
+      shell: bash
+      env:
+        SCALE_FACTOR: ${{ inputs.scale_factor }}
+      run: |
+        if [[ ! "$SCALE_FACTOR" =~ ^[0-9]+([.][0-9]+)?$ ]] || [[ -z "${SCALE_FACTOR//[0.]/}" ]]; then
+          echo "Error: scale_factor must be a positive number"
+          exit 1
+        fi
+        echo "directory_scale=${SCALE_FACTOR//./_}" >> "$GITHUB_OUTPUT"
+
     - name: Prepare file-based data directory (Linux/macOS)
       if: runner.os != 'Windows'
       shell: bash
@@ -38,7 +54,7 @@ runs:
       if: (inputs.query_set == 'tpch' || inputs.query_set == 'tpch[parameterized]' || inputs.query_set == 'scenario') && runner.os != 'Windows'
       run: |
         cd /opt/spiced/data
-        mc cp spice-minio/benchmarks/tpch_sf1/tpch.db ./
+        mc cp spice-minio/benchmarks/tpch_sf${{ steps.scale.outputs.directory_scale }}/tpch.db ./
 
     - name: Download DuckDB TPCH Data (Windows)
       shell: pwsh
@@ -46,14 +62,14 @@ runs:
       run: |
         $ErrorActionPreference = 'Stop'
         cd C:\spiced\data
-        mc cp spice-minio/benchmarks/tpch_sf1/tpch.db ./
+        mc cp spice-minio/benchmarks/tpch_sf${{ steps.scale.outputs.directory_scale }}/tpch.db ./
 
     - name: Download DuckDB TPCDS Data (Linux/macOS)
       shell: bash
       if: inputs.query_set == 'tpcds' && runner.os != 'Windows'
       run: |
         cd /opt/spiced/data
-        mc cp spice-minio/benchmarks/tpcds_sf1/tpcds.db ./
+        mc cp spice-minio/benchmarks/tpcds_sf${{ steps.scale.outputs.directory_scale }}/tpcds.db ./
 
     - name: Download DuckDB TPCDS Data (Windows)
       shell: pwsh
@@ -61,14 +77,14 @@ runs:
       run: |
         $ErrorActionPreference = 'Stop'
         cd C:\spiced\data
-        mc cp spice-minio/benchmarks/tpcds_sf1/tpcds.db ./
+        mc cp spice-minio/benchmarks/tpcds_sf${{ steps.scale.outputs.directory_scale }}/tpcds.db ./
 
     - name: Download File Connector TPCH Data (Linux/macOS)
       shell: bash
       if: (inputs.query_set == 'tpch' || inputs.query_set == 'tpch[parameterized]' || inputs.query_set == 'scenario') && runner.os != 'Windows'
       run: |
         cd /opt/spiced/data
-        mc cp --recursive spice-minio/benchmarks/tpch_sf1/ ./
+        mc cp --recursive spice-minio/benchmarks/tpch_sf${{ steps.scale.outputs.directory_scale }}/ ./
 
     - name: Download File Connector TPCH Data (Windows)
       shell: pwsh
@@ -76,14 +92,14 @@ runs:
       run: |
         $ErrorActionPreference = 'Stop'
         cd C:\spiced\data
-        mc cp --recursive spice-minio/benchmarks/tpch_sf1/ ./
+        mc cp --recursive spice-minio/benchmarks/tpch_sf${{ steps.scale.outputs.directory_scale }}/ ./
 
     - name: Download File Connector TPCDS Data (Linux/macOS)
       shell: bash
       if: inputs.query_set == 'tpcds' && runner.os != 'Windows'
       run: |
         cd /opt/spiced/data
-        mc cp --recursive spice-minio/benchmarks/tpcds_sf1/ ./
+        mc cp --recursive spice-minio/benchmarks/tpcds_sf${{ steps.scale.outputs.directory_scale }}/ ./
         mkdir ./sf0_01
         cd ./sf0_01
         mc cp --recursive spice-minio/benchmarks/tpcds_sf0_01/ ./
@@ -94,7 +110,7 @@ runs:
       run: |
         $ErrorActionPreference = 'Stop'
         cd C:\spiced\data
-        mc cp --recursive spice-minio/benchmarks/tpcds_sf1/ ./
+        mc cp --recursive spice-minio/benchmarks/tpcds_sf${{ steps.scale.outputs.directory_scale }}/ ./
         New-Item -ItemType Directory -Force -Path .\sf0_01 | Out-Null
         cd .\sf0_01
         mc cp --recursive spice-minio/benchmarks/tpcds_sf0_01/ ./

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -53,6 +53,16 @@ on:
           - 'postgres-catalog'
           - 'mysql-catalog'
           - 'mssql-catalog'
+          - 'arrow'
+          - 'bigquery'
+          - 'dynamodb'
+          - 'scylladb'
+          - 'turso'
+      scale_factor:
+        description: 'Scale factor for the data and queries'
+        required: false
+        type: string
+        default: '1'
       runner_type:
         description: 'Runner type'
         required: true
@@ -93,11 +103,24 @@ jobs:
 
       - name: Set spicepod path
         id: set_spicepod_path
+        env:
+          QUERY_SET: ${{ github.event.inputs.query_set }}
+          SCALE_FACTOR: ${{ github.event.inputs.scale_factor }}
+          SPICEPOD_FILE: ${{ github.event.inputs.spicepod_path }}
         run: |
-          query_set="${{ github.event.inputs.query_set }}"
+          if [[ ! "$SCALE_FACTOR" =~ ^[0-9]+([.][0-9]+)?$ ]] || [[ -z "${SCALE_FACTOR//[0.]/}" ]]; then
+            echo "Error: scale_factor must be a positive number"
+            exit 1
+          fi
+          query_set="$QUERY_SET"
           query_set="${query_set%%\[*\]*}"
-          SPICEPOD_PATH="./test/spicepods/${query_set}/sf1/${{ github.event.inputs.spicepod_path }}"
-          echo "SPICEPOD_PATH=${SPICEPOD_PATH}" >> $GITHUB_OUTPUT
+          fixture_scale="${SCALE_FACTOR//./_}"
+          SPICEPOD_PATH="./test/spicepods/${query_set}/sf${fixture_scale}/${SPICEPOD_FILE}"
+          {
+            echo "SPICEPOD_PATH=${SPICEPOD_PATH}"
+            echo "query_set=${query_set}"
+            echo "fixture_scale=${fixture_scale}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Validate spicepod file exists
         run: |
@@ -141,13 +164,15 @@ jobs:
         uses: ./.github/actions/setup-testoperator-data
         with:
           query_set: ${{ github.event.inputs.query_set }}
+          scale_factor: ${{ github.event.inputs.scale_factor }}
 
       - name: Setup MySQL
+        env:
+          QUERY_SET: ${{ steps.set_spicepod_path.outputs.query_set }}
+          FIXTURE_SCALE: ${{ steps.set_spicepod_path.outputs.fixture_scale }}
         run: |
-          if [[ ${{ github.event.inputs.query_set }} == "tpcds" ]]; then
-            echo "MYSQL_DB=tpcds_sf1" >> $GITHUB_ENV
-          elif [[ ${{ github.event.inputs.query_set }} == "tpch" ]]; then
-            echo "MYSQL_DB=tpch_sf1" >> $GITHUB_ENV
+          if [[ "$QUERY_SET" == "tpcds" || "$QUERY_SET" == "tpch" ]]; then
+            echo "MYSQL_DB=${QUERY_SET}_sf${FIXTURE_SCALE}" >> "$GITHUB_ENV"
           fi
 
       - name: Install OpenMP runtime library
@@ -163,6 +188,7 @@ jobs:
             -p ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }} \
             -d /opt/spiced/data \
             --query-set ${{ github.event.inputs.query_set }} \
+            --scale-factor "$TEST_SCALE_FACTOR" \
             --ready-wait 900 \
             --disable-progress-bars \
             --duration ${{ github.event.inputs.duration }} \
@@ -173,6 +199,7 @@ jobs:
             ${{ github.event.inputs.scrape_spiced_metrics == 'true' && '--scrape-spiced-metrics' || '' }} \
             --metrics
         env:
+          TEST_SCALE_FACTOR: ${{ github.event.inputs.scale_factor }}
           S3_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT}}
           S3_KEY: ${{ secrets.TEST_MINIO_ACCESS_KEY}}
           S3_SECRET: ${{ secrets.TEST_MINIO_SECRET_KEY}}

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -114,7 +114,17 @@ jobs:
           fi
           query_set="$QUERY_SET"
           query_set="${query_set%%\[*\]*}"
-          fixture_scale="${SCALE_FACTOR//./_}"
+          scale_factor="$SCALE_FACTOR"
+          while [[ "$scale_factor" == 0[0-9]* ]]; do
+            scale_factor="${scale_factor#0}"
+          done
+          if [[ "$scale_factor" == *.* ]]; then
+            while [[ "$scale_factor" == *0 ]]; do
+              scale_factor="${scale_factor%0}"
+            done
+            scale_factor="${scale_factor%.}"
+          fi
+          fixture_scale="${scale_factor//./_}"
           SPICEPOD_PATH="./test/spicepods/${query_set}/sf${fixture_scale}/${SPICEPOD_FILE}"
           {
             echo "SPICEPOD_PATH=${SPICEPOD_PATH}"

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -190,6 +190,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgomp1
 
+      - name: Install ADBC BigQuery Driver
+        if: ${{ contains(github.event.inputs.spicepod_path, 'adbc[bigquery]') }}
+        uses: ./.github/actions/setup-adbc-bigquery
+
       - name: Run the load test - ${{ github.event.inputs.spicepod_path }}
         run: |
           rm -rf .spice/data
@@ -215,6 +219,7 @@ jobs:
           S3_SECRET: ${{ secrets.TEST_MINIO_SECRET_KEY}}
           DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          BIGQUERY_SERVICE_ACCOUNT_JSON: ${{ secrets.BIGQUERY_SERVICE_ACCOUNT_JSON }}
           DATABRICKS_ENDPOINT: ${{ vars.DATABRICKS_ENDPOINT }}
           DATABRICKS_CLUSTER_ID: ${{ vars.DATABRICKS_CLUSTER_ID }}
           DATABRICKS_SQL_WAREHOUSE_ID: ${{ vars.DATABRICKS_SQL_WAREHOUSE_ID }}


### PR DESCRIPTION
## WHAT
Backport the load workflow fixes to `release/2.3` (OSS #14027; Enterprise #1538). Make configured OSS load tests accept their query overrides and use the requested scale for the Spicepod, local fixtures, MySQL database and query generation. Add matching support for scale factors in the shared fixture action, defaulting to SF1.

## WHY
GitHub rejects configured loads with HTTP 422, and the existing path-selection step chooses SF1 even when the configuration requests SF10.

## HOW
Accept the five configured overrides missing from the load workflow and pass the scale through the existing testoperator interface; validate positive numeric scales before selecting fixture paths. Other fixture-action callers keep the SF1 default.

Reproduction on current trunk: GitHub returns `Unexpected inputs provided: ["scale_factor"]` for the OSS SF10 load and `Provided value 'turso' for input 'query_overrides' not in the list of allowed values` for the Enterprise Turso load. Neither rejected dispatch starts a runner.

Validation: the 89-configuration OSS load contract audit changes from 13 rejected input selections to zero, accounting for the custom deserializer that removes `ready_wait`. Executing the actual path-selection Bash step chooses `tpch/sf1` before and `tpch/sf10` after for the same SF10 request; both selected Spicepods exist. Numeric fixture selection passes SF1, SF10 and SF0.01 and rejects zero, negative and malformed values. Actionlint reports only the pre-existing empty-choice diagnostic. Remote fixture availability and runtime load execution are pending serialized CI capacity.

Normalize equivalent decimal spellings before selecting fixtures: `1.0` and `01.000` map to `sf1`, `0010.00` maps to `sf10`, and `000.0100` maps to `sf0_01`. Before this change, executing the actual path step selected nonexistent `sf1_0` for `1.0`; afterward it selects the existing SF1 Spicepod. All 30 positive/negative cases pass across the actual workflow and fixture-action Bash steps on this branch.

Install the same pinned BigQuery ADBC driver used by benchmarks before BigQuery load tests, and pass the service-account configuration to each load invocation. [The driver probe](https://github.com/spicehq/spiceai/actions/runs/34491449925) confirms the runner starts without the driver, then successfully loads its installed ADBC entrypoint. The previous [Enterprise throughput run](https://github.com/spicehq/spiceai/actions/runs/34424879193) failed with `Driver not found: bigquery`; a runtime throughput rerun remains pending.
