### PR TITLE
feat(cloud-connect): add a GetDatasets command that answers the /v1/datasets document (refs #13369)

### DIFF
--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -1568,6 +1568,7 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             Capability::ApplySpicepod
             | Capability::AttachApp
             | Capability::GetStatus
+            | Capability::GetDatasets
             | Capability::ExecuteQuery => true,
             // Only when the log-capture layer was installed at startup;
             // otherwise there is no buffer to read from.
@@ -1584,6 +1585,7 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             Capability::ApplySpicepod
             | Capability::AttachApp
             | Capability::GetStatus
+            | Capability::GetDatasets
             | Capability::ExecuteQuery => format!(
                 "{} is not supported by this instance",
                 capability.wire_name()
@@ -1636,6 +1638,21 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             "models": models,
             "catalogs": catalogs,
             "views": views,
+        })
+    }
+
+    /// The `/v1/datasets?status=true` document for the app this instance
+    /// serves: the same rows the local HTTP endpoint answers, so `spice cloud
+    /// datasets` shows a self-hosted instance the way it shows a managed one.
+    /// No loaded app is an empty list, not an error: there is nothing to list.
+    async fn datasets_json(&self) -> Result<serde_json::Value, CommandError> {
+        let Some(app) = self.runtime.read_app().await else {
+            return Ok(serde_json::Value::Array(Vec::new()));
+        };
+        let df = self.runtime.datafusion();
+        let infos = runtime::app_dataset_infos(Arc::clone(&self.runtime), &df, &app, true);
+        serde_json::to_value(infos).map_err(|source| {
+            CommandError::internal(format!("Failed to encode the dataset list: {source}"))
         })
     }
 

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -1644,13 +1644,8 @@ impl RuntimeHandle for SpicedRuntimeHandle {
     /// The `/v1/datasets?status=true` document for the app this instance
     /// serves: the same rows the local HTTP endpoint answers, so `spice cloud
     /// datasets` shows a self-hosted instance the way it shows a managed one.
-    /// No loaded app is an empty list, not an error: there is nothing to list.
     async fn datasets_json(&self) -> Result<serde_json::Value, CommandError> {
-        let Some(app) = self.runtime.read_app().await else {
-            return Ok(serde_json::Value::Array(Vec::new()));
-        };
-        let df = self.runtime.datafusion();
-        let infos = runtime::app_dataset_infos(Arc::clone(&self.runtime), &df, &app, true);
+        let infos = runtime::dataset_infos_with_status(&self.runtime).await;
         serde_json::to_value(infos).map_err(|source| {
             CommandError::internal(format!("Failed to encode the dataset list: {source}"))
         })

--- a/crates/runtime-cloud-connect/proto/cloud_connect.proto
+++ b/crates/runtime-cloud-connect/proto/cloud_connect.proto
@@ -178,6 +178,7 @@ message ControlMessage {
     DeleteSecrets delete_secrets = 15;
     ExecuteQuery execute_query = 18;
     AttachApp attach_app = 19;
+    GetDatasets get_datasets = 20;
   }
 
   // Correlates the eventual `CommandResult`. Empty for an unsolicited
@@ -254,7 +255,8 @@ message StandaloneRuntimeStatus {
 // reverse). Absent means the command produced no payload.
 message CommandResult {
   oneof payload {
-    // A JSON document (GetRuntimeInfo, GetStatus, ApplySpicepod, Adopt).
+    // A JSON document (GetRuntimeInfo, GetStatus, GetDatasets, ApplySpicepod,
+    // Adopt).
     string json = 1;
     // Verbatim text, not JSON-encoded (GetLogs).
     string text = 2;
@@ -370,6 +372,14 @@ message Remove {}
 // document carrying the `RuntimePhase` as its `phase`, a `reason`, and
 // whatever per-component detail the instance can supply.
 message GetStatus {}
+
+// Lists the datasets this instance serves, with the status of each. The reply
+// is the JSON array the instance's own `GET /v1/datasets?status=true` answers,
+// so the control plane reads the same document a local operator does; the
+// `spice cloud datasets` and `spice cloud status` dataset-health views relay
+// it. Advertised as `get_datasets`. A standalone instance lists itself; a
+// cluster instance is addressed by `ControlMessage.target`.
+message GetDatasets {}
 
 // GetLogs returns recent stdout/stderr of a spiced runtime. A cluster (BYOC)
 // instance reads them from the customer cluster's kube API for the workload

--- a/crates/runtime-cloud-connect/proto/cloud_connect_contract.json
+++ b/crates/runtime-cloud-connect/proto/cloud_connect_contract.json
@@ -53,7 +53,8 @@
         { "name": "command_id", "number": 16, "type": "string", "presence": "implicit" },
         { "name": "target", "number": 17, "type": "message:spice.cloud.v1.WorkloadRef", "presence": "explicit" },
         { "name": "execute_query", "number": 18, "type": "message:spice.cloud.v1.ExecuteQuery", "presence": "explicit", "oneof": "body" },
-        { "name": "attach_app", "number": 19, "type": "message:spice.cloud.v1.AttachApp", "presence": "explicit", "oneof": "body" }
+        { "name": "attach_app", "number": 19, "type": "message:spice.cloud.v1.AttachApp", "presence": "explicit", "oneof": "body" },
+        { "name": "get_datasets", "number": 20, "type": "message:spice.cloud.v1.GetDatasets", "presence": "explicit", "oneof": "body" }
       ]
     },
     "Heartbeat": {

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -943,6 +943,17 @@ impl ClientDriver {
                     reply_with_json(tx, &command_id, result).await;
                 }
             }
+            proto::control_message::Body::GetDatasets(_) => {
+                if self
+                    .supported(tx, &command_id, Capability::GetDatasets, name)
+                    .await
+                {
+                    // The same document the instance serves on
+                    // `GET /v1/datasets?status=true`, unchanged.
+                    let result = self.runtime.datasets_json().await;
+                    reply_with_json(tx, &command_id, result).await;
+                }
+            }
             proto::control_message::Body::GetLogs(cmd) => {
                 if self
                     .supported(tx, &command_id, Capability::GetLogs, name)
@@ -1751,6 +1762,7 @@ fn command_name(body: &proto::control_message::Body) -> &'static str {
         Body::ApplyManifest(_) => "ApplyManifest",
         Body::DeleteManifest(_) => "DeleteManifest",
         Body::GetStatus(_) => "GetStatus",
+        Body::GetDatasets(_) => "GetDatasets",
         Body::Drain(_) => "Drain",
         Body::Pause(_) => "Pause",
         Body::ApplySecrets(_) => "ApplySecrets",

--- a/crates/runtime-cloud-connect/src/handlers.rs
+++ b/crates/runtime-cloud-connect/src/handlers.rs
@@ -171,6 +171,8 @@ pub enum Capability {
     GetLogs,
     /// Report runtime readiness.
     GetStatus,
+    /// List the datasets this instance serves, with the status of each.
+    GetDatasets,
     /// Execute a bounded SQL query through the in-process runtime.
     ExecuteQuery,
 }
@@ -181,6 +183,7 @@ impl Capability {
         Self::ApplySpicepod,
         Self::AttachApp,
         Self::ExecuteQuery,
+        Self::GetDatasets,
         Self::GetLogs,
         Self::GetStatus,
         Self::Restart,
@@ -198,6 +201,7 @@ impl Capability {
             Self::UpgradeRuntime => "upgrade_runtime",
             Self::GetLogs => "get_logs",
             Self::GetStatus => "get_status",
+            Self::GetDatasets => "get_datasets",
             Self::ExecuteQuery => "execute_query",
         }
     }
@@ -486,6 +490,19 @@ pub trait RuntimeHandle: Send + Sync + 'static {
         ))
     }
 
+    /// List the datasets this instance serves, for a `GetDatasets` command:
+    /// the JSON array `GET /v1/datasets?status=true` answers locally, so the
+    /// control plane and a local operator read the same document.
+    ///
+    /// The default reports the command as unsupported so mocks don't
+    /// fabricate an empty list a control plane would read as "no datasets".
+    /// Real adapters override this.
+    async fn datasets_json(&self) -> Result<serde_json::Value, CommandError> {
+        Err(CommandError::unsupported(
+            "GetDatasets is not implemented in this build",
+        ))
+    }
+
     /// The configuration sections whose deployed value is not the one this
     /// process is running with, sorted and deduplicated: what a restart would
     /// put into effect. Stamped on every heartbeat.
@@ -680,6 +697,41 @@ mod tests {
         );
     }
 
+    /// `get_datasets` follows the same rule: advertised only by a handle that
+    /// answers it, and the default answer is unsupported rather than an empty
+    /// list a control plane would read as "no datasets".
+    #[tokio::test]
+    async fn get_datasets_is_advertised_only_by_a_handle_that_lists() {
+        struct ListingHandle;
+
+        #[async_trait]
+        impl RuntimeHandle for ListingHandle {
+            fn supports(&self, capability: Capability) -> bool {
+                capability == Capability::GetDatasets
+            }
+
+            // This list-only test handle cannot hold delivered secrets.
+            async fn clear_cloud_delivered_secrets(&self) {}
+
+            async fn datasets_json(&self) -> Result<serde_json::Value, CommandError> {
+                Ok(serde_json::json!([{ "name": "taxi_trips", "status": "Ready" }]))
+            }
+        }
+
+        assert_eq!(
+            advertised_capabilities(&ListingHandle),
+            vec!["get_datasets"]
+        );
+        assert!(
+            !advertised_capabilities(&NoopRuntimeHandle).contains(&"get_datasets".to_string()),
+            "a handle that cannot list must not advertise get_datasets"
+        );
+        assert!(matches!(
+            NoopRuntimeHandle.datasets_json().await,
+            Err(CommandError::Unsupported { .. })
+        ));
+    }
+
     #[test]
     fn zero_requested_rows_means_the_default_cap() {
         assert_eq!(effective_max_rows(0), MAX_QUERY_ROWS);
@@ -776,6 +828,7 @@ mod tests {
                 | Capability::UpgradeRuntime
                 | Capability::GetLogs
                 | Capability::GetStatus
+                | Capability::GetDatasets
                 | Capability::ExecuteQuery => {}
             }
         }
@@ -791,6 +844,7 @@ mod tests {
                 "apply_spicepod",
                 "attach_app",
                 "execute_query",
+                "get_datasets",
                 "get_logs",
                 "get_status",
                 "restart",

--- a/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
@@ -3678,16 +3678,17 @@ async fn remove_clears_identity_and_exits() {
 // that cannot list neither advertises `get_datasets` nor is asked for one.
 // --------------------------------------------------------------------------
 
+/// A handle with a dataset list to answer, or none: the capability and the
+/// answer come from the same field, so the two cannot disagree.
 struct DatasetsRuntime {
-    can_list: bool,
-    document: serde_json::Value,
+    document: Option<serde_json::Value>,
 }
 
 #[async_trait]
 impl RuntimeHandle for DatasetsRuntime {
     fn supports(&self, capability: Capability) -> bool {
         match capability {
-            Capability::GetDatasets => self.can_list,
+            Capability::GetDatasets => self.document.is_some(),
             // GetRuntimeInfo needs no capability, so this keeps the handle to
             // exactly the one command under test.
             _ => false,
@@ -3698,18 +3699,13 @@ impl RuntimeHandle for DatasetsRuntime {
     async fn clear_cloud_delivered_secrets(&self) {}
 
     async fn datasets_json(&self) -> Result<serde_json::Value, CommandError> {
-        if self.can_list {
-            Ok(self.document.clone())
-        } else {
-            Err(CommandError::unsupported(
+        match &self.document {
+            Some(document) => Ok(document.clone()),
+            None => Err(CommandError::unsupported(
                 "this test handle has no dataset list",
-            ))
+            )),
         }
     }
-}
-
-fn get_datasets() -> proto::control_message::Body {
-    proto::control_message::Body::GetDatasets(proto::GetDatasets {})
 }
 
 /// The list comes back on the `json` arm exactly as the runtime produced it:
@@ -3724,8 +3720,7 @@ async fn get_datasets_returns_the_runtime_document_on_the_json_arm() {
           "error_message": "connection refused" }
     ]);
     let runtime = Arc::new(DatasetsRuntime {
-        can_list: true,
-        document: document.clone(),
+        document: Some(document.clone()),
     });
     let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
 
@@ -3736,12 +3731,10 @@ async fn get_datasets_returns_the_runtime_document_on_the_json_arm() {
         "a runtime that lists must advertise get_datasets: {advertised:?}"
     );
 
-    harness
-        .gateway
-        .outbound
-        .lock()
-        .await
-        .push_back(ctrl_id("cmd-datasets", get_datasets()));
+    harness.gateway.outbound.lock().await.push_back(ctrl_id(
+        "cmd-datasets",
+        proto::control_message::Body::GetDatasets(proto::GetDatasets {}),
+    ));
 
     let result = await_result(&captured, "cmd-datasets")
         .await
@@ -3769,10 +3762,7 @@ async fn get_datasets_returns_the_runtime_document_on_the_json_arm() {
 #[tokio::test]
 async fn get_datasets_is_unsupported_when_the_runtime_cannot_list() {
     let harness = Harness::new(24 * 60 * 60).await;
-    let runtime = Arc::new(DatasetsRuntime {
-        can_list: false,
-        document: serde_json::Value::Null,
-    });
+    let runtime = Arc::new(DatasetsRuntime { document: None });
     let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
 
     let captured = Arc::clone(&harness.gateway.captured);
@@ -3782,12 +3772,10 @@ async fn get_datasets_is_unsupported_when_the_runtime_cannot_list() {
         "a runtime that cannot list must not advertise get_datasets: {advertised:?}"
     );
 
-    harness
-        .gateway
-        .outbound
-        .lock()
-        .await
-        .push_back(ctrl_id("cmd-nolist", get_datasets()));
+    harness.gateway.outbound.lock().await.push_back(ctrl_id(
+        "cmd-nolist",
+        proto::control_message::Body::GetDatasets(proto::GetDatasets {}),
+    ));
 
     let result = await_result(&captured, "cmd-nolist")
         .await

--- a/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
@@ -3672,3 +3672,145 @@ async fn remove_clears_identity_and_exits() {
     // shutdown() returns promptly because the task already exited on Remove.
     handle.shutdown().await;
 }
+
+// --------------------------------------------------------------------------
+// GetDatasets: the dataset list rides the json arm unchanged, and a handle
+// that cannot list neither advertises `get_datasets` nor is asked for one.
+// --------------------------------------------------------------------------
+
+struct DatasetsRuntime {
+    can_list: bool,
+    document: serde_json::Value,
+}
+
+#[async_trait]
+impl RuntimeHandle for DatasetsRuntime {
+    fn supports(&self, capability: Capability) -> bool {
+        match capability {
+            Capability::GetDatasets => self.can_list,
+            // GetRuntimeInfo needs no capability, so this keeps the handle to
+            // exactly the one command under test.
+            _ => false,
+        }
+    }
+
+    // This list-only test handle cannot hold delivered secrets.
+    async fn clear_cloud_delivered_secrets(&self) {}
+
+    async fn datasets_json(&self) -> Result<serde_json::Value, CommandError> {
+        if self.can_list {
+            Ok(self.document.clone())
+        } else {
+            Err(CommandError::unsupported(
+                "this test handle has no dataset list",
+            ))
+        }
+    }
+}
+
+fn get_datasets() -> proto::control_message::Body {
+    proto::control_message::Body::GetDatasets(proto::GetDatasets {})
+}
+
+/// The list comes back on the `json` arm exactly as the runtime produced it:
+/// the client is a courier for the `/v1/datasets?status=true` document, not a
+/// re-shaper of it.
+#[tokio::test]
+async fn get_datasets_returns_the_runtime_document_on_the_json_arm() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    let document = serde_json::json!([
+        { "from": "s3://bucket/taxi/", "name": "taxi_trips", "status": "Ready" },
+        { "from": "postgres:orders", "name": "orders", "status": "Error",
+          "error_message": "connection refused" }
+    ]);
+    let runtime = Arc::new(DatasetsRuntime {
+        can_list: true,
+        document: document.clone(),
+    });
+    let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+    let captured = Arc::clone(&harness.gateway.captured);
+    let advertised = advertised_capabilities(&captured).await;
+    assert!(
+        advertised.contains(&"get_datasets".to_string()),
+        "a runtime that lists must advertise get_datasets: {advertised:?}"
+    );
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-datasets", get_datasets()));
+
+    let result = await_result(&captured, "cmd-datasets")
+        .await
+        .expect("the client must answer a GetDatasets");
+    assert_eq!(
+        result.code,
+        proto::ResultCode::Ok as i32,
+        "listing must succeed: {}",
+        result.message
+    );
+    let Some(proto::command_result::Payload::Json(json)) = result.payload else {
+        panic!(
+            "the dataset list must ride on the json arm: {:?}",
+            result.payload
+        );
+    };
+    let decoded: serde_json::Value = serde_json::from_str(&json).expect("the payload is JSON");
+    assert_eq!(decoded, document);
+
+    handle.shutdown().await;
+}
+
+/// A handle that cannot list is answered UNSUPPORTED without being asked, and
+/// the refusal leaves the session serving other commands.
+#[tokio::test]
+async fn get_datasets_is_unsupported_when_the_runtime_cannot_list() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    let runtime = Arc::new(DatasetsRuntime {
+        can_list: false,
+        document: serde_json::Value::Null,
+    });
+    let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+    let captured = Arc::clone(&harness.gateway.captured);
+    let advertised = advertised_capabilities(&captured).await;
+    assert!(
+        !advertised.contains(&"get_datasets".to_string()),
+        "a runtime that cannot list must not advertise get_datasets: {advertised:?}"
+    );
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-nolist", get_datasets()));
+
+    let result = await_result(&captured, "cmd-nolist")
+        .await
+        .expect("an unsupported GetDatasets must still be answered");
+    assert_eq!(
+        result.code,
+        proto::ResultCode::Unsupported as i32,
+        "an unsupported listing must be typed unsupported: {}",
+        result.message
+    );
+    assert!(
+        result.payload.is_none(),
+        "an unsupported listing carries no payload"
+    );
+
+    harness.gateway.outbound.lock().await.push_back(ctrl_id(
+        "cmd-after-nolist",
+        proto::control_message::Body::GetRuntimeInfo(proto::GetRuntimeInfo {}),
+    ));
+    let after = await_result(&captured, "cmd-after-nolist")
+        .await
+        .expect("the session must keep answering after an unsupported command");
+    assert_eq!(after.code, proto::ResultCode::Ok as i32);
+
+    handle.shutdown().await;
+}

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -180,19 +180,18 @@ pub(crate) async fn get(
     }
 }
 
-/// The `/v1/datasets` rows for every valid dataset of `app`, with each
-/// dataset's status when `include_status` is set.
+/// The `GET /v1/datasets?status=true` document for the app `rt` serves: every
+/// valid dataset with its status.
 ///
-/// Shared with the Cloud Connect `GetDatasets` command, so the control plane
-/// reads the same document as `GET /v1/datasets?status=true`.
-pub fn app_dataset_infos(
-    rt: Arc<Runtime>,
-    df: &DataFusion,
-    app: &Arc<App>,
-    include_status: bool,
-) -> Vec<DatasetResponseItem> {
-    let datasets = rt.get_valid_datasets(app, LogErrors(false));
-    dataset_infos(df, &datasets, include_status)
+/// Answers the Cloud Connect `GetDatasets` command, so the control plane reads
+/// the same rows a local operator does. No loaded app is an empty list, not an
+/// error: there is nothing to list.
+pub async fn dataset_infos_with_status(rt: &Arc<Runtime>) -> Vec<DatasetResponseItem> {
+    let Some(app) = rt.read_app().await else {
+        return Vec::new();
+    };
+    let datasets = Arc::clone(rt).get_valid_datasets(&app, LogErrors(false));
+    dataset_infos(&rt.datafusion(), &datasets, true)
 }
 
 fn dataset_infos(

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -21,7 +21,7 @@ use crate::{
     accelerated::refresh::RefreshOverrides,
     component::dataset::Dataset,
     datafusion::{
-        SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA,
+        DataFusion, SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA,
         request_context_extension::get_current_datafusion,
     },
 };
@@ -166,11 +166,45 @@ pub(crate) async fn get(
         None => valid_datasets,
     };
 
-    let resp: Vec<_> = datasets
+    let resp = dataset_infos(&df, &datasets, params.status);
+
+    match params.format {
+        Format::Json => (status::StatusCode::OK, Json(resp)).into_response(),
+        Format::Csv => match convert_entry_to_csv(&resp) {
+            Ok(csv) => (status::StatusCode::OK, csv).into_response(),
+            Err(e) => {
+                tracing::error!("Error converting to CSV: {e}");
+                (status::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+            }
+        },
+    }
+}
+
+/// The `/v1/datasets` rows for every valid dataset of `app`, with each
+/// dataset's status when `include_status` is set.
+///
+/// Shared with the Cloud Connect `GetDatasets` command, so the control plane
+/// reads the same document as `GET /v1/datasets?status=true`.
+pub fn app_dataset_infos(
+    rt: Arc<Runtime>,
+    df: &DataFusion,
+    app: &Arc<App>,
+    include_status: bool,
+) -> Vec<DatasetResponseItem> {
+    let datasets = rt.get_valid_datasets(app, LogErrors(false));
+    dataset_infos(df, &datasets, include_status)
+}
+
+fn dataset_infos(
+    df: &DataFusion,
+    datasets: &[Arc<Dataset>],
+    include_status: bool,
+) -> Vec<DatasetResponseItem> {
+    datasets
         .iter()
         .map(|d| {
-            let status = if params.status {
-                Some(dataset_status(&df, d))
+            let status = if include_status {
+                Some(dataset_status(df, d))
             } else {
                 None
             };
@@ -198,18 +232,7 @@ pub(crate) async fn get(
                 error_message,
             }
         })
-        .collect();
-
-    match params.format {
-        Format::Json => (status::StatusCode::OK, Json(resp)).into_response(),
-        Format::Csv => match convert_entry_to_csv(&resp) {
-            Ok(csv) => (status::StatusCode::OK, csv).into_response(),
-            Err(e) => {
-                tracing::error!("Error converting to CSV: {e}");
-                (status::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-            }
-        },
-    }
+        .collect()
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -106,7 +106,7 @@ pub mod extension;
 pub use runtime_table::federated;
 pub mod flight;
 mod http;
-pub use http::v1::datasets::app_dataset_infos;
+pub use http::v1::datasets::dataset_infos_with_status;
 
 pub mod http_types {
     pub use crate::http::v1::queries::SubmitQueryRequest;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -106,6 +106,7 @@ pub mod extension;
 pub use runtime_table::federated;
 pub mod flight;
 mod http;
+pub use http::v1::datasets::app_dataset_infos;
 
 pub mod http_types {
     pub use crate::http::v1::queries::SubmitQueryRequest;

--- a/crates/runtime/tests/datasets_api/mod.rs
+++ b/crates/runtime/tests/datasets_api/mod.rs
@@ -236,7 +236,18 @@ async fn test_datasets_api_returns_correct_status() -> Result<(), anyhow::Error>
                 "API should return success status"
             );
 
-            let datasets: Vec<DatasetResponse> = response.json().await?;
+            let datasets_json: Value = response.json().await?;
+
+            // The Cloud Connect `GetDatasets` command answers this same
+            // document through `dataset_infos_with_status`, so the two are
+            // compared here, against a real runtime, on every status this test
+            // drives the dataset through.
+            assert_eq!(
+                serde_json::to_value(runtime::dataset_infos_with_status(&rt).await)?,
+                datasets_json,
+                "GetDatasets must answer the /v1/datasets?status=true document (Ready)"
+            );
+            let datasets: Vec<DatasetResponse> = serde_json::from_value(datasets_json)?;
 
             // Find our test dataset
             let test_dataset = datasets
@@ -266,7 +277,13 @@ async fn test_datasets_api_returns_correct_status() -> Result<(), anyhow::Error>
                 "API should return success status"
             );
 
-            let datasets: Vec<DatasetResponse> = response.json().await?;
+            let datasets_json: Value = response.json().await?;
+            assert_eq!(
+                serde_json::to_value(runtime::dataset_infos_with_status(&rt).await)?,
+                datasets_json,
+                "GetDatasets must answer the /v1/datasets?status=true document (Error)"
+            );
+            let datasets: Vec<DatasetResponse> = serde_json::from_value(datasets_json)?;
 
             let test_dataset = datasets
                 .iter()


### PR DESCRIPTION
## 📝 Summary

`spice cloud datasets`, and the dataset-health section of `spice cloud status`, fail for a project served by a self-hosted (Cloud Connect standalone) instance with HTTP 501: the data plane serves `GET /v1/datasets` by proxying to a managed runtime pod, and a self-hosted runtime is reachable only over its outbound control stream, whose typed command set had nothing that means "list your datasets and their statuses".

This is the contract-first half of #13369, in the repository that owns the authoritative wire contract:

- `GetDatasets` joins the `ControlMessage` oneof as arm 20 (the next free number, per the proto's numbering rules), documented beside `GetStatus`.
- The client advertises it in `Hello.capabilities` as `get_datasets`, derived from `RuntimeHandle::supports` like every other capability, so what an instance advertises and what it answers cannot drift.
- A new `RuntimeHandle::datasets_json` returns the document; the default answers `RESULT_CODE_UNSUPPORTED` so a mock never fabricates an empty list a control plane would read as "no datasets".
- `spiced` answers with the same JSON array its local `GET /v1/datasets?status=true` serves. The row-building code moves out of the HTTP handler into one shared `dataset_infos_with_status` (re-exported from the runtime crate root because `http` is a private module), so the two paths cannot diverge.

The control plane's mirror of the proto and its relay of `GET /v1/datasets` over the gateway are the platform half and live in the platform repository. Instances that do not advertise `get_datasets` keep answering unsupported, which the CLI already degrades on gracefully, so this is `refs`, not `fixes`.

## Test plan

### Reproduction (the gap)

On `trunk` (`4c7b254d6c`) the contract cannot express the command: the capability list the client can advertise has no `get_datasets`, and neither the proto nor the handler module mentions it.

```
$ cargo test -p runtime-cloud-connect --test probe_capabilities -- --nocapture   # throwaway probe printing Capability::ALL
Capability::ALL wire names on 2.4.0-unstable: ["apply_spicepod", "attach_app", "execute_query", "get_logs", "get_status", "restart", "upgrade_runtime"]
get_datasets advertised: false
$ grep -c "GetDatasets\|get_datasets" crates/runtime-cloud-connect/proto/cloud_connect.proto crates/runtime-cloud-connect/src/handlers.rs
crates/runtime-cloud-connect/proto/cloud_connect.proto:0
crates/runtime-cloud-connect/src/handlers.rs:0
```

On this branch (`98690913ae`; the follow-up refactor `4ddbe54cb2` does not touch the capability list):

```
$ cargo test -p runtime-cloud-connect --test probe_capabilities -- --nocapture
Capability::ALL wire names on 2.4.0-unstable: ["apply_spicepod", "attach_app", "execute_query", "get_datasets", "get_logs", "get_status", "restart", "upgrade_runtime"]
get_datasets advertised: true
$ cargo test -p runtime-cloud-connect --lib -- get_datasets
test handlers::tests::get_datasets_is_advertised_only_by_a_handle_that_lists ... ok
test handlers::tests::capability_all_lists_every_variant_exactly_once ... ok
```

### Tests

- `handlers::tests::get_datasets_is_advertised_only_by_a_handle_that_lists`: a listing handle advertises exactly `get_datasets`; `NoopRuntimeHandle` does not, and its default `datasets_json` is `Unsupported`.
- `capability_all_lists_every_variant_exactly_once`: extended, so a variant missing from `ALL` or sharing a wire name fails at compile time or in the set comparison.
- E2E (`standalone_enrollment_e2e`): `get_datasets_returns_the_runtime_document_on_the_json_arm` drives a real enrolled client through the mock gateway and asserts the document comes back on the `json` arm byte-for-byte; `get_datasets_is_unsupported_when_the_runtime_cannot_list` asserts a non-listing handle neither advertises nor is asked, answers `UNSUPPORTED` with no payload, and keeps serving `GetRuntimeInfo` afterwards.

### Gate

- [x] `cargo test -p runtime-cloud-connect --lib` on this host: `180 passed`; the 80 failures are the same 80 on stashed `trunk` (`179 passed`, set difference empty), every one a Windows platform failure (`secure state-file reads are unsupported on this platform` and its dependents).
- [x] `cargo test -p runtime-cloud-connect --test contract` on this host: on 4ddbe54cb2 `compiled_schema_matches_the_shared_contract_fixture` fails (`ControlMessage drifted from the shared contract fixture` — `get_datasets` (20) present in the compiled proto and absent from the fixture); on 5a4f52fedd `test result: ok. 9 passed; 0 failed`
- [x] `test_datasets_api_returns_correct_status` (`crates/runtime/tests/datasets_api`, a real `Runtime` with an S3 parquet dataset) now asserts on both the Ready and the Error path that `serde_json::to_value(runtime::dataset_infos_with_status(&rt).await)` equals the `GET /v1/datasets?status=true` body — the document `GetDatasets` answers with. Not runnable on this host (`crates/runtime` does not build on Windows); it compiles and runs in the integration workflow in the merge queue
- [x] The E2E suite is not runnable on this Windows host: every test in it fails at enrollment with the same platform error, including trunk's own `execute_query_returns_the_runtime_bytes_on_the_binary_arm`, so the two new E2E tests run in the remote sign-off below.
- [x] `make lint` / `make test`: not run locally — `spiced` and `runtime` do not type-check on this host (`openssl-sys` build script), so the remote sign-off is the compile and test gate for the `runtime`/`spiced` edits. Crate-scoped pedantic clippy on `runtime-cloud-connect` (lib and tests) reports the identical 14 pre-existing Windows dead-code errors as stashed `trunk` and nothing new (`diff` of the two error lists: identical).
- [x] `make signoff` → `Attestation`: remote sign-off (`signoff.yml`) dispatched for this branch, local sign-off being blocked by the same constraint. First run https://github.com/spiceai/spiceai/actions/runs/34570686429 hit the 353-minute budget with zero tests run (three cold workspace compiles of 70, 97 and 124 minutes under pool contention) and posted `Sign-off checks failed after 21200s`, which is the budget expiring, not a verdict. The re-dispatch on 5a4f52fedd (https://github.com/spiceai/spiceai/actions/runs/34619840311) was superseded by the real-runtime comparison commit; current run on 4c408e8409: https://github.com/spiceai/spiceai/actions/runs/34623498980 (in progress; the sign-off status and the `Attestation` re-run land when it completes)

## Review gate

- Adversarial review: `codex` — job `review-mtx6cp8t-4f7ylm` — verdict approve on the current HEAD (4c408e8409, the real-runtime comparison commit): no findings. On 5a4f52fedd (the contract-fixture commit) `review-mtx54kii-2sbsjl` also approved with no findings. The PR-creation round could not run it (`codex` had exited 1: "Your workspace is out of credits"; `grok` is not permitted to review a Grok-authored diff)
- `/security-review`: no findings on the two follow-up commits — the real-runtime comparison adds two assertions to an existing integration test (`serde_json`, `Value`, the crate-root re-export and `DatasetInfo: Serialize` all checked statically, `rt` only borrowed) and touches no input or secret; one added `ControlMessage` entry matching `cloud_connect.proto:181` (`get_datasets = 20`, `oneof body`), no field number reused, the fixture consumed only by `tests/contract.rs`. Earlier round on the feature diff: no defects introduced — the command is gated by the same `supported()` capability check as `GetStatus`, the document carries `from`/`name`/flags/`status`/`error_message` and no credential (the HTTPS connector attaches auth at connect time, not into `from`), and the handler runs no query. Three pre-existing, low-severity shapes it extends to one more command, none reproduced: the `json` arm has no size cap (same as `GetStatus`); `read_app()` is awaited on the pump without the HTTP route's 5 s timeout (its only writer is a momentary assignment); a user who embeds URL userinfo in `from` already exposes it to every local `/v1/datasets` caller
- `/simplify`: nothing applicable on the two follow-up commits (a single JSON entry; two assertions in an existing test). Earlier round: applied (proposal pass, then edits) — the app read and DataFusion handle folded into `dataset_infos_with_status` so `spiced` hands over its `Runtime` and nothing else; the E2E test handle keeps one `Option` for both capability and answer; the one-line command constructor inlined. Light checks re-run: fmt clean, E2E target compiles (`--no-run`), lib tests `180 passed` with the same 80 Windows failures, pedantic clippy error list identical to trunk

## 🔗 Related

Refs #13369

## 📚 Docs

The Cloud Connect command reference gains `get_datasets` once the platform half lands; nothing to update in this repository's docs now.

## 👀 Notes for Reviewers

- Field number 20 and the message shape must be mirrored in the platform's copy of the proto in the same review as the relay, per the header of `cloud_connect.proto`.
- `spiced` builds the document from `runtime.datafusion()` (the runtime-wide instance), the same choice `execute_query` already makes for this handle; the HTTP route uses the request-context DataFusion, which is the same instance on a standalone runtime.
- No loaded app answers an empty list rather than an error: there is nothing to list, and the CLI renders an empty table.

