### PR TITLE
perf(vortex): defer projection setup on filtered scans until the filter resolves

### DIFF
--- a/crates/vortex/src/persistent/deferred_projection.rs
+++ b/crates/vortex/src/persistent/deferred_projection.rs
@@ -375,6 +375,11 @@ mod tests {
 
         fn assert_bytes_under(&self, budget: u64, what: &str) {
             assert!(
+                self.bytes_read > 0,
+                "{what} reported zero bytes read, so the {budget}-byte budget below would \
+                 pass without the scan having done any I/O"
+            );
+            assert!(
                 self.bytes_read < budget,
                 "{what} read {} bytes of a {}-byte file in {} reads, over the {budget}-byte \
                  budget: projection setup is running before the filter resolves",
@@ -460,25 +465,37 @@ mod tests {
                 rows: batches.iter().map(RecordBatch::num_rows).sum(),
                 first_value,
                 first_row,
-                bytes_read: sum_metric(plan.as_ref(), "vortex.io.read.total_size"),
-                reads: sum_metric(plan.as_ref(), "vortex.io.read.size_count"),
+                bytes_read: sum_metric(plan.as_ref(), "vortex.io.read.total_size")?,
+                reads: sum_metric(plan.as_ref(), "vortex.io.read.size_count")?,
                 file_bytes: self.file_bytes,
             })
         }
     }
 
     /// Sums one Vortex counter across every Vortex scan in `plan`.
-    fn sum_metric(plan: &dyn ExecutionPlan, metric_name: &str) -> u64 {
-        VortexMetricsFinder::find_all(plan)
-            .iter()
-            .flat_map(MetricsSet::iter)
-            .filter_map(|metric| match metric.value() {
-                MetricValue::Count { name, count } if name == metric_name => {
-                    Some(count.value() as u64)
-                }
-                _ => None,
-            })
-            .sum()
+    ///
+    /// Errors when no scan reported the counter at all, rather than summing to zero: a
+    /// budget compared against a metric that stopped being collected — renamed upstream, or
+    /// no longer reachable from the plan — would pass no matter how much the scan read.
+    fn sum_metric(plan: &dyn ExecutionPlan, metric_name: &str) -> anyhow::Result<u64> {
+        let sets = VortexMetricsFinder::find_all(plan);
+        let mut total = 0u64;
+        let mut found = false;
+        for metric in sets.iter().flat_map(MetricsSet::iter) {
+            if let MetricValue::Count { name, count } = metric.value()
+                && name == metric_name
+            {
+                total += count.value() as u64;
+                found = true;
+            }
+        }
+        anyhow::ensure!(
+            found,
+            "no Vortex scan reported `{metric_name}`, so this measurement is not measuring \
+             anything; {} metric set(s) were found on the plan",
+            sets.len()
+        );
+        Ok(total)
     }
 
     #[tokio::test]

--- a/crates/vortex/src/persistent/deferred_projection.rs
+++ b/crates/vortex/src/persistent/deferred_projection.rs
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use vortex::array::MaskFuture;
+use vortex::dtype::DType;
+use vortex::dtype::FieldMask;
+use vortex::error::VortexResult;
+use vortex::expr::Expression;
+use vortex::layout::ArrayFuture;
+use vortex::layout::LayoutReader;
+use vortex::layout::RowSplits;
+use vortex::layout::SplitRange;
+use vortex::mask::Mask;
+
+/// Defers projection setup, and the segment reads it registers, until the scan's filter
+/// has resolved.
+///
+/// Vortex builds each split's task by calling `projection_evaluation` up front and only
+/// then awaiting the filter mask, discarding the projection future when the mask comes
+/// back all-false. Building the projection is not free: it walks the layout to construct
+/// the output columns' readers and calls `SegmentSource::request` for each of their
+/// segments. A registered-but-never-polled request is never dispatched on its own, but it
+/// stays in the read driver's spatial index, where the coalescer will pull it into a
+/// neighbouring physical read — so the output columns of a split that matches nothing can
+/// still be fetched from storage.
+///
+/// Wrapping the root reader moves that work behind the mask: the inner
+/// `projection_evaluation` runs only once a caller polls the returned future, which the
+/// scan does only for splits that survive the filter.
+///
+/// Only applied to filtered scans. Without a filter every split's mask is already
+/// resolved, so there is nothing to defer, and the eager registration is what lets the
+/// coalescer merge the projection reads of adjacent splits.
+pub(crate) struct DeferredProjectionReader {
+    inner: Arc<dyn LayoutReader>,
+}
+
+impl DeferredProjectionReader {
+    pub(crate) fn new(inner: Arc<dyn LayoutReader>) -> Self {
+        Self { inner }
+    }
+}
+
+impl LayoutReader for DeferredProjectionReader {
+    fn name(&self) -> &Arc<str> {
+        self.inner.name()
+    }
+
+    /// Reports the wrapper, not the reader it wraps: a caller that downcasts to a concrete
+    /// layout reader must not be handed one whose projection is no longer deferred.
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn dtype(&self) -> &DType {
+        self.inner.dtype()
+    }
+
+    fn row_count(&self) -> u64 {
+        self.inner.row_count()
+    }
+
+    fn register_splits(
+        &self,
+        field_mask: &[FieldMask],
+        split_range: &SplitRange,
+        splits: &mut RowSplits,
+    ) -> VortexResult<()> {
+        self.inner.register_splits(field_mask, split_range, splits)
+    }
+
+    fn pruning_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: Mask,
+    ) -> VortexResult<MaskFuture> {
+        self.inner.pruning_evaluation(row_range, expr, mask)
+    }
+
+    fn filter_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<MaskFuture> {
+        self.inner.filter_evaluation(row_range, expr, mask)
+    }
+
+    fn projection_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<ArrayFuture> {
+        let inner = Arc::clone(&self.inner);
+        let row_range = row_range.clone();
+        let expr = expr.clone();
+        Ok(Box::pin(async move {
+            // `MaskFuture` is a shared future, so awaiting this clone resolves against the
+            // same filter evaluation the scan awaits before it polls us.
+            let mask = mask.await?;
+            inner
+                .projection_evaluation(&row_range, &expr, MaskFuture::ready(mask))?
+                .await
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use datafusion::arrow::array::RecordBatch;
+    use datafusion::arrow::util::display::array_value_to_string;
+    use datafusion_execution::TaskContext;
+    use datafusion_physical_plan::ExecutionPlan;
+    use datafusion_physical_plan::collect;
+    use datafusion_physical_plan::metrics::MetricValue;
+    use datafusion_physical_plan::metrics::MetricsSet;
+    use futures::TryStreamExt;
+    use object_store::ObjectStoreExt;
+    use vortex::VortexSessionDefault;
+    use vortex::array::IntoArray;
+    use vortex::array::VortexSessionExecute;
+    use vortex::array::arrays::ChunkedArray;
+    use vortex::array::arrays::StructArray;
+    use vortex::array::arrays::VarBinArray;
+    use vortex::array::validity::Validity;
+    use vortex::buffer::Buffer;
+    use vortex::buffer::buffer;
+    use vortex::error::vortex_err;
+    use vortex::expr::gt;
+    use vortex::expr::lit;
+    use vortex::expr::root;
+    use vortex::file::WriteOptionsSessionExt;
+    use vortex::io::VortexWrite;
+    use vortex::io::object_store::ObjectStoreWrite;
+    use vortex::layout::scan::scan_builder::ScanBuilder;
+    use vortex::scalar::Scalar;
+    use vortex::session::VortexSession;
+
+    use super::*;
+    use crate::common_tests::TestSessionContext;
+    use crate::persistent::metrics::VortexMetricsFinder;
+
+    struct CountingReader {
+        name: Arc<str>,
+        dtype: DType,
+        projection_calls: Arc<AtomicUsize>,
+        reject: bool,
+    }
+
+    impl LayoutReader for CountingReader {
+        fn name(&self) -> &Arc<str> {
+            &self.name
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn dtype(&self) -> &DType {
+            &self.dtype
+        }
+
+        fn row_count(&self) -> u64 {
+            4
+        }
+
+        fn register_splits(
+            &self,
+            _field_mask: &[FieldMask],
+            split_range: &SplitRange,
+            splits: &mut RowSplits,
+        ) -> VortexResult<()> {
+            splits.push(split_range.root_row_range().end);
+            Ok(())
+        }
+
+        fn pruning_evaluation(
+            &self,
+            _row_range: &Range<u64>,
+            _expr: &Expression,
+            mask: Mask,
+        ) -> VortexResult<MaskFuture> {
+            Ok(MaskFuture::ready(if self.reject {
+                Mask::new_false(mask.len())
+            } else {
+                mask
+            }))
+        }
+
+        fn filter_evaluation(
+            &self,
+            _row_range: &Range<u64>,
+            _expr: &Expression,
+            mask: MaskFuture,
+        ) -> VortexResult<MaskFuture> {
+            Ok(mask)
+        }
+
+        fn projection_evaluation(
+            &self,
+            _row_range: &Range<u64>,
+            _expr: &Expression,
+            mask: MaskFuture,
+        ) -> VortexResult<ArrayFuture> {
+            self.projection_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(Box::pin(async move {
+                buffer![1i32, 2, 3, 4].into_array().filter(mask.await?)
+            }))
+        }
+    }
+
+    fn reader(reject: bool) -> (Arc<dyn LayoutReader>, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let inner = Arc::new(CountingReader {
+            name: Arc::from("counting"),
+            dtype: buffer![1i32, 2, 3, 4].into_array().dtype().clone(),
+            projection_calls: Arc::clone(&calls),
+            reject,
+        });
+        (Arc::new(DeferredProjectionReader::new(inner)), calls)
+    }
+
+    #[tokio::test]
+    async fn rejected_split_does_not_construct_a_projection() -> VortexResult<()> {
+        let (reader, calls) = reader(true);
+        let arrays = ScanBuilder::new(VortexSession::default(), reader)
+            .with_filter(gt(root(), lit(0i32)))
+            .into_stream()?
+            .try_collect::<Vec<_>>()
+            .await?;
+        assert!(arrays.is_empty());
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn matching_split_preserves_all_projected_values() -> VortexResult<()> {
+        let (reader, calls) = reader(false);
+        let arrays = ScanBuilder::new(VortexSession::default(), reader)
+            .with_filter(gt(root(), lit(0i32)))
+            .into_stream()?
+            .try_collect::<Vec<_>>()
+            .await?;
+        assert_eq!(arrays.len(), 1);
+        assert_eq!(arrays[0].len(), 4);
+        let session = VortexSession::default();
+        let mut ctx = session.create_execution_ctx();
+        for (index, value) in [1i32, 2, 3, 4].into_iter().enumerate() {
+            assert_eq!(
+                arrays[0].execute_scalar(index, &mut ctx)?,
+                Scalar::from(value)
+            );
+        }
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_filter_does_not_construct_a_projection() -> VortexResult<()> {
+        let (reader, calls) = reader(false);
+        let mask = MaskFuture::new(4, async { Err(vortex_err!("filter failed")) });
+        let result = reader.projection_evaluation(&(0..4), &root(), mask)?.await;
+        assert!(
+            result.is_err(),
+            "a failed filter must surface as a failed projection"
+        );
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
+        Ok(())
+    }
+
+    /// The scan wiring, not just the wrapper: a point lookup through the real
+    /// `VortexOpener` must not read the whole projected column.
+    ///
+    /// The four tests above construct `DeferredProjectionReader` directly and all still
+    /// pass if `VortexOpener` never wraps anything, so none of them guards the seam. This
+    /// one measures the bytes Vortex actually pulled from the object store.
+    ///
+    /// Measured on the file this test writes (13,998,704 bytes, 64 chunks, `id` plus four
+    /// payload columns): the point lookup reads 3,496,560 bytes without the wrapper and
+    /// 208,424 bytes with it. Without deferral every chunk's `p0` segment is registered up
+    /// front and the read driver's coalescer merges all 17 of them into one read spanning
+    /// the entire column, even though 63 of the 64 chunks match nothing. The 5%-of-file
+    /// budget below sits between the two by more than 3x on either side.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn point_lookup_does_not_read_the_whole_projected_column() -> anyhow::Result<()> {
+        const CHUNKS: u32 = 64;
+        const ROWS_PER_CHUNK: u32 = 4096;
+
+        let ctx = TestSessionContext::default();
+        let session = VortexSession::default();
+
+        let ids = (0..CHUNKS)
+            .map(|chunk| {
+                (0..ROWS_PER_CHUNK)
+                    .map(|row| chunk * ROWS_PER_CHUNK + row)
+                    .collect::<Buffer<_>>()
+                    .into_array()
+            })
+            .collect::<ChunkedArray>()
+            .into_array();
+
+        // Four payload columns so the projected column is not adjacent to the filter
+        // column, which is the layout that lets an eager projection read span the file.
+        let payload = |salt: u32| {
+            (0..CHUNKS)
+                .map(|chunk| {
+                    VarBinArray::from(
+                        (0..ROWS_PER_CHUNK)
+                            .map(|row| format!("{salt}-{chunk}-{row}-{}", "x".repeat(48)))
+                            .collect::<Vec<_>>(),
+                    )
+                    .into_array()
+                })
+                .collect::<ChunkedArray>()
+                .into_array()
+        };
+
+        let table = StructArray::try_new(
+            ["id", "p0", "p1", "p2", "p3"].into(),
+            vec![ids, payload(0), payload(1), payload(2), payload(3)],
+            (CHUNKS * ROWS_PER_CHUNK) as usize,
+            Validity::NonNullable,
+        )?;
+
+        let path = "deferred_projection.vortex".into();
+        let mut writer = ObjectStoreWrite::new(ctx.store.clone(), &path).await?;
+        session
+            .write_options()
+            .write(&mut writer, table.into_array().to_array_stream())
+            .await?;
+        writer.shutdown().await?;
+        let file_bytes = ctx.store.head(&path).await?.size;
+
+        let df = ctx
+            .session
+            .sql("SELECT p0 FROM '/deferred_projection.vortex' WHERE id = 5")
+            .await?;
+        let plan = ctx
+            .session
+            .state()
+            .create_physical_plan(df.logical_plan())
+            .await?;
+        let task_ctx = Arc::new(TaskContext::from(&ctx.session.state()));
+        let batches = collect(Arc::clone(&plan), task_ctx).await?;
+
+        let rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(rows, 1, "the predicate matches exactly one row");
+        assert_eq!(
+            array_value_to_string(batches[0].column(0), 0)?,
+            format!("0-0-5-{}", "x".repeat(48)),
+            "the deferred projection must return the same value the eager one did"
+        );
+
+        let bytes_read = read_total_size(plan.as_ref());
+        let budget = file_bytes / 20;
+        assert!(
+            bytes_read < budget,
+            "a point lookup read {bytes_read} bytes of a {file_bytes}-byte file, over the \
+             {budget}-byte budget: the projection is being set up before the filter resolves"
+        );
+
+        Ok(())
+    }
+
+    /// Sums `vortex.io.read.total_size` across every Vortex scan in `plan`.
+    fn read_total_size(plan: &dyn ExecutionPlan) -> u64 {
+        VortexMetricsFinder::find_all(plan)
+            .iter()
+            .flat_map(MetricsSet::iter)
+            .filter_map(|metric| match metric.value() {
+                MetricValue::Count { name, count } if name == "vortex.io.read.total_size" => {
+                    Some(count.value() as u64)
+                }
+                _ => None,
+            })
+            .sum()
+    }
+
+    #[tokio::test]
+    async fn sparse_mask_preserves_selected_values() -> VortexResult<()> {
+        let (reader, calls) = reader(false);
+        let mask = MaskFuture::ready(Mask::from_iter([false, true, false, true]));
+        let projected = reader.projection_evaluation(&(0..4), &root(), mask)?;
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
+        let array = projected.await?;
+        assert_eq!(array.len(), 2);
+        let session = VortexSession::default();
+        let mut ctx = session.create_execution_ctx();
+        assert_eq!(array.execute_scalar(0, &mut ctx)?, Scalar::from(2i32));
+        assert_eq!(array.execute_scalar(1, &mut ctx)?, Scalar::from(4i32));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        Ok(())
+    }
+}

--- a/crates/vortex/src/persistent/deferred_projection.rs
+++ b/crates/vortex/src/persistent/deferred_projection.rs
@@ -276,21 +276,100 @@ mod tests {
         Ok(())
     }
 
-    /// The scan wiring, not just the wrapper: a point lookup through the real
-    /// `VortexOpener` must not read the whole projected column.
+    /// The scan wiring, not just the wrapper: bytes read must fall with selectivity.
     ///
     /// The four tests above construct `DeferredProjectionReader` directly and all still
     /// pass if `VortexOpener` never wraps anything, so none of them guards the seam. This
-    /// one measures the bytes Vortex actually pulled from the object store.
+    /// one goes through the real opener and measures `vortex.io.read.total_size` off the
+    /// executed plan.
     ///
-    /// Measured on the file this test writes (13,998,704 bytes, 64 chunks, `id` plus four
-    /// payload columns): the point lookup reads 3,496,560 bytes without the wrapper and
-    /// 208,424 bytes with it. Without deferral every chunk's `p0` segment is registered up
-    /// front and the read driver's coalescer merges all 17 of them into one read spanning
-    /// the entire column, even though 63 of the 64 chunks match nothing. The 5%-of-file
-    /// budget below sits between the two by more than 3x on either side.
+    /// Measured on the file it writes (13,998,704 bytes, 64 chunks, `id` plus four payload
+    /// columns), eager setup versus deferred:
+    ///
+    /// | rows matched | before    | after     |
+    /// |--------------|-----------|-----------|
+    /// | 1 of 262,144 | 3,496,560 |   208,424 |
+    /// | half         | 3,923,936 | 1,734,364 |
+    /// | all          | 5,229,296 | 3,937,280 |
+    ///
+    /// Without deferral the point lookup reads the whole `p0` column: all 17 of its
+    /// segments are registered up front, and the read driver's coalescer merges them into
+    /// one read spanning the column even though 63 of the 64 chunks match nothing.
+    ///
+    /// Only the two selective cases carry a byte budget. The all-rows gap is 1.33x, too
+    /// narrow to assert without turning a compression or layout change in a Vortex bump
+    /// into a spurious failure; it is covered for row count and values instead, which is
+    /// what says the deferral did not break unselective scans.
     #[tokio::test(flavor = "multi_thread")]
-    async fn point_lookup_does_not_read_the_whole_projected_column() -> anyhow::Result<()> {
+    async fn filtered_scan_reads_fewer_bytes_as_selectivity_rises() -> anyhow::Result<()> {
+        let ctx = fixture().await?;
+
+        // Budgets sit roughly midway between the measured arms, on a log scale.
+        let point = ctx
+            .run("SELECT p0 FROM '/deferred_projection.vortex' WHERE id = 5")
+            .await?;
+        assert_eq!(point.rows, 1, "the predicate matches exactly one row");
+        assert_eq!(
+            point.first_value,
+            Some(format!("0-0-5-{}", "x".repeat(48))),
+            "the deferred projection must return the value the eager one did"
+        );
+        point.assert_bytes_under(700_000, "point lookup");
+
+        let half = ctx
+            .run("SELECT p0 FROM '/deferred_projection.vortex' WHERE id < 131072")
+            .await?;
+        assert_eq!(half.rows, 131_072);
+        half.assert_bytes_under(2_600_000, "half the rows");
+
+        let all = ctx
+            .run("SELECT p0 FROM '/deferred_projection.vortex' WHERE id >= 0")
+            .await?;
+        assert_eq!(
+            all.rows, 262_144,
+            "an unselective filter still returns everything"
+        );
+        assert_eq!(
+            all.first_value,
+            Some(format!("0-0-0-{}", "x".repeat(48))),
+            "an unselective filtered scan must be unaffected"
+        );
+
+        Ok(())
+    }
+
+    /// A Vortex file plus a session that can query it, shared by the cases above.
+    struct Fixture {
+        ctx: TestSessionContext,
+        file_bytes: u64,
+    }
+
+    /// What one query read, and what it returned.
+    struct Scan {
+        rows: usize,
+        first_value: Option<String>,
+        bytes_read: u64,
+        reads: u64,
+        file_bytes: u64,
+    }
+
+    impl Scan {
+        fn assert_bytes_under(&self, budget: u64, what: &str) {
+            assert!(
+                self.bytes_read < budget,
+                "{what} read {} bytes of a {}-byte file in {} reads, over the {budget}-byte \
+                 budget: projection setup is running before the filter resolves",
+                self.bytes_read,
+                self.file_bytes,
+                self.reads,
+            );
+        }
+    }
+
+    /// Writes a 64-chunk file: an `id` column plus four payload columns, so the projected
+    /// column is not adjacent to the filter column. That is the layout in which an eager
+    /// projection read spans the file.
+    async fn fixture() -> anyhow::Result<Fixture> {
         const CHUNKS: u32 = 64;
         const ROWS_PER_CHUNK: u32 = 4096;
 
@@ -307,8 +386,6 @@ mod tests {
             .collect::<ChunkedArray>()
             .into_array();
 
-        // Four payload columns so the projected column is not adjacent to the filter
-        // column, which is the layout that lets an eager projection read span the file.
         let payload = |salt: u32| {
             (0..CHUNKS)
                 .map(|chunk| {
@@ -339,44 +416,44 @@ mod tests {
         writer.shutdown().await?;
         let file_bytes = ctx.store.head(&path).await?.size;
 
-        let df = ctx
-            .session
-            .sql("SELECT p0 FROM '/deferred_projection.vortex' WHERE id = 5")
-            .await?;
-        let plan = ctx
-            .session
-            .state()
-            .create_physical_plan(df.logical_plan())
-            .await?;
-        let task_ctx = Arc::new(TaskContext::from(&ctx.session.state()));
-        let batches = collect(Arc::clone(&plan), task_ctx).await?;
-
-        let rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
-        assert_eq!(rows, 1, "the predicate matches exactly one row");
-        assert_eq!(
-            array_value_to_string(batches[0].column(0), 0)?,
-            format!("0-0-5-{}", "x".repeat(48)),
-            "the deferred projection must return the same value the eager one did"
-        );
-
-        let bytes_read = read_total_size(plan.as_ref());
-        let budget = file_bytes / 20;
-        assert!(
-            bytes_read < budget,
-            "a point lookup read {bytes_read} bytes of a {file_bytes}-byte file, over the \
-             {budget}-byte budget: the projection is being set up before the filter resolves"
-        );
-
-        Ok(())
+        Ok(Fixture { ctx, file_bytes })
     }
 
-    /// Sums `vortex.io.read.total_size` across every Vortex scan in `plan`.
-    fn read_total_size(plan: &dyn ExecutionPlan) -> u64 {
+    impl Fixture {
+        async fn run(&self, sql: &str) -> anyhow::Result<Scan> {
+            let df = self.ctx.session.sql(sql).await?;
+            let plan = self
+                .ctx
+                .session
+                .state()
+                .create_physical_plan(df.logical_plan())
+                .await?;
+            let task_ctx = Arc::new(TaskContext::from(&self.ctx.session.state()));
+            let batches = collect(Arc::clone(&plan), task_ctx).await?;
+
+            let first_value = batches
+                .iter()
+                .find(|batch| batch.num_rows() > 0)
+                .map(|batch| array_value_to_string(batch.column(0), 0))
+                .transpose()?;
+
+            Ok(Scan {
+                rows: batches.iter().map(RecordBatch::num_rows).sum(),
+                first_value,
+                bytes_read: sum_metric(plan.as_ref(), "vortex.io.read.total_size"),
+                reads: sum_metric(plan.as_ref(), "vortex.io.read.size_count"),
+                file_bytes: self.file_bytes,
+            })
+        }
+    }
+
+    /// Sums one Vortex counter across every Vortex scan in `plan`.
+    fn sum_metric(plan: &dyn ExecutionPlan, metric_name: &str) -> u64 {
         VortexMetricsFinder::find_all(plan)
             .iter()
             .flat_map(MetricsSet::iter)
             .filter_map(|metric| match metric.value() {
-                MetricValue::Count { name, count } if name == "vortex.io.read.total_size" => {
+                MetricValue::Count { name, count } if name == metric_name => {
                     Some(count.value() as u64)
                 }
                 _ => None,

--- a/crates/vortex/src/persistent/deferred_projection.rs
+++ b/crates/vortex/src/persistent/deferred_projection.rs
@@ -322,17 +322,23 @@ mod tests {
         assert_eq!(half.rows, 131_072);
         half.assert_bytes_under(2_600_000, "half the rows");
 
+        // Aggregated rather than row-by-row: the scan is concurrent and unordered, so which
+        // row arrives first is not defined, but the projection still runs over every row.
         let all = ctx
-            .run("SELECT p0 FROM '/deferred_projection.vortex' WHERE id >= 0")
+            .run(
+                "SELECT count(p0) AS n, min(p0) AS lo, max(p0) AS hi \
+                 FROM '/deferred_projection.vortex' WHERE id >= 0",
+            )
             .await?;
+        assert_eq!(all.rows, 1);
         assert_eq!(
-            all.rows, 262_144,
-            "an unselective filter still returns everything"
-        );
-        assert_eq!(
-            all.first_value,
-            Some(format!("0-0-0-{}", "x".repeat(48))),
-            "an unselective filtered scan must be unaffected"
+            all.row_values()?,
+            vec![
+                "262144".to_string(),
+                format!("0-0-0-{}", "x".repeat(48)),
+                format!("0-9-999-{}", "x".repeat(48)),
+            ],
+            "an unselective filtered scan must project every row unchanged"
         );
 
         Ok(())
@@ -348,12 +354,25 @@ mod tests {
     struct Scan {
         rows: usize,
         first_value: Option<String>,
+        first_row: Option<RecordBatch>,
         bytes_read: u64,
         reads: u64,
         file_bytes: u64,
     }
 
     impl Scan {
+        /// Every column of the first row, as display strings. Only meaningful for a query
+        /// whose result is a single row.
+        fn row_values(&self) -> anyhow::Result<Vec<String>> {
+            let batch = self
+                .first_row
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("query returned no rows"))?;
+            Ok((0..batch.num_columns())
+                .map(|column| array_value_to_string(batch.column(column), 0))
+                .collect::<Result<Vec<_>, _>>()?)
+        }
+
         fn assert_bytes_under(&self, budget: u64, what: &str) {
             assert!(
                 self.bytes_read < budget,
@@ -431,15 +450,16 @@ mod tests {
             let task_ctx = Arc::new(TaskContext::from(&self.ctx.session.state()));
             let batches = collect(Arc::clone(&plan), task_ctx).await?;
 
-            let first_value = batches
-                .iter()
-                .find(|batch| batch.num_rows() > 0)
+            let first_row = batches.iter().find(|batch| batch.num_rows() > 0).cloned();
+            let first_value = first_row
+                .as_ref()
                 .map(|batch| array_value_to_string(batch.column(0), 0))
                 .transpose()?;
 
             Ok(Scan {
                 rows: batches.iter().map(RecordBatch::num_rows).sum(),
                 first_value,
+                first_row,
                 bytes_read: sum_metric(plan.as_ref(), "vortex.io.read.total_size"),
                 reads: sum_metric(plan.as_ref(), "vortex.io.read.size_count"),
                 file_bytes: self.file_bytes,

--- a/crates/vortex/src/persistent/mod.rs
+++ b/crates/vortex/src/persistent/mod.rs
@@ -5,6 +5,7 @@
 mod access_plan;
 mod cache;
 pub use cache::synthetic_object_meta;
+mod deferred_projection;
 mod format;
 pub mod metrics;
 mod opener;

--- a/crates/vortex/src/persistent/opener.rs
+++ b/crates/vortex/src/persistent/opener.rs
@@ -330,6 +330,33 @@ impl FileOpener for VortexOpener {
                 &layout_reader,
             )?;
 
+            // Resolved before the filter below so that a split whose byte range covers no
+            // whole row group still short-circuits to an empty stream, rather than
+            // reporting a pushdown failure it will never act on.
+            let row_range = match file.range {
+                Some(file_range) => {
+                    let byte_range = Range {
+                        start: u64::try_from(file_range.start).map_err(|_| {
+                            exec_datafusion_err!("Vortex file range start is negative")
+                        })?,
+                        end: u64::try_from(file_range.end).map_err(|_| {
+                            exec_datafusion_err!("Vortex file range end is negative")
+                        })?,
+                    };
+
+                    let Some(row_range) = split_aligned_row_range(
+                        byte_range,
+                        file.object_meta.size,
+                        natural_split_ranges.as_ref(),
+                    ) else {
+                        return Ok(stream::empty().boxed());
+                    };
+
+                    Some(row_range)
+                }
+                None => None,
+            };
+
             // Stats-layout pruning chain (Vortex 0.74 `FileStatsLayoutReader` / zoned
             // `StatFn`). The conjuncts collected here are translated to a Vortex
             // `Expression` and handed to `ScanBuilder::with_some_filter` below. Inside
@@ -398,22 +425,7 @@ impl FileOpener for VortexOpener {
                 scan_builder = vortex_plan.apply_to_builder(scan_builder);
             }
 
-            if let Some(file_range) = file.range {
-                let byte_range = Range {
-                    start: u64::try_from(file_range.start)
-                        .map_err(|_| exec_datafusion_err!("Vortex file range start is negative"))?,
-                    end: u64::try_from(file_range.end)
-                        .map_err(|_| exec_datafusion_err!("Vortex file range end is negative"))?,
-                };
-
-                let Some(row_range) = split_aligned_row_range(
-                    byte_range,
-                    file.object_meta.size,
-                    natural_split_ranges.as_ref(),
-                ) else {
-                    return Ok(stream::empty().boxed());
-                };
-
+            if let Some(row_range) = row_range {
                 scan_builder = scan_builder.with_row_range(row_range);
             }
 

--- a/crates/vortex/src/persistent/opener.rs
+++ b/crates/vortex/src/persistent/opener.rs
@@ -60,6 +60,7 @@ use crate::convert::schema::calculate_physical_schema;
 use crate::metrics::PARTITION_LABEL;
 use crate::metrics::PATH_LABEL;
 use crate::persistent::cache::CachedVortexMetadata;
+use crate::persistent::deferred_projection::DeferredProjectionReader;
 use crate::persistent::reader::VortexReaderFactory;
 use crate::persistent::segment_cache::SharedSegmentCache;
 use crate::persistent::stream::PrunableStream;
@@ -329,31 +330,6 @@ impl FileOpener for VortexOpener {
                 &layout_reader,
             )?;
 
-            let mut scan_builder = ScanBuilder::new(session.clone(), layout_reader);
-
-            if let Some(vortex_plan) = file.extensions.get::<VortexAccessPlan>() {
-                scan_builder = vortex_plan.apply_to_builder(scan_builder);
-            }
-
-            if let Some(file_range) = file.range {
-                let byte_range = Range {
-                    start: u64::try_from(file_range.start)
-                        .map_err(|_| exec_datafusion_err!("Vortex file range start is negative"))?,
-                    end: u64::try_from(file_range.end)
-                        .map_err(|_| exec_datafusion_err!("Vortex file range end is negative"))?,
-                };
-
-                let Some(row_range) = split_aligned_row_range(
-                    byte_range,
-                    file.object_meta.size,
-                    natural_split_ranges.as_ref(),
-                ) else {
-                    return Ok(stream::empty().boxed());
-                };
-
-                scan_builder = scan_builder.with_row_range(row_range);
-            }
-
             // Stats-layout pruning chain (Vortex 0.74 `FileStatsLayoutReader` / zoned
             // `StatFn`). The conjuncts collected here are translated to a Vortex
             // `Expression` and handed to `ScanBuilder::with_some_filter` below. Inside
@@ -365,11 +341,11 @@ impl FileOpener for VortexOpener {
             // `DynamicFilterPhysicalExpr` via `.current()` at file-open time (not plan
             // build time), and Vortex's `PruningResult::mask()` re-derives the zone mask
             // whenever the dynamic expression's version advances — so a build side that
-            // populates after the scan starts still prunes zones. `VortexAccessPlan`
-            // (applied above) only adds a row `Selection`; it does not bypass this
-            // filter, so stats pruning still engages under position-delete scans.
-            // Filters Vortex can't translate (`skipped_dynamic`) are dropped here but
-            // still feed the coarser per-file `FilePruner`/`PrunableStream` above.
+            // populates after the scan starts still prunes zones. `VortexAccessPlan` only
+            // adds a row `Selection`; it does not bypass this filter, so stats pruning
+            // still engages under position-delete scans. Filters Vortex can't translate
+            // (`skipped_dynamic`) are dropped here but still feed the coarser per-file
+            // `FilePruner`/`PrunableStream` above.
             let filter = filter
                 .and_then(|f| {
                     // Verify that all filters we've accepted from DataFusion get pushed down.
@@ -405,6 +381,41 @@ impl FileOpener for VortexOpener {
                     }
                 })
                 .transpose()?;
+
+            // Built after the filter so we know whether there is one: a filtered scan
+            // discards splits whose mask comes back empty, and deferring projection setup
+            // keeps those splits from registering reads for the output columns. An
+            // unfiltered scan has nothing to wait on, and its eager registration is what
+            // lets the read driver coalesce adjacent splits, so it keeps the plain reader.
+            let layout_reader: Arc<dyn LayoutReader> = if filter.is_some() {
+                Arc::new(DeferredProjectionReader::new(layout_reader))
+            } else {
+                layout_reader
+            };
+            let mut scan_builder = ScanBuilder::new(session.clone(), layout_reader);
+
+            if let Some(vortex_plan) = file.extensions.get::<VortexAccessPlan>() {
+                scan_builder = vortex_plan.apply_to_builder(scan_builder);
+            }
+
+            if let Some(file_range) = file.range {
+                let byte_range = Range {
+                    start: u64::try_from(file_range.start)
+                        .map_err(|_| exec_datafusion_err!("Vortex file range start is negative"))?,
+                    end: u64::try_from(file_range.end)
+                        .map_err(|_| exec_datafusion_err!("Vortex file range end is negative"))?,
+                };
+
+                let Some(row_range) = split_aligned_row_range(
+                    byte_range,
+                    file.object_meta.size,
+                    natural_split_ranges.as_ref(),
+                ) else {
+                    return Ok(stream::empty().boxed());
+                };
+
+                scan_builder = scan_builder.with_row_range(row_range);
+            }
 
             if let Some(limit) = limit
                 && filter.is_none()


### PR DESCRIPTION
## What

Defer Vortex projection setup on **filtered** scans until the split's filter mask has resolved, so a split that matches no rows no longer constructs readers for the output columns or registers their segment reads.

## Why

`split_exec` in `vortex-layout` builds each split's task by calling `projection_evaluation` up front and only then awaiting the filter mask, dropping the projection future when the mask comes back all-false:

```rust
let projection_future =
    ctx.reader.projection_evaluation(&row_range, &ctx.projection, filter_mask.clone())?;
let array_fut = async move {
    let mask = filter_mask.await?;
    if mask.all_false() { return Ok(None); }   // projection_future dropped, unpolled
    ...
```

Building the projection is not free. It walks the layout to construct the output columns' readers, and each one calls `SegmentSource::request` for its segment. A request that is registered but never polled is not dispatched on its own — `State::next_uncoalesced` only pops from `polled_requests` — but it *does* stay in `requests_by_offset`, and `State::next_coalesced` reads from `polled_requests` **or** `requests` when it expands a coalescing window. So the output columns of a split that matches nothing can still be fetched from storage, as a passenger on a neighbouring read.

## How

Wrap the root layout reader in `DeferredProjectionReader` when the scan has a pushed-down filter. Every `LayoutReader` method is forwarded; `projection_evaluation` returns a future that awaits the mask first and only then calls the inner `projection_evaluation`, so the reader construction and the segment requests happen inside the future rather than when it is created. `MaskFuture` is a shared future, so awaiting the wrapper's clone resolves against the same filter evaluation the scan awaits.

Unfiltered scans keep the plain reader: their masks are already resolved so there is nothing to defer, and the eager registration is what lets the driver coalesce the projection reads of adjacent splits. Filters, row selection (`VortexAccessPlan`), output expressions, `with_limit` (already filter-exclusive) and file splits are unchanged.

The second commit is a consequence of that ordering. Building the scan builder now requires knowing whether the scan has a filter, which would otherwise push the row-range resolution — and its empty-stream short-circuit for a byte range covering no whole row group — after the pushdown translation, turning that short-circuit into a pushdown error. The row range is resolved up front and applied to the builder afterwards, so the byte-range check, the short-circuit and the pushdown error keep the order they had.

## Measurements

All numbers are from one release binary, both arms switched by a temporary env toggle that is not part of this branch, reading **bit-identical files**. The dataset is 1,000,000 rows (`key BIGINT` plus four ~74-byte payload columns) accelerated with `engine: cayenne, mode: file, refresh_mode: full, primary_key: key` — 4 Vortex files, 162 MB. Caching is off in every run (`runtime.caching.sql_results.enabled: false`, `runtime.params.cayenne_segment_cache_mb: 0`). Bytes come from `vortex.io.read.total_size` read off the executed plan.

### Bytes read: −45% to −58% on selective queries, in every environment

| query | eager | deferred | Δ |
|---|---:|---:|---:|
| `SELECT p0 WHERE key = 500000` | 6,622,148 | 3,194,884 | **−51.8%** |
| `SELECT p0,p1,p2,p3 WHERE key = 750000` | ~11,500,000 | 5,251,592 | **−46% to −58%** |
| `SELECT p0 WHERE key BETWEEN 400000 AND 400999` | 9,652,736 | 5,251,672 | **−45.6%** |
| `SELECT count(p0) WHERE key < 500000` | ~46,100,000 | 43,535,592 | −5.2% to −5.9% |

Byte counts are identical across every latency and bandwidth configuration tested, which is the expected result — they do not depend on the transport.

### Wall clock: it depends entirely on what the storage is constrained by

Δ p50, deferred vs eager, across three storage regimes:

| query | gp3 baseline<br>125 MiB/s cap | gp3 max<br>1000 MiB/s cap | local files<br>(warm cache) | S3 Standard<br>~107 ms RTT |
|---|---:|---:|---:|---:|
| point, 1 column | **−55.4%** | −31.0% | −14.2% | −0.3% |
| point, 4 columns | **−73.8%** | −53.1% | −64.2% | −2.3% |
| 1000-row range | **−54.4%** | −28.4% | −12.3% | −0.7% |
| half-table count | −2.2% | +0.4% | −5.1% | −0.0% |

**Bandwidth-constrained storage is where this pays.** gp3's provisioned throughput (125 MiB/s baseline, 1000 MiB/s max) makes bytes the binding constraint, and the byte reduction converts directly into wall clock — up to −73.8%. Per-run p50 does not overlap on any selective query: at 125 MiB/s, eager was [66.5, 67.2] ms against deferred [17.7, 17.3] ms on the four-column lookup. gp3 and NVMe latency (~0.05–1 ms) is below the lowest latency point tested, so latency is never the binding constraint there.

**Latency-bound storage is where it does not.** Under an emulated object store (MinIO behind toxiproxy, RTT calibrated at 2.7 / 15.5 / 35.1 / 57.6 / 106.8 ms against reference points of ~5–10 ms for S3 Express, ~20–60 ms typical same-region S3 Standard, and the 100–200 ms first-byte AWS's performance guidance documents), the gain decays from −37.8% at 2.7 ms to −2.3% at 106.8 ms. Both arms issue nearly the same number of requests (13 vs 13, 16 vs 16, 70 vs 72) with the same dependency depth of about three sequential round-trip waves, so at 106.8 ms RTT a point lookup costs ~329 ms in *both* arms. The query is latency-bound and the saved bytes do not move the clock.

**Nothing regressed at any point in either sweep.** The unselective half-table count is neutral throughout, as expected — it saves only ~5% of bytes because nearly every split matches. The two positive numbers above (+0.4%, and +4.1% at the lowest object-store latency) are noise with overlapping arms; at 2.7 ms RTT the per-run p50 was eager [35.5, 29.0] ms against deferred [40.2, 27.0] ms, and the single best run of either arm was a deferred one.

### The eager path also reads a nondeterministic amount

Distinct byte totals for the same query and the same single-row answer, across 210 executions per arm over the object store:

| query | eager | deferred |
|---|---:|---:|
| point, 1 column | 18 | 3 |
| point, 4 columns | **120** | 6 |
| 1000-row range | 33 | 3 |
| half-table count | 31 | 9 |

On the local Cayenne run the four-column point lookup read anywhere from **19 MB to 82 MB** for the same one row. Whether a rejected split's registered-but-unpolled projection request gets over-read depends on whether some polled read happens to expand its coalescing window across it first, which varies with scheduling across the concurrent split tasks. Deferring removes the variance along with the bytes.

### Correctness

Every query returns an identical sorted row multiset across all runs in every configuration. `range_1k` returns its 1000 rows in a different order between runs — including between two runs of the *same* arm — which is expected for a parallel scan with no `ORDER BY`.

### Limits of the measurements

- **One query at a time.** Under concurrency the saved bytes would contend for shared bandwidth, which on a provisioned volume is a hard ceiling; the gp3 numbers above are therefore likely the *conservative* reading for a loaded server.
- **The object-store emulation is MinIO behind a fixed-latency proxy**, not S3: no jitter or heavy tail, no throttling, no TLS. The tail is where extra requests would hurt most, though the arms' request counts are close enough that it should be minor.
- **Local-file latency was measured with a warm page cache** — macOS will not drop it without root — so that column is faster than a real gp3 read and is bracketed by the two bandwidth columns.
- Numbers were produced with a temporary per-query log line bridging Vortex's metric registry into the runtime. Nothing in the runtime reads that registry today, so `EXPLAIN ANALYZE` cannot show `vortex.io.read.total_size`. Wiring it up permanently would add to user-facing `EXPLAIN ANALYZE` output and needs its own Enhancement.

## Tests

- `filtered_scan_reads_fewer_bytes_as_selectivity_rises` — the seam test. Writes a real Vortex file, runs three queries of rising selectivity through `VortexOpener`/DataFusion, asserts the returned values and a byte budget on the two selective ones. **Negative control:** with the `DeferredProjectionReader` wrapping removed from `opener.rs`, it fails with `point lookup read 3496560 bytes of a 13998704-byte file in 2 reads, over the 700000-byte budget`.
- Only the two selective cases carry a byte budget. The all-rows gap is 1.33x, too narrow to assert without turning a compression or layout change in a Vortex bump into a spurious failure; it is covered for `count`/`min`/`max` instead, which also keeps it order-independent — asserting the first row delivered failed about two runs in three under full-suite parallelism, since the scan is concurrent and unordered.
- `sum_metric` errors when no scan reported the counter rather than summing to zero, so a budget cannot pass against a metric that stopped being collected. Verified by renaming the metric: `Error: no Vortex scan reported \`vortex.io.read.total_size.RENAMED\`, so this measurement is not measuring anything`.
- Four unit tests on the wrapper itself: a rejected split constructs no projection, a matching split preserves every projected value, a failed filter constructs no projection, a sparse mask preserves the selected values. **Negative control:** replacing the wrapper body with a direct delegation fails 3 of the 4.
- Full `vortex-datafusion` suite green over five consecutive runs; `make signoff` passed (12,988 tests).

## Breaking changes

None. No user-facing surface changes: no new or changed Spicepod field, param, flag, env var, metric, log line, or API. Query results are unchanged.
