### PR TITLE
fix(ci): call a linker that died of a signal an infrastructure failure, not a check failure (fixes #13614)

### DIFF
--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -639,7 +639,7 @@ reclaiming space is then the remedy that fixes both. Unlike disk there is no
 after-the-fact backstop: the endpoint may well be answering again by the time the
 run ends, so the only evidence is what the build said while it was failing.
 
-### "The linker crashed on the runner, so nothing was built"
+### "The linker crashed on the runner, so the build did not finish"
 
 The compiler driver can lose the linker to a signal — a crash in `ld` itself, or
 the kernel killing it for memory — and reports it in its own words, with a crash
@@ -652,19 +652,26 @@ clang: note: diagnostic msg: /var/folders/…/T/linker-crash-122a1e
 error: could not compile `cayenne` (test "result_correctness_vs_sqlite_test") due to 1 previous error
 ```
 
-**Re-dispatch it.** Nothing was linked, so no test ran and no lint verdict was
-reached; the run is not a statement about your branch. The hedge is the same as
-for an unloadable test binary: if it recurs on this branch alone, or names a
-crate whose build this branch changes — a new build script, a dependency whose
-objects the linker cannot digest — the diff is worth suspecting.
+**Re-dispatch it.** The binary being linked was never produced, so the sign-off
+stopped there: whatever passed before it stands (the run above had already cleared
+lint), and nothing after it ran. None of that is a statement about your branch.
+The hedge is the same as for an unloadable test binary: if it recurs on this
+branch alone, or names a crate whose build this branch changes — a new build
+script, a dependency whose objects the linker cannot digest — the diff is worth
+suspecting.
 
-The same watcher reads this signature, and both halves are required: the driver
-reporting a signal *and* cargo's `could not compile` line. This repo's own suites
-assert on error strings, so a test that quotes the driver's wording and then
-fails stays a verdict about the branch, and cargo's line alone is every ordinary
-compile error. Disk, cache, and an unloadable artifact all outrank it when they
-appear alongside, because each of those names a cause with its own remedy where
-this one only names the symptom.
+The same watcher reads this signature, and both halves are required: the
+compiler driver reporting a signal under its own `<driver>: error:` prefix at the
+start of the line (`clang`, `cc`, `gcc`, `g++`, `collect2` and their C++ spellings),
+*and* cargo's `could not compile` line. This repo's own suites assert on error
+strings, so a test that quotes the driver's wording and then fails stays a
+verdict about the branch; a `compile_error!` or build script whose text reads
+like a crash — prefix included — lands behind rustc's own `error:` rather than at
+the start of the line, and stays one too; and cargo's line alone is every
+ordinary compile error. Disk,
+cache, and an unloadable artifact all outrank it when they appear alongside,
+because each of those names a cause with its own remedy where this one only
+names the symptom.
 
 ### External contributors (forks)
 

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -639,7 +639,7 @@ reclaiming space is then the remedy that fixes both. Unlike disk there is no
 after-the-fact backstop: the endpoint may well be answering again by the time the
 run ends, so the only evidence is what the build said while it was failing.
 
-### "A compiler subprocess crashed on the runner"
+### "Compiler subprocess crashed — checks did not complete"
 
 The compiler driver can lose a subprocess to a signal — a crash in `ld` itself,
 the kernel killing it for memory, or the driver's own frontend going down the

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -639,6 +639,33 @@ reclaiming space is then the remedy that fixes both. Unlike disk there is no
 after-the-fact backstop: the endpoint may well be answering again by the time the
 run ends, so the only evidence is what the build said while it was failing.
 
+### "The linker crashed on the runner, so nothing was built"
+
+The compiler driver can lose the linker to a signal — a crash in `ld` itself, or
+the kernel killing it for memory — and reports it in its own words, with a crash
+snapshot beside them; cargo then stops the build at that crate:
+
+```
+clang: error: unable to execute command: Segmentation fault: 11
+clang: error: linker command failed due to signal (use -v to see invocation)
+clang: note: diagnostic msg: /var/folders/…/T/linker-crash-122a1e
+error: could not compile `cayenne` (test "result_correctness_vs_sqlite_test") due to 1 previous error
+```
+
+**Re-dispatch it.** Nothing was linked, so no test ran and no lint verdict was
+reached; the run is not a statement about your branch. The hedge is the same as
+for an unloadable test binary: if it recurs on this branch alone, or names a
+crate whose build this branch changes — a new build script, a dependency whose
+objects the linker cannot digest — the diff is worth suspecting.
+
+The same watcher reads this signature, and both halves are required: the driver
+reporting a signal *and* cargo's `could not compile` line. This repo's own suites
+assert on error strings, so a test that quotes the driver's wording and then
+fails stays a verdict about the branch, and cargo's line alone is every ordinary
+compile error. Disk, cache, and an unloadable artifact all outrank it when they
+appear alongside, because each of those names a cause with its own remedy where
+this one only names the symptom.
+
 ### External contributors (forks)
 
 Posting a commit status requires write access to this repository, so

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -639,7 +639,7 @@ reclaiming space is then the remedy that fixes both. Unlike disk there is no
 after-the-fact backstop: the endpoint may well be answering again by the time the
 run ends, so the only evidence is what the build said while it was failing.
 
-### "A compiler subprocess crashed on the runner, so the build did not finish"
+### "A compiler subprocess crashed on the runner"
 
 The compiler driver can lose a subprocess to a signal — a crash in `ld` itself,
 the kernel killing it for memory, or the driver's own frontend going down the

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -662,7 +662,8 @@ suspecting.
 
 The same watcher reads this signature, and both halves are required: the
 compiler driver reporting a signal under its own `<driver>: error:` prefix at the
-start of the line (`clang`, `cc`, `gcc`, `g++`, `collect2` and their C++ spellings),
+start of the line (`clang`, `cc`, `gcc`, `g++`, `collect2` and their C++ spellings;
+`collect2` says `fatal error:`),
 *and* cargo's `could not compile` line. This repo's own suites assert on error
 strings, so a test that quotes the driver's wording and then fails stays a
 verdict about the branch; a `compile_error!` or build script whose text reads

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -639,11 +639,12 @@ reclaiming space is then the remedy that fixes both. Unlike disk there is no
 after-the-fact backstop: the endpoint may well be answering again by the time the
 run ends, so the only evidence is what the build said while it was failing.
 
-### "The linker crashed on the runner, so the build did not finish"
+### "A compiler subprocess crashed on the runner, so the build did not finish"
 
-The compiler driver can lose the linker to a signal — a crash in `ld` itself, or
-the kernel killing it for memory — and reports it in its own words, with a crash
-snapshot beside them; cargo then stops the build at that crate:
+The compiler driver can lose a subprocess to a signal — a crash in `ld` itself,
+the kernel killing it for memory, or the driver's own frontend going down the
+same way — and reports it in its own words, with a crash snapshot beside them;
+cargo then stops the build at that crate:
 
 ```
 clang: error: unable to execute command: Segmentation fault: 11
@@ -652,7 +653,16 @@ clang: note: diagnostic msg: /var/folders/…/T/linker-crash-122a1e
 error: could not compile `cayenne` (test "result_correctness_vs_sqlite_test") due to 1 previous error
 ```
 
-**Re-dispatch it.** The binary being linked was never produced, so the sign-off
+The driver words a crash in its own frontend the same way, so the status names
+the class rather than the tool:
+
+```
+clang: error: unable to execute command: Segmentation fault: 11
+clang: error: clang frontend command failed due to signal (use -v to see invocation)
+error: could not compile `spiced` (lib) due to 1 previous error
+```
+
+**Re-dispatch it.** The artifact being produced never appeared, so the sign-off
 stopped there: whatever passed before it stands (the run above had already cleared
 lint), and nothing after it ran. None of that is a statement about your branch.
 The hedge is the same as for an unloadable test binary: if it recurs on this

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -899,11 +899,13 @@ readonly CORRUPT_ARTIFACT_PATTERN='Malformed Mach-o file|Exec format error'
 # which is where a corrupt artifact is met first (#13518).
 readonly TEST_LIST_FAILURE_PATTERN='error: creating test list failed'
 
-# The compiler driver reporting that a tool it ran — the linker, on every run
-# seen so far — died of a signal rather than returning a diagnostic. `clang`
-# prints the first form with the signal's name and the second on its way out;
-# both are its own words for its own crash, and it writes a crash snapshot
-# beside them. GNU's driver says it through `collect2`, whose signal path is a
+# The compiler driver reporting that a subprocess it ran died of a signal
+# rather than returning a diagnostic — the linker on every run seen so far,
+# but the driver words a crash in its own frontend identically (`clang: error:
+# unable to execute command: Segmentation fault: 11`), so this names the class
+# and not the tool. `clang` prints the first form with the signal's name and
+# the second on its way out; both are its own words for its own crash, and it
+# writes a crash snapshot beside them. GNU's driver says it through `collect2`, whose signal path is a
 # `fatal error:` rather than an `error:`. `Killed: 9` is the same class from
 # the other side: the kernel taking the linker for memory.
 #
@@ -1376,9 +1378,12 @@ describe_check_failure() {
       SIGNOFF_FAILURE_MESSAGE="sign-off aborted: a test binary on the runner would not load, so nextest never ran the suite (the checks did not complete) — re-dispatch"
       ;;
     toolchain-crash)
-      # The compiler driver reported that the linker died of a signal, and cargo
-      # stopped the build at that crate: the binary it was linking was never
-      # produced, so the step that needed it never ran. Whatever passed before
+      # The compiler driver reported that a subprocess it ran died of a signal,
+      # and cargo stopped the build at that crate: the artifact it was producing
+      # never appeared, so the step that needed it never ran. The wording says
+      # "a compiler subprocess" rather than "the linker" because the driver's
+      # `unable to execute command: <signal>` line covers a frontend crash too,
+      # and naming the wrong tool sends the author looking in the wrong place. Whatever passed before
       # that point stands — run 33041791988 had already cleared lint — which is
       # why this says "did not complete" and not "nothing ran". Worded like the
       # other kinds that reached no verdict, because the generic "checks
@@ -1391,9 +1396,9 @@ describe_check_failure() {
       # whose objects the linker cannot digest — and this cannot tell. A
       # recurrence on this branch alone, or on a crate whose build this branch
       # changes, is worth suspecting the diff for.
-      SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not complete after ${elapsed}s — the linker crashed on the runner, so the build did not finish; re-dispatch (triggered by ${user})"
-      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — the compiler driver reported that the linker died of a signal (a crash or an out-of-memory kill, not a diagnostic), and cargo stopped the build at that crate, so **the checks did not complete**: the binary being linked was never produced and nothing after it ran, while whatever passed before it stands. That is the runner's toolchain failing on its own, not a statement about the branch. Re-dispatch the sign-off. If it recurs on this branch alone, or names a crate whose build this branch changes, the diff is worth suspecting."$'\n'
-      SIGNOFF_FAILURE_MESSAGE="sign-off aborted: the linker crashed on the runner, so the build did not finish (the checks did not complete) — re-dispatch"
+      SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not complete after ${elapsed}s — a compiler subprocess crashed on the runner, so the build did not finish; re-dispatch (triggered by ${user})"
+      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — the compiler driver reported that a subprocess it ran died of a signal (a crash or an out-of-memory kill, not a diagnostic) — the linker on every run seen so far, though the driver words a frontend crash the same way — and cargo stopped the build at that crate, so **the checks did not complete**: the binary being linked was never produced and nothing after it ran, while whatever passed before it stands. That is the runner's toolchain failing on its own, not a statement about the branch. Re-dispatch the sign-off. If it recurs on this branch alone, or names a crate whose build this branch changes, the diff is worth suspecting."$'\n'
+      SIGNOFF_FAILURE_MESSAGE="sign-off aborted: a compiler subprocess crashed on the runner, so the build did not finish (the checks did not complete) — re-dispatch"
       ;;
     missing-target)
       # Neither of the two readings above: the runner is fine and the code was

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -903,8 +903,9 @@ readonly TEST_LIST_FAILURE_PATTERN='error: creating test list failed'
 # seen so far — died of a signal rather than returning a diagnostic. `clang`
 # prints the first form with the signal's name and the second on its way out;
 # both are its own words for its own crash, and it writes a crash snapshot
-# beside them. GNU's driver says it through `collect2`. `Killed: 9` is the same
-# class from the other side: the kernel taking the linker for memory.
+# beside them. GNU's driver says it through `collect2`, whose signal path is a
+# `fatal error:` rather than an `error:`. `Killed: 9` is the same class from
+# the other side: the kernel taking the linker for memory.
 #
 # Anchored on the driver's own `<driver>: error: ` prefix AT THE START of the
 # line (after the indentation rustc gives linker output), not on the words
@@ -914,7 +915,7 @@ readonly TEST_LIST_FAILURE_PATTERN='error: creating test list failed'
 # about the branch even once cargo prints its summary (#13614). The driver's
 # own report is never preceded by anything but whitespace.
 # `[+]` rather than `\+` because awk rewrites `\+` in a -v value to a plain `+`.
-readonly TOOLCHAIN_CRASH_PATTERN='^[[:space:]]*(clang|clang[+][+]|cc|c[+][+]|gcc|g[+][+]|collect2): error: (unable to execute command: (Segmentation fault|Bus error|Illegal instruction|Abort trap|Killed: 9)|linker command failed due to signal|ld terminated with signal)'
+readonly TOOLCHAIN_CRASH_PATTERN='^[[:space:]]*(clang|clang[+][+]|cc|c[+][+]|gcc|g[+][+]|collect2): (fatal )?error: (unable to execute command: (Segmentation fault|Bus error|Illegal instruction|Abort trap|Killed: 9)|linker command failed due to signal|ld terminated with signal)'
 
 # The line that says the crash above stopped a compilation, rather than being
 # quoted by a test that ran to completion. cargo prints it once per crate whose

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -899,6 +899,23 @@ readonly CORRUPT_ARTIFACT_PATTERN='Malformed Mach-o file|Exec format error'
 # which is where a corrupt artifact is met first (#13518).
 readonly TEST_LIST_FAILURE_PATTERN='error: creating test list failed'
 
+# The compiler driver reporting that a tool it ran — the linker, on every run
+# seen so far — died of a signal rather than returning a diagnostic. `clang`
+# prints the first form with the signal's name and the second on its way out;
+# both are its own words for its own crash, and it writes a crash snapshot
+# beside them. `Killed: 9` is the same class from the other side: the kernel
+# taking the linker for memory. Anchored on the driver's prefix so the bare
+# words, which a test can print, are not enough on their own (#13614).
+readonly TOOLCHAIN_CRASH_PATTERN='unable to execute command: (Segmentation fault|Bus error|Illegal instruction|Abort trap|Killed: 9)|linker command failed due to signal'
+
+# The line that says the crash above stopped a compilation, rather than being
+# quoted by a test that ran to completion. cargo prints it once per crate whose
+# build did not finish; a genuine test failure never reaches it, because a test
+# only runs once its crate compiled. Both halves are required, for the same
+# reason as the artifact pair above: this repo's own suites assert on error
+# strings, and excusing a real failure as infrastructure is the costlier mistake.
+readonly COMPILE_ABORTED_PATTERN='error: could not compile `[^`]+`.* due to '
+
 # Set to 1 on remote runs, where run_make_step watches build output for the
 # out-of-disk and unusable-cache signatures. Separates "watched, and it was
 # neither" from "nothing watched at all", which failure_kind answers differently.
@@ -931,6 +948,13 @@ SIGNOFF_CACHE_HIT="${SIGNOFF_CACHE_HIT:-}"
 # can set up a classification without running a build.
 SIGNOFF_ARTIFACT_HIT="${SIGNOFF_ARTIFACT_HIT:-}"
 
+# Set to 1 by run_make_step when the step it ran lost a compilation to a tool
+# that crashed — the linker taking a signal — rather than to a diagnostic. Same
+# mechanism and the same reason for being a variable rather than a file as the
+# three above, and likewise seeded from the environment so a test can set up a
+# classification without running a build.
+SIGNOFF_TOOLCHAIN_HIT="${SIGNOFF_TOOLCHAIN_HIT:-}"
+
 # The statuses the watcher exits with to report each signature. Deliberately
 # not 1 or 2: awk uses those for its own errors, and a watcher that itself died
 # must not be read as a volume that filled. Reserving distinct statuses is also
@@ -939,6 +963,7 @@ SIGNOFF_ARTIFACT_HIT="${SIGNOFF_ARTIFACT_HIT:-}"
 readonly DISK_WATCH_HIT_STATUS=3
 readonly CACHE_WATCH_HIT_STATUS=4
 readonly ARTIFACT_WATCH_HIT_STATUS=5
+readonly TOOLCHAIN_WATCH_HIT_STATUS=6
 
 # The watcher itself, held in one place so the probe below runs exactly the
 # program that will read the build output — a probe of anything else predicts
@@ -958,11 +983,14 @@ readonly DISK_WATCH_PROGRAM='
     $0 ~ cache_pat { cache_hit = 1 }
     $0 ~ artifact_pat { artifact_hit = 1 }
     $0 ~ list_pat { list_failed = 1 }
+    $0 ~ crash_pat { crash_hit = 1 }
+    $0 ~ compile_pat { compile_aborted = 1 }
     { print; fflush() }
     END {
       if (hit) exit (hit_status + 0)
       if (cache_hit) exit (cache_status + 0)
       if (artifact_hit && list_failed) exit (artifact_status + 0)
+      if (crash_hit && compile_aborted) exit (crash_status + 0)
     }
   '
 
@@ -975,6 +1003,8 @@ disk_watch_probe() {
     -v cache_pat="$CACHE_UNUSABLE_PATTERN" -v cache_status="$CACHE_WATCH_HIT_STATUS" \
     -v artifact_pat="$CORRUPT_ARTIFACT_PATTERN" -v list_pat="$TEST_LIST_FAILURE_PATTERN" \
     -v artifact_status="$ARTIFACT_WATCH_HIT_STATUS" \
+    -v crash_pat="$TOOLCHAIN_CRASH_PATTERN" -v compile_pat="$COMPILE_ABORTED_PATTERN" \
+    -v crash_status="$TOOLCHAIN_WATCH_HIT_STATUS" \
     "$DISK_WATCH_PROGRAM" </dev/null >/dev/null 2>&1
 }
 
@@ -1004,6 +1034,7 @@ run_make_step() {
   SIGNOFF_DISK_HIT=""
   SIGNOFF_CACHE_HIT=""
   SIGNOFF_ARTIFACT_HIT=""
+  SIGNOFF_TOOLCHAIN_HIT=""
   # Ask whether the watcher runs before make writes a byte to it, because the
   # only other place to find out is downstream of make — where a watcher that
   # exits at once closes the pipe under a still-writing make, make dies of
@@ -1023,6 +1054,8 @@ run_make_step() {
       -v cache_pat="$CACHE_UNUSABLE_PATTERN" -v cache_status="$CACHE_WATCH_HIT_STATUS" \
       -v artifact_pat="$CORRUPT_ARTIFACT_PATTERN" -v list_pat="$TEST_LIST_FAILURE_PATTERN" \
       -v artifact_status="$ARTIFACT_WATCH_HIT_STATUS" \
+      -v crash_pat="$TOOLCHAIN_CRASH_PATTERN" -v compile_pat="$COMPILE_ABORTED_PATTERN" \
+      -v crash_status="$TOOLCHAIN_WATCH_HIT_STATUS" \
       "$DISK_WATCH_PROGRAM"
   # Copy the whole array in one statement: reading PIPESTATUS is itself a command,
   # so a second `x="${PIPESTATUS[1]}"` would be reading the *assignment's* status
@@ -1036,6 +1069,8 @@ run_make_step() {
     SIGNOFF_CACHE_HIT=1
   elif [[ "$watch_status" -eq "$ARTIFACT_WATCH_HIT_STATUS" ]]; then
     SIGNOFF_ARTIFACT_HIT=1
+  elif [[ "$watch_status" -eq "$TOOLCHAIN_WATCH_HIT_STATUS" ]]; then
+    SIGNOFF_TOOLCHAIN_HIT=1
   elif [[ "$watch_status" -ne 0 ]]; then
     # The watcher started, so the probe cleared it, and then died part-way
     # through: killed for memory, or a signal that reached the whole group. Its
@@ -1087,6 +1122,13 @@ build_hit_cache_unusable() {
 # in the same shell that ran the step, for the same reason as its two siblings.
 build_hit_corrupt_artifact() {
   [[ -n "$SIGNOFF_ARTIFACT_HIT" ]]
+}
+
+# True when the step that failed lost a compilation to a crashing tool rather
+# than to a diagnostic. Read in the same shell that ran the step, for the same
+# reason as its three siblings.
+build_hit_toolchain_crash() {
+  [[ -n "$SIGNOFF_TOOLCHAIN_HIT" ]]
 }
 
 # Free space in GiB on the volume holding "$1" (default: the working tree).
@@ -1160,8 +1202,10 @@ watch_for_signals() {
 # Names what broke in a check run that did not pass, given run_checks' exit
 # status: "signalled" when nothing judged the branch at all, "disk" when the work
 # volume is the cause, "cache" when sccache could not reach its storage and so
-# nothing was compiled, "missing-target" and "stale-lockfile" when a preflight
-# refused to start, "checks" for everything else, which is the branch. Three
+# nothing was compiled, "corrupt-artifact" when the runner could not load a test
+# binary it built, "toolchain-crash" when a tool the build ran died of a signal,
+# "missing-target" and "stale-lockfile" when a preflight refused to start,
+# "checks" for everything else, which is the branch. Three
 # ways to reach "disk", in falling order of authority: the preflight refused to
 # start, the build said so itself, or the volume is at ~0 now. The last is a
 # backstop for a build whose output we did not record — a local run, or a remote
@@ -1237,6 +1281,14 @@ failure_kind() {
       # signatures went past, i.e. the artifact is unloadable for a reason this
       # run cannot see.
       echo "corrupt-artifact"
+    elif build_hit_toolchain_crash; then
+      # Last, because the three above each name a cause with its own remedy,
+      # while this one only names the symptom: a tool the build ran died of a
+      # signal, and nothing here can say why. A volume that fills mid-link
+      # kills the linker with ENOSPC rather than a signal, so disk and this do
+      # not normally coincide — but when both signatures go past, reclaiming
+      # space is the remedy that fixes both.
+      echo "toolchain-crash"
     else
       echo "checks"
     fi
@@ -1313,6 +1365,23 @@ describe_check_failure() {
       SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not complete after ${elapsed}s — a test binary on the runner would not load; re-dispatch (triggered by ${user})"
       SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — \`nextest\` could not execute a test binary while listing tests, because the runner's copy is not a loadable executable, so **the checks did not complete**. That is a truncated or clobbered artifact on the shared \`target/\` volume rather than a statement about the branch. Re-dispatch the sign-off. If it recurs on this branch alone, or names a crate whose build script this branch changes, the diff is worth suspecting."$'\n'
       SIGNOFF_FAILURE_MESSAGE="sign-off aborted: a test binary on the runner would not load, so nextest never ran the suite (the checks did not complete) — re-dispatch"
+      ;;
+    toolchain-crash)
+      # The compiler driver reported that the linker died of a signal, and cargo
+      # stopped the build there: nothing was linked, so no test ran and no lint
+      # verdict was reached. Worded like the other kinds that reached no
+      # verdict, because the generic "checks failed" sends the author into a
+      # log several thousand lines long to look for a defect in a diff nothing
+      # judged (#13614, and #12813 before it).
+      #
+      # Hedged rather than asserted, like corrupt-artifact: a crash can be the
+      # branch's own doing — a build script it changes, a dependency it adds
+      # whose objects the linker cannot digest — and this cannot tell. A
+      # recurrence on this branch alone, or on a crate whose build this branch
+      # changes, is worth suspecting the diff for.
+      SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not complete after ${elapsed}s — the linker crashed on the runner, so nothing was built; re-dispatch (triggered by ${user})"
+      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — the compiler driver reported that the linker died of a signal (a crash or an out-of-memory kill, not a diagnostic), and cargo stopped the build there, so **the checks did not complete**. That is the runner's toolchain failing on its own, not a statement about the branch. Re-dispatch the sign-off. If it recurs on this branch alone, or names a crate whose build this branch changes, the diff is worth suspecting."$'\n'
+      SIGNOFF_FAILURE_MESSAGE="sign-off aborted: the linker crashed on the runner, so the build never finished (the checks did not complete) — re-dispatch"
       ;;
     missing-target)
       # Neither of the two readings above: the runner is fine and the code was

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -653,6 +653,12 @@ warn_status_not_recorded() {
   fi
 }
 
+# What GitHub keeps of a commit status description; the rest is discarded
+# silently. Named rather than written inline at the slice below because the
+# suite asserts every verdict fits it, and a second copy of the number is a
+# guard that can pass while the real cut still truncates.
+readonly STATUS_DESC_MAX_CHARS=140
+
 # Post a commit status for STATUS_CONTEXT. Used for pending/failure on remote
 # runs and the final success attestation.
 #
@@ -661,7 +667,7 @@ warn_status_not_recorded() {
 # its token — would otherwise discard hours of runner time for good.
 post_commit_status() {
   local repo="$1" sha="$2" state="$3" description="$4"
-  description="${description:0:140}"
+  description="${description:0:STATUS_DESC_MAX_CHARS}"
   debug "posting ${STATUS_CONTEXT}=${state} on ${repo}@${sha}: ${description}"
 
   local -a backoff=()
@@ -1396,10 +1402,15 @@ describe_check_failure() {
       # whose objects the linker cannot digest — and this cannot tell. A
       # recurrence on this branch alone, or on a crate whose build this branch
       # changes, is worth suspecting the diff for.
-      # Kept to the register of the sibling arms so that, with a five-digit
-      # elapsed, the whole line fits GitHub's 140-character status description
-      # and the attribution suffix survives; the summary carries the detail.
-      SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not complete after ${elapsed}s — a compiler subprocess crashed on the runner; re-dispatch (triggered by ${user})"
+      #
+      # Kept to the register of the two sibling arms that fit — cause first,
+      # then "checks did not complete, re-dispatch". `post_commit_status` cuts
+      # the description at STATUS_DESC_MAX_CHARS and the attribution suffix is
+      # last, so what an over-long line loses is the name of whoever triggered
+      # the run, mid-word, rather than any of the detail. With the longest login
+      # GitHub issues (39 characters) and a six-digit elapsed this is 135
+      # characters where the wording it replaces was 155.
+      SIGNOFF_FAILURE_STATUS_DESC="Compiler subprocess crashed after ${elapsed}s — checks did not complete, re-dispatch (triggered by ${user})"
       SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — the compiler driver reported that a subprocess it ran died of a signal (a crash or an out-of-memory kill, not a diagnostic) — the linker on every run seen so far, though the driver words a frontend crash the same way — and cargo stopped the build at that crate, so **the checks did not complete**: the binary being linked was never produced and nothing after it ran, while whatever passed before it stands. That is the runner's toolchain failing on its own, not a statement about the branch. Re-dispatch the sign-off. If it recurs on this branch alone, or names a crate whose build this branch changes, the diff is worth suspecting."$'\n'
       SIGNOFF_FAILURE_MESSAGE="sign-off aborted: a compiler subprocess crashed on the runner, so the build did not finish (the checks did not complete) — re-dispatch"
       ;;

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -903,10 +903,18 @@ readonly TEST_LIST_FAILURE_PATTERN='error: creating test list failed'
 # seen so far — died of a signal rather than returning a diagnostic. `clang`
 # prints the first form with the signal's name and the second on its way out;
 # both are its own words for its own crash, and it writes a crash snapshot
-# beside them. `Killed: 9` is the same class from the other side: the kernel
-# taking the linker for memory. Anchored on the driver's prefix so the bare
-# words, which a test can print, are not enough on their own (#13614).
-readonly TOOLCHAIN_CRASH_PATTERN='unable to execute command: (Segmentation fault|Bus error|Illegal instruction|Abort trap|Killed: 9)|linker command failed due to signal'
+# beside them. GNU's driver says it through `collect2`. `Killed: 9` is the same
+# class from the other side: the kernel taking the linker for memory.
+#
+# Anchored on the driver's own `<driver>: error: ` prefix AT THE START of the
+# line (after the indentation rustc gives linker output), not on the words
+# alone: rustc quotes a build script's or `compile_error!`'s text verbatim under
+# its own `error:` line — `error: clang: error: linker command failed …` — and
+# a genuine defect worded like a crash, prefix included, must stay a verdict
+# about the branch even once cargo prints its summary (#13614). The driver's
+# own report is never preceded by anything but whitespace.
+# `[+]` rather than `\+` because awk rewrites `\+` in a -v value to a plain `+`.
+readonly TOOLCHAIN_CRASH_PATTERN='^[[:space:]]*(clang|clang[+][+]|cc|c[+][+]|gcc|g[+][+]|collect2): error: (unable to execute command: (Segmentation fault|Bus error|Illegal instruction|Abort trap|Killed: 9)|linker command failed due to signal|ld terminated with signal)'
 
 # The line that says the crash above stopped a compilation, rather than being
 # quoted by a test that ran to completion. cargo prints it once per crate whose
@@ -1368,20 +1376,23 @@ describe_check_failure() {
       ;;
     toolchain-crash)
       # The compiler driver reported that the linker died of a signal, and cargo
-      # stopped the build there: nothing was linked, so no test ran and no lint
-      # verdict was reached. Worded like the other kinds that reached no
-      # verdict, because the generic "checks failed" sends the author into a
-      # log several thousand lines long to look for a defect in a diff nothing
-      # judged (#13614, and #12813 before it).
+      # stopped the build at that crate: the binary it was linking was never
+      # produced, so the step that needed it never ran. Whatever passed before
+      # that point stands — run 33041791988 had already cleared lint — which is
+      # why this says "did not complete" and not "nothing ran". Worded like the
+      # other kinds that reached no verdict, because the generic "checks
+      # failed" sends the author into a log several thousand lines long to
+      # look for a defect in a diff nothing judged (#13614, and #12813 before
+      # it).
       #
       # Hedged rather than asserted, like corrupt-artifact: a crash can be the
       # branch's own doing — a build script it changes, a dependency it adds
       # whose objects the linker cannot digest — and this cannot tell. A
       # recurrence on this branch alone, or on a crate whose build this branch
       # changes, is worth suspecting the diff for.
-      SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not complete after ${elapsed}s — the linker crashed on the runner, so nothing was built; re-dispatch (triggered by ${user})"
-      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — the compiler driver reported that the linker died of a signal (a crash or an out-of-memory kill, not a diagnostic), and cargo stopped the build there, so **the checks did not complete**. That is the runner's toolchain failing on its own, not a statement about the branch. Re-dispatch the sign-off. If it recurs on this branch alone, or names a crate whose build this branch changes, the diff is worth suspecting."$'\n'
-      SIGNOFF_FAILURE_MESSAGE="sign-off aborted: the linker crashed on the runner, so the build never finished (the checks did not complete) — re-dispatch"
+      SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not complete after ${elapsed}s — the linker crashed on the runner, so the build did not finish; re-dispatch (triggered by ${user})"
+      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — the compiler driver reported that the linker died of a signal (a crash or an out-of-memory kill, not a diagnostic), and cargo stopped the build at that crate, so **the checks did not complete**: the binary being linked was never produced and nothing after it ran, while whatever passed before it stands. That is the runner's toolchain failing on its own, not a statement about the branch. Re-dispatch the sign-off. If it recurs on this branch alone, or names a crate whose build this branch changes, the diff is worth suspecting."$'\n'
+      SIGNOFF_FAILURE_MESSAGE="sign-off aborted: the linker crashed on the runner, so the build did not finish (the checks did not complete) — re-dispatch"
       ;;
     missing-target)
       # Neither of the two readings above: the runner is fine and the code was

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -1396,7 +1396,10 @@ describe_check_failure() {
       # whose objects the linker cannot digest — and this cannot tell. A
       # recurrence on this branch alone, or on a crate whose build this branch
       # changes, is worth suspecting the diff for.
-      SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not complete after ${elapsed}s — a compiler subprocess crashed on the runner, so the build did not finish; re-dispatch (triggered by ${user})"
+      # Kept to the register of the sibling arms so that, with a five-digit
+      # elapsed, the whole line fits GitHub's 140-character status description
+      # and the attribution suffix survives; the summary carries the detail.
+      SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not complete after ${elapsed}s — a compiler subprocess crashed on the runner; re-dispatch (triggered by ${user})"
       SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — the compiler driver reported that a subprocess it ran died of a signal (a crash or an out-of-memory kill, not a diagnostic) — the linker on every run seen so far, though the driver words a frontend crash the same way — and cargo stopped the build at that crate, so **the checks did not complete**: the binary being linked was never produced and nothing after it ran, while whatever passed before it stands. That is the runner's toolchain failing on its own, not a statement about the branch. Re-dispatch the sign-off. If it recurs on this branch alone, or names a crate whose build this branch changes, the diff is worth suspecting."$'\n'
       SIGNOFF_FAILURE_MESSAGE="sign-off aborted: a compiler subprocess crashed on the runner, so the build did not finish (the checks did not complete) — re-dispatch"
       ;;

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -1160,9 +1160,10 @@ assert_recorder "leaves a quoted driver diagnostic under rustc's error prefix un
    echo "error: could not compile \`runtime\` (build script) due to 1 previous error"
    exit 101' \
   101 no "build.rs" no no no
-# GNU's driver reports the same death through collect2.
+# GNU's driver reports the same death through collect2, whose signal path is a
+# `fatal error:` — the plain `error:` spelling alone would miss every GCC crash.
 assert_recorder "records the GNU driver's spelling of a linker killed by a signal" \
-  'echo "collect2: error: ld terminated with signal 11 [Segmentation fault]"
+  'echo "collect2: fatal error: ld terminated with signal 11 [Segmentation fault]"
    echo "error: could not compile \`cayenne\` (lib) due to 1 previous error"
    exit 101' \
   101 no "collect2" no no yes

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -1663,7 +1663,7 @@ assert_describe "tells the author to re-dispatch rather than to read the log" 10
 # status names the class, not the tool, because the driver's signature does not
 # distinguish its frontend from the linker.
 assert_describe "says a crashed compiler subprocess could not complete, not that checks failed" 101 \
-  "Sign-off could not complete after 21195s — a compiler subprocess crashed on the runner, so the build did not finish; re-dispatch (triggered by someone)" \
+  "Sign-off could not complete after 21195s — a compiler subprocess crashed on the runner; re-dispatch (triggered by someone)" \
   "the checks did not complete" \
   SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 assert_describe_lacks "does not call a crashed compiler subprocess a check failure" 101 \

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -1119,6 +1119,18 @@ assert_recorder "records a linker that died of a signal" \
    echo "make: *** [nextest] Error 101"
    exit 101' \
   101 no "Segmentation fault" no no yes
+# The driver words a crash in its own frontend identically — `unable to execute
+# command: <signal>` names the subprocess only by its signal — so this signature
+# is the same no-verdict class one step earlier, with no linker involved at all.
+# Recorded rather than excluded: narrowing to the linker would send a frontend
+# crash back to the generic "checks failed" this kind exists to replace, and the
+# published wording therefore names the class and not the tool.
+assert_recorder "records the driver's own frontend dying of a signal, not just the linker" \
+  'echo "clang: error: unable to execute command: Segmentation fault: 11"
+   echo "clang: error: clang frontend command failed due to signal (use -v to see invocation)"
+   echo "error: could not compile \`spiced\` (lib) due to 1 previous error"
+   exit 101' \
+  101 no "Segmentation fault" no no yes
 # The same pool has killed a linker for memory, which the driver reports in the
 # same channel with the kernel's wording.
 assert_recorder "records a linker the kernel killed" \
@@ -1408,7 +1420,7 @@ assert_failure_kind "ignores an artifact flag when nothing watched the build" 10
 # and cargo stopped there, and none of the three causes above went past. Distinct
 # from "checks" for the same reason as every kind above — nothing about the
 # branch was judged (#13614).
-assert_failure_kind "calls a linker that died of a signal its own kind, not a check failure" 101 "toolchain-crash" \
+assert_failure_kind "calls a compiler subprocess that died of a signal its own kind, not a check failure" 101 "toolchain-crash" \
   SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 # The three named causes outrank the symptom, because each carries its own remedy.
 assert_failure_kind "reports disk when the volume filled and the linker died" 101 "disk" \
@@ -1645,14 +1657,16 @@ assert_describe "tells the author to re-dispatch rather than to read the log" 10
   "Sign-off could not complete after 21195s — a test binary on the runner would not load; re-dispatch (triggered by someone)" \
   "re-dispatch" \
   SIGNOFF_DISK_WATCH=1 SIGNOFF_ARTIFACT_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
-# A linker that died of a signal has to say so in the commit status too, and
-# name the remedy: run 33041791988 published "Sign-off checks failed after
-# 5975s" for a crash on a crate the branch never touched (#13614).
-assert_describe "says a crashed linker could not complete, not that checks failed" 101 \
-  "Sign-off could not complete after 21195s — the linker crashed on the runner, so the build did not finish; re-dispatch (triggered by someone)" \
+# A compiler subprocess that died of a signal has to say so in the commit status
+# too, and name the remedy: run 33041791988 published "Sign-off checks failed
+# after 5975s" for a crash on a crate the branch never touched (#13614). The
+# status names the class, not the tool, because the driver's signature does not
+# distinguish its frontend from the linker.
+assert_describe "says a crashed compiler subprocess could not complete, not that checks failed" 101 \
+  "Sign-off could not complete after 21195s — a compiler subprocess crashed on the runner, so the build did not finish; re-dispatch (triggered by someone)" \
   "the checks did not complete" \
   SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
-assert_describe_lacks "does not call a crashed linker a check failure" 101 \
+assert_describe_lacks "does not call a crashed compiler subprocess a check failure" 101 \
   "checks failed" \
   SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 assert_describe "still publishes a genuine check failure" 101 \

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -1140,6 +1140,32 @@ assert_recorder "leaves an ordinary compile failure unmarked despite cargo's sum
    echo "error: could not compile \`runtime\` (lib) due to 1 previous error"
    exit 101' \
   101 no "E0308" no no no
+# The words alone, under rustc's own `error:` rather than the driver's, are a
+# defect the branch wrote — a `compile_error!` or a build script quoting them —
+# and cargo's summary follows a defect just as it follows a crash. Only the
+# driver's prefix tells the two apart.
+assert_recorder "leaves a compile error worded like a crash unmarked" \
+  'echo "error: linker command failed due to signal"
+   echo "  --> crates/runtime/build.rs:1:1"
+   echo "error: could not compile \`runtime\` (build script) due to 1 previous error"
+   exit 101' \
+  101 no "build.rs" no no no
+# The complete driver diagnostic, prefix included, quoted under rustc's own
+# `error:` — a `compile_error!` that copied the wording, or a build script that
+# echoed it and then failed for its own reasons. The driver itself never prints
+# behind another prefix, so only a line-start anchor tells this from the real one.
+assert_recorder "leaves a quoted driver diagnostic under rustc's error prefix unmarked" \
+  'echo "error: clang: error: linker command failed due to signal (use -v to see invocation)"
+   echo "  --> crates/runtime/build.rs:3:5"
+   echo "error: could not compile \`runtime\` (build script) due to 1 previous error"
+   exit 101' \
+  101 no "build.rs" no no no
+# GNU's driver reports the same death through collect2.
+assert_recorder "records the GNU driver's spelling of a linker killed by a signal" \
+  'echo "collect2: error: ld terminated with signal 11 [Segmentation fault]"
+   echo "error: could not compile \`cayenne\` (lib) due to 1 previous error"
+   exit 101' \
+  101 no "collect2" no no yes
 # Disk wins over a crash, as it wins over the other two: a volume at zero can
 # take the linker down too, and reclaiming space is the remedy that fixes both.
 assert_recorder "reports disk, not the crash, when the volume filled as well" \
@@ -1622,7 +1648,7 @@ assert_describe "tells the author to re-dispatch rather than to read the log" 10
 # name the remedy: run 33041791988 published "Sign-off checks failed after
 # 5975s" for a crash on a crate the branch never touched (#13614).
 assert_describe "says a crashed linker could not complete, not that checks failed" 101 \
-  "Sign-off could not complete after 21195s — the linker crashed on the runner, so nothing was built; re-dispatch (triggered by someone)" \
+  "Sign-off could not complete after 21195s — the linker crashed on the runner, so the build did not finish; re-dispatch (triggered by someone)" \
   "the checks did not complete" \
   SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 assert_describe_lacks "does not call a crashed linker a check failure" 101 \

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -10,12 +10,12 @@
 # credentials: a stub `df` on PATH reports whatever free space a case needs, and a
 # stub `make` prints whatever a case needs the watcher to read.
 #
-# `failure_kind` names three further causes with the same consequence — a run that
+# `failure_kind` names four further causes with the same consequence — a run that
 # was signalled and so judged nothing at all, a branch whose Makefile has no rule
-# for a target the gate invokes, so nothing was compiled, and a test binary the
-# runner's loader will not execute, so nothing was run — so their cases live here
-# too, alongside `describe_check_failure`, which turns any of them into what the
-# run publishes. The make-target preflight is here for the same reason
+# for a target the gate invokes, so nothing was compiled, a test binary the
+# runner's loader will not execute, so nothing was run, and a linker that died of
+# a signal, so nothing was built — so their cases live here too, alongside
+# `describe_check_failure`, which turns any of them into what the run publishes. The make-target preflight is here for the same reason
 # the disk one is: it decides whether a run gets to start, and getting it wrong
 # either way is the bug.
 #
@@ -906,6 +906,9 @@ assert_recorder() {
   # ...and the same for the unloadable-artifact signature, which the disk and
   # cache cases above must not trip either.
   local want_artifact_marked="${7:-no}"
+  # ...and for the crashed-toolchain signature, so every earlier case also proves
+  # an ordinary compile failure is not read as a linker crash.
+  local want_toolchain_marked="${8:-no}"
   tests_run=$((tests_run + 1))
 
   local fake_make="$stub_dir/make"
@@ -921,6 +924,7 @@ assert_recorder() {
       echo "VERDICT=${SIGNOFF_DISK_HIT:+yes}"
       echo "CACHEHIT=${SIGNOFF_CACHE_HIT:+yes}"
       echo "ARTIFACTHIT=${SIGNOFF_ARTIFACT_HIT:+yes}"
+      echo "TOOLCHAINHIT=${SIGNOFF_TOOLCHAIN_HIT:+yes}"
       exit "$step_rc"' _ "$subject" 2>&1)"
   rc=$?
 
@@ -970,6 +974,19 @@ assert_recorder() {
   fi
   if [[ "$artifact_marked" != "$want_artifact_marked" ]]; then
     fail_test "$name: expected artifact_marked=${want_artifact_marked}, got ${artifact_marked} (output: '${output}')"
+    rm -f "$fake_make"
+    return
+  fi
+
+  local toolchain_marked="no"
+  [[ "$output" == *"TOOLCHAINHIT=yes"* ]] && toolchain_marked="yes"
+  if [[ "$output" != *"TOOLCHAINHIT="* ]]; then
+    fail_test "$name: the step never reported a toolchain verdict — output: '${output}'"
+    rm -f "$fake_make"
+    return
+  fi
+  if [[ "$toolchain_marked" != "$want_toolchain_marked" ]]; then
+    fail_test "$name: expected toolchain_marked=${want_toolchain_marked}, got ${toolchain_marked} (output: '${output}')"
     rm -f "$fake_make"
     return
   fi
@@ -1090,6 +1107,47 @@ assert_recorder "reports disk, not the artifact, when the volume filled first" \
    echo "  Malformed Mach-o file (os error 88)"
    exit 104' \
   104 yes "errno=28" no no
+
+# Verbatim from run 33041791988, where the linker took SIGSEGV linking a cayenne
+# test binary on a branch that never touched the crate, and the run published
+# "Sign-off checks failed" (#13614). cargo stopped at the crate, so no test ran.
+assert_recorder "records a linker that died of a signal" \
+  'echo "          clang: error: unable to execute command: Segmentation fault: 11"
+   echo "          clang: error: linker command failed due to signal (use -v to see invocation)"
+   echo "          clang: note: diagnostic msg: /var/folders/mk/T/linker-crash-122a1e"
+   echo "error: could not compile \`cayenne\` (test \"result_correctness_vs_sqlite_test\") due to 1 previous error"
+   echo "make: *** [nextest] Error 101"
+   exit 101' \
+  101 no "Segmentation fault" no no yes
+# The same pool has killed a linker for memory, which the driver reports in the
+# same channel with the kernel's wording.
+assert_recorder "records a linker the kernel killed" \
+  'echo "clang: error: unable to execute command: Killed: 9"
+   echo "error: could not compile \`runtime\` (lib) due to 1 previous error"
+   exit 101' \
+  101 no "Killed: 9" no no yes
+# Both halves are required. This repo's own suites assert on error strings, so a
+# test that quotes the driver's wording and then fails must stay a verdict about
+# the branch — and cargo never prints "could not compile" for a test that ran.
+assert_recorder "leaves a failure unmarked when the crash wording is only quoted" \
+  'echo "assertion failed: expected \"linker command failed due to signal\""
+   echo "test result: FAILED. 1 passed; 1 failed"
+   exit 100' \
+  100 no "assertion failed" no no no
+# ...and cargo's line alone is every ordinary compile error, which is the branch.
+assert_recorder "leaves an ordinary compile failure unmarked despite cargo's summary line" \
+  'echo "error[E0308]: mismatched types"
+   echo "error: could not compile \`runtime\` (lib) due to 1 previous error"
+   exit 101' \
+  101 no "E0308" no no no
+# Disk wins over a crash, as it wins over the other two: a volume at zero can
+# take the linker down too, and reclaiming space is the remedy that fixes both.
+assert_recorder "reports disk, not the crash, when the volume filled as well" \
+  'echo "ld: write() failed, errno=28 (No space left on device)"
+   echo "clang: error: linker command failed due to signal (use -v to see invocation)"
+   echo "error: could not compile \`cayenne\` (lib) due to 1 previous error"
+   exit 101' \
+  101 yes "errno=28" no no no
 
 # Stickiness: a step that merely mentions running out of disk and then succeeds
 # must not leave the verdict blaming the volume for a later, genuine failure.
@@ -1319,6 +1377,27 @@ assert_failure_kind "a signalled run stays signalled, not an unloadable artifact
 assert_failure_kind "ignores an artifact flag when nothing watched the build" 104 "checks" \
   SIGNOFF_ARTIFACT_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 
+# The crashed-toolchain kind: the watch was armed, the linker reported a signal
+# and cargo stopped there, and none of the three causes above went past. Distinct
+# from "checks" for the same reason as every kind above — nothing about the
+# branch was judged (#13614).
+assert_failure_kind "calls a linker that died of a signal its own kind, not a check failure" 101 "toolchain-crash" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+# The three named causes outrank the symptom, because each carries its own remedy.
+assert_failure_kind "reports disk when the volume filled and the linker died" 101 "disk" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_DISK_HIT=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+assert_failure_kind "reports cache when the cache was unreachable and the linker died" 101 "cache" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_CACHE_HIT=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+assert_failure_kind "reports the unloadable artifact over the crash when both were recorded" 104 "corrupt-artifact" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_ARTIFACT_HIT=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+# ...and a signalled run still outranks it: it reached no verdict at all.
+assert_failure_kind "a signalled run stays signalled, not a crashed toolchain" 143 "signalled" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+# A crash flag inherited from the environment with nothing watching is not a
+# reading anyone took, exactly as for the artifact flag above.
+assert_failure_kind "ignores a crash flag when nothing watched the build" 101 "checks" \
+  SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+
 # The cache verdict, same shape as the disk one: authoritative when the watch was
 # armed, and worth nothing without it.
 assert_failure_kind "calls an unreachable compiler cache an infrastructure failure" 101 "cache" \
@@ -1539,6 +1618,16 @@ assert_describe "tells the author to re-dispatch rather than to read the log" 10
   "Sign-off could not complete after 21195s — a test binary on the runner would not load; re-dispatch (triggered by someone)" \
   "re-dispatch" \
   SIGNOFF_DISK_WATCH=1 SIGNOFF_ARTIFACT_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+# A linker that died of a signal has to say so in the commit status too, and
+# name the remedy: run 33041791988 published "Sign-off checks failed after
+# 5975s" for a crash on a crate the branch never touched (#13614).
+assert_describe "says a crashed linker could not complete, not that checks failed" 101 \
+  "Sign-off could not complete after 21195s — the linker crashed on the runner, so nothing was built; re-dispatch (triggered by someone)" \
+  "the checks did not complete" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+assert_describe_lacks "does not call a crashed linker a check failure" 101 \
+  "checks failed" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 assert_describe "still publishes a genuine check failure" 101 \
   "Sign-off checks failed after 21195s (triggered by someone)" \
   "sign-off checks failed" STUB_FREE_KB="$(gib_to_kb 200)"

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -1663,12 +1663,70 @@ assert_describe "tells the author to re-dispatch rather than to read the log" 10
 # status names the class, not the tool, because the driver's signature does not
 # distinguish its frontend from the linker.
 assert_describe "says a crashed compiler subprocess could not complete, not that checks failed" 101 \
-  "Sign-off could not complete after 21195s — a compiler subprocess crashed on the runner; re-dispatch (triggered by someone)" \
+  "Compiler subprocess crashed after 21195s — checks did not complete, re-dispatch (triggered by someone)" \
   "the checks did not complete" \
   SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 assert_describe_lacks "does not call a crashed compiler subprocess a check failure" 101 \
   "checks failed" \
   SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+# What a verdict must still say once GitHub is done with the line.
+#
+# post_commit_status cuts the description at STATUS_DESC_MAX_CHARS and the
+# attribution suffix is last, so an over-long verdict does not lose the detail
+# — it loses the name of whoever triggered it, mid-word. Asserted as a
+# property rather than against a copy of the text, so rewording an arm cannot
+# pass this by accident, and driven through describe_check_failure so it
+# measures what the run will publish.
+#
+# The cap comes from the subject rather than a literal here: a second copy of
+# the number is a guard that can agree with itself while the real cut still
+# truncates. The length likewise comes from the subject, which is the shell
+# that performs the cut — with no locale set that counts bytes, two or three
+# more than the characters GitHub counts, so this errs strict and never lax.
+assert_describe_fits() {
+  local name="$1" check_status="$2"
+  shift 2
+  tests_run=$((tests_run + 1))
+
+  # The longest login GitHub issues. The bug only appears at this boundary:
+  # every login that signs off today is a third of it, which is why four arms
+  # carried it unnoticed (spiceai/spiceai#14076).
+  local login
+  login="$(printf "%0${LONGEST_LOGIN_LEN}d" 0 | tr 0 a)"
+
+  local result rc output length cap
+  result="$(call_subject \
+    "describe_check_failure ${check_status} 999999 ${login}
+     printf 'LEN[%s]\nCAP[%s]\nDESC[%s]\n' \"\${#SIGNOFF_FAILURE_STATUS_DESC}\" \"\$STATUS_DESC_MAX_CHARS\" \"\$SIGNOFF_FAILURE_STATUS_DESC\"" \
+    "$@")"
+  rc="${result%%|*}"
+  output="${result#*|}"
+
+  if [[ "$rc" -ne 0 ]]; then
+    fail_test "$name: expected exit 0, got ${rc} (output: ${output})"
+    return
+  fi
+  length="${output#*LEN[}"; length="${length%%]*}"
+  cap="${output#*CAP[}"; cap="${cap%%]*}"
+  if [[ ! "$length" =~ ^[0-9]+$ || ! "$cap" =~ ^[0-9]+$ ]]; then
+    fail_test "$name: the verdict's length or the cap did not parse: '${output}'"
+    return
+  fi
+  if (( length > cap )); then
+    fail_test "$name: the verdict is ${length} long against a cap of ${cap}; GitHub cuts it there and the attribution is what is lost: '${output}'"
+    return
+  fi
+  if [[ "$output" != *"(triggered by ${login})"* ]]; then
+    fail_test "$name: the verdict must carry the whole login: '${output}'"
+    return
+  fi
+  echo "  ok: $name"
+}
+readonly LONGEST_LOGIN_LEN=39
+
+assert_describe_fits "the crash verdict fits a commit status with the longest login GitHub issues" 101 \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_TOOLCHAIN_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+
 assert_describe "still publishes a genuine check failure" 101 \
   "Sign-off checks failed after 21195s (triggered by someone)" \
   "sign-off checks failed" STUB_FREE_KB="$(gib_to_kb 200)"


### PR DESCRIPTION
## Summary

Sign-off [run 33041791988](https://github.com/spiceai/spiceai/actions/runs/33041791988) lost the linker to `SIGSEGV` while linking a `cayenne` test binary on a branch that never touched the crate, and published `Sign-off checks failed after 5975s`. Lint had already passed; the crash stopped `cargo test --no-run`, so the binary being linked was never produced and no test ran — but the commit status was indistinguishable from a lint or test denial, which sends the author into an 8,700-line log for a defect that is not there and hides the one remedy that applies (re-dispatch).

**Root cause:** `run_make_step`'s build-output watcher recognised three no-verdict signatures — out-of-disk, an unreachable `sccache`, and a test binary the loader will not execute (#13597) — and `failure_kind` fell through to `checks` for everything else. A compiler driver reporting that the linker died of a signal is the same class one step earlier than the corrupt-artifact case, and nothing read it.

## Changes

- `scripts/signoff`: the watcher reads a fourth signature, in the same two-part shape that keeps the corrupt-artifact one honest — the compiler driver reporting a signal under its own prefix **at the start of the line** (`^[[:space:]]*(clang|clang++|cc|c++|gcc|g++|collect2): (fatal )?error: ` — collect2 says `fatal error:` — followed by `unable to execute command: Segmentation fault|Bus error|Illegal instruction|Abort trap|Killed: 9`, `linker command failed due to signal`, or collect2's `fatal error: ld terminated with signal`) **and** cargo's own `error: could not compile … due to` line. A test that quotes the driver's wording, a `compile_error!` or build script whose text carries the whole driver diagnostic (which rustc renders behind its own `error:`, so not at line start), and an ordinary compile error (cargo's line alone) all stay verdicts about the branch.
- `failure_kind` names it `toolchain-crash`, below `disk`, `cache` and `corrupt-artifact` (each of those names a cause with its own remedy; this one names the symptom), and above `checks`. A signalled run still outranks all of them. Without an armed watch the flag is ignored, exactly as the artifact flag is.
- `describe_check_failure` publishes it in the register the other no-verdict kinds use — *Sign-off could not complete … the linker crashed on the runner, so the build did not finish; re-dispatch* — saying what did not complete rather than that nothing ran (whatever passed before the crash stands), with the same hedge as corrupt-artifact: a recurrence on one branch alone, or on a crate whose build the branch changes, is worth suspecting the diff for.
- `scripts/test_signoff_disk_guard.sh`: 16 cases — the verbatim run-33041791988 signature, the `Killed: 9` and `collect2` spellings are recorded; the crash wording quoted by a failing test, the full driver diagnostic quoted under rustc's `error:`, and cargo's line on an ordinary compile error are not; disk wins when both appear; the `failure_kind` precedence and the published wording.
- `docs/dev/ci_signoff.md`: a subsection for the new status text, beside the disk and cache ones.

The missing-toolchain signature the issue's comment adds (`make: cargo: No such file or directory`) is a preflight-shaped fix, not a watcher signature, and is left to #13614's follow-up discussion rather than folded in here.

## Test plan
- [x] Added regression test for the run-33041791988 signature (linker `SIGSEGV` + cargo `could not compile`) being recorded, classified `toolchain-crash`, and published as "could not complete … re-dispatch" — `scripts/test_signoff_disk_guard.sh`, output below
- [x] Added edge case tests for the `Killed: 9` and `collect2` spellings, the crash wording only quoted by a test, the whole driver diagnostic quoted under rustc's `error:`, cargo's line on an ordinary compile error, disk/cache/artifact precedence, a signalled run, and an unarmed watch — same suite, output below
- [x] `make lint` / `make test` (workspace gates): not run — this PR changes no Rust, and the remote sign-off fast-tracked the branch as such: `signoff: success — Signed off by grokspice via remote — no Rust changes (lint/test skipped)` ([run https://github.com/spiceai/spiceai/actions/runs/34553053875](https://github.com/spiceai/spiceai/actions/runs/34553053875) on HEAD `a73840b3`; the first push was signed off the same way by [run 34548818815](https://github.com/spiceai/spiceai/actions/runs/34548818815)). The shell suites below are the checks that cover this change.
- [x] `make signoff` equivalent run on the pushed HEAD `a73840b3` via `signoff.yml` (`branch=` dispatch, [run https://github.com/spiceai/spiceai/actions/runs/34553053875](https://github.com/spiceai/spiceai/actions/runs/34553053875)) — commit status read back: `signoff: success — Signed off by grokspice via remote — no Rust changes (lint/test skipped) in 2s`; `Attestation` re-run on the PR
- [x] `bash scripts/test_signoff_disk_guard.sh` on the branch @ `a73840b3`:
  ```
  ok: records a linker that died of a signal
  ok: records a linker the kernel killed
  ok: leaves a failure unmarked when the crash wording is only quoted
  ok: leaves an ordinary compile failure unmarked despite cargo's summary line
  ok: leaves a compile error worded like a crash unmarked
  ok: leaves a quoted driver diagnostic under rustc's error prefix unmarked
  ok: records the GNU driver's spelling of a linker killed by a signal   (collect2: fatal error: ld terminated with signal 11)
  ok: reports disk, not the crash, when the volume filled as well
  ok: calls a linker that died of a signal its own kind, not a check failure
  ok: reports disk when the volume filled and the linker died
  ok: reports cache when the cache was unreachable and the linker died
  ok: reports the unloadable artifact over the crash when both were recorded
  ok: a signalled run stays signalled, not a crashed toolchain
  ok: ignores a crash flag when nothing watched the build
  ok: says a crashed linker could not complete, not that checks failed
  ok: does not call a crashed linker a check failure
  1 of 180 tests failed
  ```
  The one failure is `treats a runner with no make as target present: expected exit 0, got 127` — this Windows host has no `make` on `PATH`, and the same case fails identically against unmodified `origin/trunk` (`1 of 164 tests failed`). `scripts/test_signoff_status.sh`: `all 34 tests passed`. `shellcheck -S warning scripts/signoff scripts/test_signoff_disk_guard.sh`: exit 0.

### Reproduction
Before, on `trunk` @ 9972f4a6d4 — the 31 lines of run 33041791988's log around the crash (its indented `clang: error:` lines and cargo's `could not compile`), fed through `run_make_step` by a stub `make` that prints them and exits 101, then classified:
```
$ env PATH=$stub:$PATH SIGNOFF_DISK_WATCH=1 bash -c 'source scripts/signoff; run_make_step nextest >/dev/null || rc=$?; echo "make exit=$rc failure_kind=$(failure_kind $rc)"; describe_check_failure $rc 5975 grokspice; echo "status: $SIGNOFF_FAILURE_STATUS_DESC"'
make exit=101 failure_kind=checks
status: Sign-off checks failed after 5975s (triggered by grokspice)
```
After, on this branch @ a73840b3:
```
$ (same command)
make exit=101 failure_kind=toolchain-crash
status: Sign-off could not complete after 5975s — the linker crashed on the runner, so the build did not finish; re-dispatch (triggered by grokspice)
```

## Review gate

- Adversarial review: `codex` — job `review-mtx5sbqu-nzog4t` — verdict approve on the current HEAD (7d204d3f97): no findings. On the previous head 754c65f109 (`review-mtx50bz7-xpdlwi`) it also approved with no findings. Earlier rounds shaped this diff: `review-mtw8wloy-57j59e` (initial push) approved; `review-mtwa4ndr-m80xvi` (the Copilot-driven follow-up) found that the driver-prefix anchor still matched the complete driver diagnostic when rustc quotes it under its own `error:` — fixed by anchoring the pattern at line start, with the quoted-diagnostic negative added to the suite; `review-mtwamu3l-b9wtlj` approved that fix, and the collect2 `fatal error:` spelling Copilot raised followed
- `/security-review`: no findings on the last two commits — the non-comment diff is three constant strings, `TOOLCHAIN_CRASH_PATTERN`, `COMPILE_ABORTED_PATTERN`, `failure_kind` and the awk recorder are unchanged, and the text reaches GitHub through `post_commit_status` with `state` hard-wired to `failure`, so the new kind can change a red status's wording but not its colour. Its one informational note — the status description ran to 153 characters with a five-digit elapsed and `post_commit_status` truncates at 140, dropping the `(triggered by <user>)` attribution — is what 7d204d3f97 fixes (now 124). Earlier rounds: the awk patterns are `readonly` constants consumed as boolean matches, and the published text interpolates only `elapsed` and `user`, as the sibling arms do
- `/simplify`: nothing applicable on the last two commits (constant strings and comments). Two findings applied earlier — `g++` was missing from the driver alternation that already carried `clang++`, and the docs named two driver prefixes where the code anchors on six (now stated generally); the first round's four passes returned no findings, with a table-driven signature registry noted as a separate follow-up refactor once a fifth signature lands


### Review gate for the unblocking commit `ff28db9bb9` (grokspice)

Attests the fix commit below, not the work above it.

- **Adversarial review**: `codex` — verdict **approve**, no material findings, scoped `origin/trunk...HEAD`. It noted it could not run the suite itself (its sandbox denied `CreateFileMapping`) and asked for `scripts/test_signoff_disk_guard.sh` on a compatible runner — done, see below.
- **`/security-review`**: **no findings**. The new `STATUS_DESC_MAX_CHARS` is a `readonly` constant consumed by an existing slice; the reworded string interpolates only `elapsed` and `user`, exactly as the sibling arms do, and reaches GitHub as a single argv element (`-f "description=..."`), never re-parsed by a shell. `SIGNOFF_TOOLCHAIN_HIT` cannot turn a failing run into a passing one: its arm is reachable only inside the non-zero branch of `run_checks`, and `run_make_step` clears it before every step.
- **`/simplify`**: four passes; findings applied — the bespoke inline assertion became `assert_describe_fits` (it now checks `call_subject`'s exit status, which the inline form only caught incidentally through its parse guard), the duplicated `140` became `STATUS_DESC_MAX_CHARS` read from the subject, the elapsed moved to six digits to match the budget the comment states, ~5 duplicative comment lines were cut, and the figures were corrected against measurement. Deferred with an issue: a budgeting helper plus a property test over every arm (#14076).

**Correction to the note above**: this block previously recorded the over-length description as fixed by `7d204d3f97` ("now 124"). That figure holds only for a short login. Measured through `describe_check_failure` with the longest login GitHub issues (39 characters), `7d204d3f97` rendered **155** characters — still over the 140 cap — which is the finding copilot re-raised and what this commit actually closes (now 135).

**Evidence**: `bash scripts/test_signoff_disk_guard.sh` — **181 of 182 pass**. The one failure, `treats a runner with no make as target present` (exit 127), reproduces identically on `@{upstream}` and is a Windows/MSYS host artifact (no `make` on the stubbed PATH), not this diff. The new guard was mutation-tested: reverting only the wording in `scripts/signoff` makes it fail with `the verdict is 157 long against a cap of 140`, and restoring it makes it pass.
Fixes #13614

## Checklist
- [x] PR title follows conventional commits and carries `(fixes #13614)`
- [x] Assigned to the authoring bot and labelled `area/ci`
- [x] No `.claude/worktrees/` paths staged


