### PR TITLE
fix(runtime): write the inferred Arrow sort order under the prefixed key its validation accepts (fixes #14023)

### DIFF
--- a/crates/runtime-component/src/dataset/schema_inference.rs
+++ b/crates/runtime-component/src/dataset/schema_inference.rs
@@ -225,17 +225,23 @@ fn apply_inferred_sort(
         return false;
     }
 
+    // Each key is the *external* spelling the engine's parameter validation
+    // accepts: a `ParameterSpec::component` param must carry the engine prefix
+    // (`arrow_sort_columns`, `cayenne_sort_columns`), while DuckDB's
+    // `on_refresh_sort_columns` is a `ParameterSpec::runtime` param and takes
+    // none. An unprefixed component key is dropped by `runtime_parameters` with a
+    // user-facing warning about a parameter the user never wrote (#14023).
     let engine = acceleration.engine.to_unpartitioned();
     let key = match engine {
         Engine::DuckDB => "on_refresh_sort_columns",
-        Engine::Arrow => "sort_columns",
+        Engine::Arrow => "arrow_sort_columns",
         Engine::Cayenne => "cayenne_sort_columns",
         // Sqlite / Turso / PostgreSQL accelerators have no sort param.
         _ => return false,
     };
 
     // For `refresh_mode: changes`, skip engines whose sort param drives the
-    // refresh itself (DuckDB `on_refresh_sort_columns`, Arrow `sort_columns`): a
+    // refresh itself (DuckDB `on_refresh_sort_columns`, Arrow `arrow_sort_columns`): a
     // refresh-time sort is a no-op for a change stream and risks perturbing the
     // initial snapshot. Cayenne is the exception — `cayenne_sort_columns` sorts
     // the background compaction rewrite, not the change stream (which stays
@@ -245,11 +251,15 @@ fn apply_inferred_sort(
         return false;
     }
 
-    // Respect any user-configured sort param (Cayenne also accepts `sort_columns`).
-    // Checked before the DuckDB constraint guard below so an explicitly-sorted
-    // dataset is reported as user-configured, not as a constraint-preservation skip.
+    // Respect any user-configured sort param. Cayenne and Arrow also read the
+    // unprefixed `sort_columns` straight from the acceleration params, so a user
+    // who wrote that spelling has configured a sort even though validation warns
+    // about the missing prefix. Checked before the DuckDB constraint guard below
+    // so an explicitly-sorted dataset is reported as user-configured, not as a
+    // constraint-preservation skip.
     let user_configured = acceleration.params.contains_key(key)
-        || (engine == Engine::Cayenne && acceleration.params.contains_key("sort_columns"));
+        || (matches!(engine, Engine::Cayenne | Engine::Arrow)
+            && acceleration.params.contains_key("sort_columns"));
     if user_configured {
         return false;
     }
@@ -801,9 +811,41 @@ mod tests {
             RefreshMode::Full,
         );
         assert_eq!(
-            acc.params.get("sort_columns").map(String::as_str),
+            acc.params.get("arrow_sort_columns").map(String::as_str),
             Some("created_at DESC, id ASC")
         );
+        // The unprefixed spelling is what Arrow's parameter validation rejects
+        // with a warning; inference must never write it (#14023).
+        assert!(!acc.params.contains_key("sort_columns"));
+    }
+
+    #[test]
+    fn arrow_respects_user_sort_param_in_either_spelling() {
+        // `arrow_sort_columns` is the validated spelling; the Arrow accelerator
+        // also reads a bare `sort_columns` from the acceleration params, so both
+        // count as user-configured and neither is overridden by inference.
+        for user_key in ["arrow_sort_columns", "sort_columns"] {
+            let mut acc = accel(Engine::Arrow);
+            acc.params
+                .insert(user_key.to_string(), "custom".to_string());
+            let inferred = InferredSchema {
+                sort_columns: vec![sort("created_at", true)],
+                ..InferredSchema::default()
+            };
+            apply_inferred_schema(
+                &mut acc,
+                &inferred,
+                &schema(&["created_at"]),
+                "ds",
+                RefreshMode::Full,
+            );
+            assert_eq!(acc.params.len(), 1, "user key {user_key}");
+            assert_eq!(
+                acc.params.get(user_key).map(String::as_str),
+                Some("custom"),
+                "user key {user_key}"
+            );
+        }
     }
 
     #[test]

--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -156,3 +156,68 @@ impl DataAccelerator for ArrowAccelerator {
 }
 
 data_accelerator_api::register_data_accelerator!(Engine::Arrow, ArrowAccelerator);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::dataset::acceleration::Acceleration;
+    use crate::component::dataset::schema_inference::apply_inferred_schema;
+    use crate::parameters::Parameters;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use data_components::inferred_schema::{InferredSchema, InferredSortColumn};
+    use runtime_secrets::{Secrets, get_params_with_secrets};
+    use tokio::sync::RwLock;
+
+    /// Regression test for #14023: the sort order schema inference writes into
+    /// the acceleration params must be spelled the way this accelerator's
+    /// parameter validation accepts it. An unprefixed `sort_columns` is dropped
+    /// by `Parameters::try_new` with a warning about a parameter the user never
+    /// wrote, so this drives the inferred params through the same validation the
+    /// runtime applies before the table is created.
+    #[tokio::test]
+    async fn inferred_sort_columns_survive_arrow_parameter_validation() {
+        let mut acceleration = Acceleration {
+            engine: Engine::Arrow,
+            ..Acceleration::default()
+        };
+        let inferred = InferredSchema {
+            sort_columns: vec![InferredSortColumn {
+                column: "id".to_string(),
+                desc: false,
+                nulls_first: None,
+            }],
+            ..InferredSchema::default()
+        };
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        apply_inferred_schema(
+            &mut acceleration,
+            &inferred,
+            &schema,
+            "ds",
+            RefreshMode::Full,
+        );
+
+        // The same conversion and validation the runtime applies before it
+        // creates the accelerated table.
+        let accelerator = ArrowAccelerator::new();
+        let secrets = Arc::new(RwLock::new(Secrets::new()));
+        let params_with_secrets =
+            get_params_with_secrets(Arc::clone(&secrets), &acceleration.params).await;
+        let params = Parameters::try_new(
+            "accelerator arrow",
+            params_with_secrets.into_iter().collect(),
+            accelerator.prefix(),
+            secrets,
+            accelerator.parameters(),
+        )
+        .await
+        .expect("inferred acceleration params validate");
+
+        let sort_columns = params
+            .get("sort_columns")
+            .expose()
+            .ok()
+            .expect("inferred sort order must survive parameter validation");
+        assert_eq!(sort_columns, "id ASC");
+    }
+}


### PR DESCRIPTION
## Summary

When a PostgreSQL dataset is accelerated with the default Arrow accelerator, schema inference fills the acceleration's sort order from the source's clustered index or primary key and writes it into the acceleration params under the key `sort_columns`. Arrow registers `sort_columns` as a `ParameterSpec::component` parameter, and component parameters are only accepted in their prefixed external spelling, so `runtime_parameters` dropped the inferred key with a warning about a parameter the user never wrote:

```
WARN runtime_parameters: Ignoring parameter sort_columns: must be prefixed with `arrow_` for accelerator arrow.
```

The Arrow accelerator separately reads a bare `sort_columns` straight from the raw acceleration params when it builds the table, so the inferred sort was still applied; the user-visible defect is the misleading warning on every startup of an accelerated PostgreSQL dataset, which the runtime's own configuration handling produced and no Spicepod change can silence.

Schema inference now writes the spelling the engine's validation accepts (`arrow_sort_columns`), matching how it already spells the Cayenne key (`cayenne_sort_columns`) and DuckDB's unprefixed runtime param (`on_refresh_sort_columns`). A user-configured sort in either spelling (`arrow_sort_columns`, or the bare `sort_columns` the accelerator also honours) is still respected and never overridden.

## Changes

- `crates/runtime-component/src/dataset/schema_inference.rs`: the Arrow key is `arrow_sort_columns`; the user-configured check for Arrow also recognises a bare `sort_columns`, as it already did for Cayenne.
- `crates/runtime/src/dataaccelerator/arrow.rs`: a regression test that runs the inferred Arrow params through `Parameters::try_new` with the accelerator's own `ParameterSpec`s and prefix, so the inference/validation boundary is exercised in one test rather than each side asserting its own spelling.
- Unit tests in `schema_inference.rs` updated to the new key, plus one asserting both user spellings are respected.

No user-facing surface changes: the accepted parameter spellings, the log wording, and the applied sort order are unchanged; the fix removes a warning that reported a condition the user never created.

## Test plan

Reproduction: a PostgreSQL 16 container holding one table with a primary key (`id INT PRIMARY KEY, name TEXT, score INT`, four rows inserted out of key order: 3, 1, 4, 2), and a Spicepod declaring it as a `postgres` dataset with `acceleration: {enabled: true, refresh_mode: full}` and no `params` under `acceleration` (the shape of the cookbook Supabase recipe the issue reproduces from). Same Spicepod, same command (`spiced --http 127.0.0.1:18090 …` with `SPICED_LOG='info,runtime_component=debug,runtime::init=debug'`), two binaries.

**Before** — `spiced` built from `4eb1bb7eca` (trunk `e10aa9f2fc` plus 7 commits, none touching schema inference or parameter validation):

```
2026-09-10T14:35:33.008189Z DEBUG runtime_component::dataset::schema_inference: Applied schema inference to acceleration settings dataset=spice_test indexes=0 sort_applied=true shard_key_applied=false
2026-09-10T14:35:33.008502Z  WARN runtime_parameters: Ignoring parameter sort_columns: must be prefixed with `arrow_` for accelerator arrow.
2026-09-10T14:35:33.036325Z  INFO runtime_table::accelerated::refresh_task: Loaded 4 rows (13.31 kiB) for dataset spice_test in 23ms.
2026-09-10T14:35:33.113771Z  INFO runtime: All components are loaded. Spice runtime is ready!
```

`SELECT id, name FROM spice_test`:

```
[{"id":1,"name":"alpha"},{"id":2,"name":"beta"},{"id":3,"name":"gamma"},{"id":4,"name":"delta"}]
```

The warning names a parameter the Spicepod does not contain. The rows come back in key order, and the `sort_applied=true` line shows the inferred sort was applied regardless: the Arrow accelerator reads the bare key straight from the acceleration params, so validation dropped it and the accelerator honoured it, and the user got a warning about neither.

**After** — this branch (`cargo build -p spiced`, dev profile), same command:

```
2026-09-10T15:50:11.564126Z DEBUG runtime_component::dataset::schema_inference: Applied schema inference to acceleration settings dataset=spice_test indexes=0 sort_applied=true shard_key_applied=false
2026-09-10T15:50:11.579139Z  INFO runtime_table::accelerated::refresh_task: Loaded 4 rows (13.31 kiB) for dataset spice_test in 12ms.
2026-09-10T15:50:11.670738Z  INFO runtime: All components are loaded. Spice runtime is ready!
```

`SELECT id, name FROM spice_test`:

```
[{"id":1,"name":"alpha"},{"id":2,"name":"beta"},{"id":3,"name":"gamma"},{"id":4,"name":"delta"}]
```

No warning; the inference line and the rows are unchanged.

Regression test on `trunk`'s `schema_inference.rs` (only the test module added), then on this branch:

```
$ cargo test -p runtime --lib dataaccelerator::arrow::tests
test dataaccelerator::arrow::tests::inferred_sort_columns_survive_arrow_parameter_validation ... FAILED
---- dataaccelerator::arrow::tests::inferred_sort_columns_survive_arrow_parameter_validation stdout ----
thread 'dataaccelerator::arrow::tests::inferred_sort_columns_survive_arrow_parameter_validation' (3767942) panicked at crates/runtime/src/dataaccelerator/arrow.rs:220:14:
inferred sort order must survive parameter validation
    dataaccelerator::arrow::tests::inferred_sort_columns_survive_arrow_parameter_validation
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1308 filtered out; finished in 0.12s
```

```
$ cargo test -p runtime --lib dataaccelerator::arrow::tests   # this branch
test dataaccelerator::arrow::tests::inferred_sort_columns_survive_arrow_parameter_validation ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1308 filtered out

$ cargo test -p runtime-component --lib schema_inference
test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 41 filtered out
```

- [x] `make lint`
- [x] `make test` / `make nextest` (via `make signoff`: lint + 12985 tests passed locally in 15190s on `774549ab03`)

## Review gate

- Adversarial review: `codex` — job `review-mtvpzud0-1xlv3x` — verdict approve, no findings (an earlier pass on the pre-`/simplify` head, job `review-mtvpkkq9-6wl04z`, also approved with no findings)
- `/security-review`: no findings (the diff changes which acceleration-params key inference writes and adds a test; the value is built only from schema column names and `ASC`/`DESC` and never reaches SQL, a path, or a log)
- `/simplify`: applied — the regression test now uses `get_params_with_secrets`, the same conversion the runtime applies before `Parameters::try_new`; `cargo fmt` and the test re-run green

Fixes #14023

## Checklist

- [x] Root cause described, not just the symptom
- [x] Regression test that fails on `trunk` and passes here, crossing the inference/validation boundary
- [x] Before/after artifact from a real `spiced` run with the same Spicepod and command
- [x] No user-facing surface change