### PR TITLE
endgame: include spiceai/skills versioned release

### DIFF
--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -237,6 +237,7 @@ Testing focus DRIs are responsible for:
   - [ ] [spice-java](https://github.com/spiceai/spice-java/releases)
   - [ ] [spice-dotnet](https://github.com/spiceai/spice-dotnet/releases)
   - [ ] [gospice](https://github.com/spiceai/gospice/releases)
+  - [ ] [spiceai/skills](https://github.com/spiceai/skills/releases) — version must match runtime (e.g. `2.3.0` / tag `v2.3.0`)
 
 - [ ] [Generate Spicepod JSON schema](https://github.com/spiceai/spiceai/actions/workflows/generate_json_schema.yml) and cherry-pick schema update PR onto the release branch.
 
@@ -256,6 +257,7 @@ Testing focus DRIs are responsible for:
 - [ ] When binaries are built for the release, edit the GitHub release and select **“Set as latest release”** to trigger the [spiced_docker workflow](https://github.com/spiceai/spiceai/actions/workflows/spiced_docker.yml) so Docker images are built from the published artifacts.
   - [ ] Monitor the spiced_docker workflow (and re-run with **workflow_dispatch** using `release_tag` and optional `target` overrides if a rebuild or partial rebuild is required).
 - [ ] Ensure all newly released SDKs (mentioned in release notes) are published
+- [ ] Publish [spiceai/skills](https://github.com/spiceai/skills) GitHub Release for this runtime version (bump `.claude-plugin/plugin.json` + `marketplace.json` version to match runtime; tag `vX.Y.Z`; confirm [Release Plugin](https://github.com/spiceai/skills/actions/workflows/release.yml) uploaded the zip asset)
 - [ ] Update the [Helm chart](https://github.com/spiceai/spiceai/blob/trunk/deploy/chart) (chart version e.g. `1.8.3` & image.tag e.g. `1.8.3-models`) in the release branch (not in trunk).
   - [ ] If this is a **minor** release, replace the `ghcr.io/spiceai/spiceai-nightly` repository in `values.yaml` with `spiceai/spiceai` and change the tag to the release version (e.g. `1.0.0`).
   - [ ] [Release Chart workflow](https://github.com/spiceai/helm-charts/actions/workflows/release.yml) is triggered using the release branch.
@@ -277,6 +279,7 @@ Testing focus DRIs are responsible for:
 - [ ] Update [brew taps](https://github.com/spiceai/homebrew-spiceai/actions/workflows/update-formula.yml) after the final build completes.
 - [ ] Remove or mark the released version in the [ROADMAP](https://github.com/spiceai/spiceai/blob/trunk/docs/ROADMAP.md).
 - [ ] Update the supported version in `SECURITY.md` if necessary.
+- [ ] Confirm docs/install refs for Skills point at the matching release (or trunk if intentional).
 - [ ] QA DRI: Run SpiceQA via [Github Action](https://github.com/spiceai/cookbook/actions/workflows/spice-qa.yml), with the correct `input.spice_version`.
   - [ ] Build new `spiced` & `spiced-internal` images in Spice.ai Cloud Platform (SCP).
   - [ ] Redeploy the SpiceQA app in the Spice.ai Cloud Platform (SCP). Ensure the deployment is successful.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Summary

Adds `spiceai/skills` release checklist items to the OSS Milestone Endgame template so the plugin is versioned and published with the runtime.

New unchecked items in `.github/ISSUE_TEMPLATE/end_game.md`:

- **Release notes**: sibling of the SDK list — link [spiceai/skills releases](https://github.com/spiceai/skills/releases) and require the version to match the runtime (e.g. `2.3.0` / tag `v2.3.0`).
- **Release Publication Steps**: publish a [spiceai/skills](https://github.com/spiceai/skills) GitHub Release for this runtime version (bump `.claude-plugin/plugin.json` + `marketplace.json`; tag `vX.Y.Z`; confirm [Release Plugin](https://github.com/spiceai/skills/actions/workflows/release.yml) uploaded the zip asset).
- **Post-Release Housekeeping**: confirm docs/install refs for Skills point at the matching release (or trunk if intentional).

`docs/RELEASE.md` already points at the Endgame issue and does not list SDKs, so no cross-reference was added. Enterprise templates are unchanged.

## 📚 Docs

Process-only: the OSS Milestone Endgame issue template. No user-facing docs or recipes.

## 👀 Notes for Reviewers

Markdown style matches neighboring checklist bullets. No Enterprise template changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bfbb2dc-4538-4529-af37-c1466f5f92c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bfbb2dc-4538-4529-af37-c1466f5f92c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

