### PR TITLE
fix(smb): pad an empty CREATE buffer so Samba lists the share root (fixes #13293)

### DIFF
--- a/crates/smb/src/client.rs
+++ b/crates/smb/src/client.rs
@@ -1634,16 +1634,6 @@ mod tests {
 
     const STATUS_MORE_PROCESSING_REQUIRED: u32 = 0xC000_0016;
     const SMB2_FLAGS_RESPONSE: u32 = 0x0000_0001;
-
-    #[test]
-    fn status_error_names_the_share_root_for_an_empty_path() {
-        let err = smb_status_to_io_error(0xC000_000D, "");
-        assert_eq!(err.kind(), io::ErrorKind::Other);
-        assert_eq!(err.to_string(), "SMB error 0xC000000D for <share root>");
-
-        let err = smb_status_to_io_error(0xC000_000D, "sub");
-        assert_eq!(err.to_string(), "SMB error 0xC000000D for sub");
-    }
     const TEST_USERNAME: &str = "spicetester";
     const TEST_PASSWORD: &str = "s3cret-pw!";
     const TEST_DOMAIN: &str = "WORKGROUP";
@@ -1909,6 +1899,16 @@ mod tests {
         let result = client.tree_connect("data").await;
         let client_sig_ok = server.await.expect("mock server task");
         (result, client_sig_ok)
+    }
+
+    #[test]
+    fn status_error_names_the_share_root_for_an_empty_path() {
+        let err = smb_status_to_io_error(0xC000_000D, "");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.to_string(), "SMB error 0xC000000D for <share root>");
+
+        let err = smb_status_to_io_error(0xC000_000D, "sub");
+        assert_eq!(err.to_string(), "SMB error 0xC000000D for sub");
     }
 
     /// Regression test for #11148: the signing key must be derived from a

--- a/crates/smb/src/client.rs
+++ b/crates/smb/src/client.rs
@@ -1453,6 +1453,13 @@ fn update_preauth_hash(hash: &mut [u8; 64], message: &[u8]) {
 }
 
 fn smb_status_to_io_error(status: u32, path: &str) -> io::Error {
+    // The share root is addressed by the empty path; name it rather than
+    // leaving the message to trail off after "for ".
+    let path = if path.is_empty() {
+        "<share root>"
+    } else {
+        path
+    };
     tracing::warn!(target: "smb", "error 0x{status:08X}: {path}");
     match status {
         0xC000_000F // STATUS_NO_SUCH_FILE
@@ -1627,6 +1634,16 @@ mod tests {
 
     const STATUS_MORE_PROCESSING_REQUIRED: u32 = 0xC000_0016;
     const SMB2_FLAGS_RESPONSE: u32 = 0x0000_0001;
+
+    #[test]
+    fn status_error_names_the_share_root_for_an_empty_path() {
+        let err = smb_status_to_io_error(0xC000_000D, "");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.to_string(), "SMB error 0xC000000D for <share root>");
+
+        let err = smb_status_to_io_error(0xC000_000D, "sub");
+        assert_eq!(err.to_string(), "SMB error 0xC000000D for sub");
+    }
     const TEST_USERNAME: &str = "spicetester";
     const TEST_PASSWORD: &str = "s3cret-pw!";
     const TEST_DOMAIN: &str = "WORKGROUP";

--- a/crates/smb/src/protocol.rs
+++ b/crates/smb/src/protocol.rs
@@ -414,8 +414,9 @@ pub const CREATE_OPTION_DELETE_ON_CLOSE: u32 = 0x0000_1000;
 /// size declares that at least one byte of dynamic data follows the fixed
 /// part, so an empty buffer still has to carry one zero byte: Samba's
 /// `smbd_smb2_request_verify_sizes` answers a frame with no dynamic bytes
-/// with `STATUS_INVALID_PARAMETER` (0xC000000D), while Windows accepts it.
-/// The share root is the common case: its path is the empty string.
+/// with `STATUS_INVALID_PARAMETER` (0xC000000D); servers that do not enforce
+/// the minimum accept the shorter frame, so the gap only shows against
+/// Samba. The share root is the common case: its path is the empty string.
 fn put_variable_buffer(buf: &mut BytesMut, bytes: &[u8]) {
     if bytes.is_empty() {
         buf.put_u8(0);
@@ -1011,13 +1012,11 @@ mod tests {
     fn encode_create_request_with_name_has_no_padding() {
         let mut buf = BytesMut::new();
         encode_create_request(&mut buf, "sub", 0, 0, 0, 0);
-        let name_len = "sub".encode_utf16().count() * 2;
-        assert_eq!(buf.len(), 56 + name_len);
+        // "sub" is 3 UTF-16 code units: 6 dynamic bytes, so no padding byte.
+        assert_eq!(buf.len(), 56 + 6);
         assert_eq!(
-            usize::from(u16::from_le_bytes(
-                buf[46..48].try_into().expect("test fixture")
-            )),
-            name_len
+            u16::from_le_bytes(buf[46..48].try_into().expect("test fixture")),
+            6
         );
     }
 

--- a/crates/smb/src/protocol.rs
+++ b/crates/smb/src/protocol.rs
@@ -409,6 +409,21 @@ pub enum CreateOptions {
 /// Bit that adds `DELETE_ON_CLOSE` to a `CreateOptions` value.
 pub const CREATE_OPTION_DELETE_ON_CLOSE: u32 = 0x0000_1000;
 
+/// Append the variable-length `Buffer` of a request whose `StructureSize`
+/// is odd (57 for CREATE, 33 for QUERY_DIRECTORY, 49 for WRITE). The odd
+/// size declares that at least one byte of dynamic data follows the fixed
+/// part, so an empty buffer still has to carry one zero byte: Samba's
+/// `smbd_smb2_request_verify_sizes` answers a frame with no dynamic bytes
+/// with `STATUS_INVALID_PARAMETER` (0xC000000D), while Windows accepts it.
+/// The share root is the common case: its path is the empty string.
+fn put_variable_buffer(buf: &mut BytesMut, bytes: &[u8]) {
+    if bytes.is_empty() {
+        buf.put_u8(0);
+    } else {
+        buf.put_slice(bytes);
+    }
+}
+
 pub fn encode_create_request(
     buf: &mut BytesMut,
     path: &str,
@@ -435,7 +450,7 @@ pub fn encode_create_request(
     buf.put_u16_le(name_len); // NameLength
     buf.put_u32_le(0); // CreateContextsOffset
     buf.put_u32_le(0); // CreateContextsLength
-    buf.put_slice(&name_bytes);
+    put_variable_buffer(buf, &name_bytes);
 }
 
 #[derive(Debug, Clone)]
@@ -578,14 +593,7 @@ pub fn encode_write_request(buf: &mut BytesMut, file_id: &[u8; 16], offset: u64,
     buf.put_u16_le(0); // WriteChannelInfoOffset
     buf.put_u16_le(0); // WriteChannelInfoLength
     buf.put_u32_le(0); // Flags
-    // Spec mandates StructureSize=49 (one byte beyond the 48-byte fixed part).
-    // When `data` is empty we still need to emit one zero byte so stricter
-    // servers (and the SMB2 validator) accept the request.
-    if data.is_empty() {
-        buf.put_u8(0);
-    } else {
-        buf.put_slice(data);
-    }
+    put_variable_buffer(buf, data);
 }
 
 #[must_use]
@@ -661,7 +669,7 @@ pub fn encode_query_directory_request(
     buf.put_u16_le(name_offset);
     buf.put_u16_le(pattern_len);
     buf.put_u32_le(65536); // OutputBufferLength
-    buf.put_slice(&pattern_bytes);
+    put_variable_buffer(buf, &pattern_bytes);
 }
 
 #[derive(Debug, Clone)]
@@ -977,6 +985,68 @@ mod tests {
         let mut buf = BytesMut::new();
         encode_read_request(&mut buf, &[0u8; 16], 0, 65536);
         assert_eq!(buf.len(), 49);
+    }
+
+    /// The share root is opened with an empty name. Samba rejects a CREATE
+    /// whose dynamic part is empty with `STATUS_INVALID_PARAMETER`, so the
+    /// frame must still be 57 bytes long: 56 fixed bytes plus one padding
+    /// byte, with `NameLength` reporting the real (zero) length.
+    #[test]
+    fn encode_create_request_empty_name_pads_buffer() {
+        let mut buf = BytesMut::new();
+        encode_create_request(&mut buf, "", 0, 0, 0, 0);
+        assert_eq!(buf.len(), 57);
+        assert_eq!(
+            u16::from_le_bytes(buf[44..46].try_into().expect("test fixture")),
+            CREATE_NAME_OFFSET
+        );
+        assert_eq!(
+            u16::from_le_bytes(buf[46..48].try_into().expect("test fixture")),
+            0
+        );
+        assert_eq!(buf[56], 0);
+    }
+
+    #[test]
+    fn encode_create_request_with_name_has_no_padding() {
+        let mut buf = BytesMut::new();
+        encode_create_request(&mut buf, "sub", 0, 0, 0, 0);
+        let name_len = "sub".encode_utf16().count() * 2;
+        assert_eq!(buf.len(), 56 + name_len);
+        assert_eq!(
+            usize::from(u16::from_le_bytes(
+                buf[46..48].try_into().expect("test fixture")
+            )),
+            name_len
+        );
+    }
+
+    #[test]
+    fn encode_query_directory_request_empty_pattern_pads_buffer() {
+        let mut buf = BytesMut::new();
+        encode_query_directory_request(
+            &mut buf,
+            &[0u8; 16],
+            "",
+            FILE_ID_BOTH_DIRECTORY_INFORMATION,
+            true,
+        );
+        assert_eq!(buf.len(), 33);
+        assert_eq!(
+            u16::from_le_bytes(buf[26..28].try_into().expect("test fixture")),
+            0
+        );
+    }
+
+    #[test]
+    fn encode_write_request_empty_data_pads_buffer() {
+        let mut buf = BytesMut::new();
+        encode_write_request(&mut buf, &[0u8; 16], 0, &[]);
+        assert_eq!(buf.len(), 49);
+        assert_eq!(
+            u32::from_le_bytes(buf[4..8].try_into().expect("test fixture")),
+            0
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 📝 Summary

Listing the root of a Samba share fails with `SMB error 0xC000000D for ` (`STATUS_INVALID_PARAMETER`), so a dataset whose `from:` is the share root, which is what the SMB cookbook's `smb://localhost/data/` does, never loads.

Root cause: SMB2 requests with an odd `StructureSize` (CREATE = 57, QUERY_DIRECTORY = 33, WRITE = 49) declare that at least one byte of dynamic buffer follows the fixed part. `encode_create_request` emitted zero buffer bytes for an empty path, which is how the share root is opened. Samba's `smbd_smb2_request_verify_sizes` derives `min_dyn_size = expected_body_size & 1` and answers a frame with no dynamic bytes with `NT_STATUS_INVALID_PARAMETER` (`source3/smbd/smb2_server.c`, called with `0x39` from `smb2_create.c`). Servers that do not enforce the minimum dynamic length accept the shorter frame, which is why the gap only surfaces against Samba. The WRITE encoder already padded an empty payload; CREATE and QUERY_DIRECTORY did not.

## Changes

- `crates/smb/src/protocol.rs`: one `put_variable_buffer` helper pads an empty dynamic buffer with a single zero byte; the CREATE, QUERY_DIRECTORY and WRITE encoders route through it. `NameLength` / `Length` still report the real (zero) length, so the padding byte never desynchronises an offset a server or the client's own framer relies on.
- `crates/smb/src/client.rs`: `smb_status_to_io_error` names `<share root>` for an empty path instead of trailing off after "for ", which is the message the reporter saw.
- Tests: `encode_create_request_empty_name_pads_buffer`, `encode_create_request_with_name_has_no_padding`, `encode_query_directory_request_empty_pattern_pads_buffer`, `encode_write_request_empty_data_pads_buffer` (protocol.rs) and `status_error_names_the_share_root_for_an_empty_path` (client.rs).

## Test plan

### Reproduction

Samba 4.23.6 serving a share named `data` for user `testuser` (the cookbook's Step 2 layout: one file `userdata1.csv` at the root plus a `sub/` directory), and a probe test that calls `ShareSession::list_directory` / `list_objects` on the root and on the subdirectory.

On `trunk` (`e8dd9d2bf9`):

```
$ SMB_PROBE_HOST=172.19.222.107 cargo test -p smb --test probe_root -- --nocapture
list_directory("") -> ERR kind=Other msg=SMB error 0xC000000D for 
list_directory("sub") -> OK files=["sub/nested.csv"] dirs=[]
list_objects("") -> ERR kind=Other msg=SMB error 0xC000000D for 
list_objects("sub/") -> OK objs=["sub/nested.csv"] prefixes=[]
```

On this branch (`ae016b070f`):

```
$ SMB_PROBE_HOST=172.19.222.107 cargo test -p smb --test probe_root -- --nocapture
list_directory("") -> OK files=["userdata1.csv"] dirs=["sub"]
list_directory("sub") -> OK files=["sub/nested.csv"] dirs=[]
list_objects("") -> OK objs=["userdata1.csv"] prefixes=["sub/"]
list_objects("sub/") -> OK objs=["sub/nested.csv"] prefixes=[]
```

The regression tests fail on trunk's encoders (tests kept, helper calls reverted to `put_slice`) and pass here:

```
test protocol::tests::encode_query_directory_request_empty_pattern_pads_buffer ... FAILED   (left: 32, right: 33)
test protocol::tests::encode_create_request_empty_name_pads_buffer ... FAILED                (left: 56, right: 57)
test protocol::tests::encode_write_request_empty_data_pads_buffer ... ok

$ cargo test -p smb --lib
test result: ok. 75 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Gate

- [x] `make lint` / `make test`: not run locally — the workspace does not build on this Windows host, so the remote sign-off below is the gate. Crate-scoped `cargo fmt -- --check` and clippy with the repo's pedantic deny set (lib and tests) finished with no warnings: `Finished dev profile [unoptimized + debuginfo] target(s)`.
- [x] `make signoff` → `Attestation`: remote sign-off (`signoff.yml`) dispatched for this branch, local sign-off being blocked by the same Windows build constraint: https://github.com/spiceai/spiceai/actions/runs/34567265583 (in progress at PR creation; the sign-off status and the `Attestation` re-run land when it completes)

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits"; `grok` is not permitted to review a Grok-authored diff
- `/security-review`: no findings — the length fields are computed from the real payload before the padding byte is appended, the outer NetBIOS and compound framing derive from the actual body length, and no new server-controlled input reaches parsing
- `/simplify`: applied — two test-only edits (the share-root message test moved beside the module's other tests; the padding-free CREATE test asserts the literal UTF-16 length); light checks re-run: `cargo fmt -- --check` clean, clippy `Finished`, `test result: ok. 75 passed`

## 🔗 Related

Fixes #13293

## 📚 Docs

None. The cookbook's `smb://localhost/data/` configuration is correct as written; it was the client that could not list a share root.

## 👀 Notes for Reviewers

The WRITE encoder's existing empty-payload padding is folded into the same helper, so the invariant lives in one place. Only the request encoders change; no response parsing is touched.
