### PR TITLE
fix(cayenne): give the empty inline view one identity so the scan-view cache can hit

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -25951,9 +25951,23 @@ impl CayenneTableProvider {
         (cached.generation == current_gen).then(|| Arc::clone(&cached.view))
     }
 
+    /// The inline view for a scan capture, or `None` when the cached view is not
+    /// generation-current (the caller rebuilds and retries).
+    ///
+    /// "This table has no inline data" is ONE state and must have ONE identity:
+    /// [`ScanViewKey`] keys on the inline view's ADDRESS (see [`RawScanInput::key`]),
+    /// so handing back a freshly allocated empty `Vec` would re-key every capture of an
+    /// empty inline corpus and no two scans could ever key alike — the demand
+    /// [`ScanViewCache`] would then miss unconditionally on any table whose inline
+    /// corpus is empty, which is the steady state of a file-mode table. The shared
+    /// empty view below is immutable and never freed, so it is also ABA-safe as a key
+    /// component. It is process-wide rather than per-table because the cache it feeds
+    /// is per-table: only captures of the same table are ever compared.
     fn try_read_inlined_view_for_scan(&self) -> Option<Arc<Vec<InlinedViewEntry>>> {
         if self.cached_inlined_row_count() <= 0 {
-            return Some(Arc::new(Vec::new()));
+            static EMPTY_INLINED_VIEW: LazyLock<Arc<Vec<InlinedViewEntry>>> =
+                LazyLock::new(|| Arc::new(Vec::new()));
+            return Some(Arc::clone(&EMPTY_INLINED_VIEW));
         }
         self.try_read_inlined_view_cached()
     }
@@ -54959,6 +54973,72 @@ mod tests {
             collect_segment_pairs(&rebuilt.visible_segments),
             vec![(1, 10), (2, 20)],
             "a scan after eviction rebuilds and still returns the correct rows"
+        );
+    }
+
+    /// A table whose inline corpus is EMPTY — the steady state of a file-mode table —
+    /// must serve a second scan the view the first one built: nothing about the
+    /// scan-visible state moved between them, so the two captures have to key alike.
+    ///
+    /// The empty inline view is part of [`ScanViewKey`] by ADDRESS, so allocating a
+    /// fresh one per capture re-keys every scan and the demand cache misses
+    /// unconditionally — every scan rebuilds, and concurrent scans cannot even dedup
+    /// onto one build.
+    #[tokio::test]
+    async fn scan_view_cache_reuses_view_when_inline_corpus_is_empty() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) =
+            create_append_only_table("scan_view_empty_inline", ctx.runtime_env()).await;
+        let schema = Arc::clone(&provider.table_metadata.schema);
+        insert_batch(
+            &provider,
+            id_value_batch_for_range(Arc::clone(&schema), 0, 64),
+        )
+        .await;
+        assert_eq!(
+            provider.cached_inlined_row_count(),
+            0,
+            "fixture must leave the inline corpus empty (inlining disabled) — that is the state under test"
+        );
+
+        let first = provider
+            .scan_view_at_current_input(Duration::ZERO)
+            .await
+            .expect("first scan builds a view");
+        let second = provider
+            .scan_view_at_current_input(Duration::ZERO)
+            .await
+            .expect("second scan");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "an unchanged table must serve the cached view rather than rebuilding it"
+        );
+
+        // Reuse must not cost read-your-writes. An append into the CURRENT snapshot
+        // moves no key component — it mints no snapshot id and touches neither the
+        // deletion snapshot, the protected map, the inline corpus nor the mem tier —
+        // so the capture legitimately keys the same and the bundle is reused. That is
+        // correct because the bundle carries no file list: scan planning resolves the
+        // listing eagerly against the pinned snapshot id on every scan. Assert the
+        // BEHAVIOUR (the rows), not the bundle's identity.
+        insert_batch(
+            &provider,
+            id_value_batch_for_range(Arc::clone(&schema), 64, 64),
+        )
+        .await;
+        let scan_ctx = SessionContext::new();
+        let plan = provider
+            .scan(&scan_ctx.state(), Some(&vec![0]), &[], None)
+            .await
+            .expect("scan plan after write");
+        let batches = datafusion::physical_plan::collect(plan, scan_ctx.task_ctx())
+            .await
+            .expect("collect rows after write");
+        let scanned: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(
+            scanned, 128,
+            "a scan after an append must read its own write (64 + 64 rows), whether or \
+             not the cached scan-view bundle was reused"
         );
     }
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -59101,6 +59101,76 @@ mod tests {
         (provider, catalog, temp_dir)
     }
 
+    /// Key-completeness guard for the demand scan-view cache on the one strategy that
+    /// cannot express a deletion in the key: a POSITION-based table has no PK deletion
+    /// index, so `ScanViewKey::deletion_index_ptr` is permanently `None`
+    /// (`PkDeletionSnapshot::PositionBased => None`) and a DELETE cannot move it. If no
+    /// OTHER key component moved either, a scan after the DELETE would be served the
+    /// bundle captured before it and would return deleted rows.
+    #[tokio::test]
+    async fn scan_after_position_based_delete_is_not_served_a_pre_delete_view() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) =
+            create_position_based_table("position_delete_scan_view", ctx.runtime_env()).await;
+        let schema = Arc::clone(&provider.table_metadata.schema);
+        insert_batch(
+            &provider,
+            id_value_batch(Arc::clone(&schema), &[1, 2, 3], &[10, 20, 30]),
+        )
+        .await;
+        assert!(
+            provider.pk_deletion_strategy().is_position_based(),
+            "precondition: a table with no primary key must use the position-based strategy"
+        );
+
+        // Populate and promote a completed bundle, so a pre-delete view EXISTS to be
+        // wrongly served. The reuse itself is the precondition under test.
+        let first = provider
+            .scan_view_at_current_input(Duration::ZERO)
+            .await
+            .expect("build");
+        let second = provider
+            .scan_view_at_current_input(Duration::ZERO)
+            .await
+            .expect("reuse");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "precondition: an unchanged table must reuse its bundle, otherwise this test \
+             cannot observe a stale serve"
+        );
+
+        let delete_plan = provider
+            .delete_from(
+                &ctx.state(),
+                vec![datafusion_expr::col("id").eq(datafusion_expr::lit(2_i64))],
+            )
+            .await
+            .expect("delete plan");
+        datafusion::physical_plan::collect(delete_plan, ctx.task_ctx())
+            .await
+            .expect("delete executed");
+
+        assert_eq!(
+            scan_id_values(&provider).await,
+            vec![(1, 10), (3, 30)],
+            "a scan after a position-based DELETE must not be served the pre-delete view"
+        );
+
+        // ... and pin WHY it is safe, so a change that makes the DELETE invisible to the
+        // key fails here rather than in a query result: the delete commits a new
+        // snapshot id, which is the component that carries it once `deletion_index_ptr`
+        // cannot.
+        let after_delete = provider
+            .scan_view_at_current_input(Duration::ZERO)
+            .await
+            .expect("scan view after delete");
+        assert!(
+            !Arc::ptr_eq(&second, &after_delete),
+            "a position-based DELETE must move some ScanViewKey component, or the cache \
+             would serve the pre-delete bundle"
+        );
+    }
+
     /// Position-based tables have no PK and never apply inline deletion filtering,
     /// so `add_inlined_tombstone` must early-return `Ok(false)` and write NOTHING
     /// (the `is_position_based()` guard). Drives the real metastore: asserts the


### PR DESCRIPTION
## 📝 Summary

An empty inline corpus had no stable identity, so the demand scan-view cache could never hit on a table that has one — which is the steady state of a file-mode table.

`ScanViewKey` keys on the inline view's **address** (`RawScanInput::key` → `inlined_view_ptr`). `try_read_inlined_view_for_scan` returned a freshly allocated `Arc::new(Vec::new())` whenever `cached_inlined_row_count() <= 0`, so that one state got a new identity on every capture, every scan re-keyed, and no two scans could ever key alike. The effect is total: the `latest_complete` slot never matches, and the `in_flight` dedup slot never matches either, so concurrent scans on identical state each spawn their own build instead of sharing one.

This returns a single shared immutable empty view instead. Content served is unchanged — the same branch already returned an empty view, and only its identity is stabilized. Being immutable and never freed, it is also sound as an ABA-safe key component.

Measured on a local periodically-refreshed Cayenne file-mode pod (5 append-refreshed datasets at 30s + 4 accelerated views at 60s, SQL results cache disabled, 6 query shapes against the views), release build, idle host, arms interleaved with their order reversed between repeats:

| | before | after |
|---|---|---|
| hit rate, hot view (1 qps, 20 min) | **0.0%** (0 / 1551) | **98.7%** (1527 / 1547) |
| hit rate, hot view (20 qps, 8 threads, 10 min) | **0.0%** (0 / 9841) | **99.9%** (9879 / 9889) |
| misses attributable to the inline view address | 1531 of 1551 | 0 |
| scan-view build time, hot view, per 20 min | 48,296 µs | 1,048 µs (−98%) |

The remaining misses after the change are exactly the real refreshes (19 per 20 min against a 60s view refresh; 10 per 10 min), which is the intended behaviour.

**This is not being claimed as a query-latency win.** On this workload the reclaimed work is ~0.06 ms/scan (5 µs capture + 55 µs build) against a 5–7 ms query, because `build_scan_view` short-circuits when there is no mem-tier: no deletion merge, no visible-segment computation. One A/B pair did show mean −15% / p99 −54%, but reversing the arm order inverted the result — the same arm varied 25% in the mean and 2.4× at p99 between its own two runs — so that delta was run-order drift and is withdrawn. The case for this change is the mechanism, plus the tables where the build is not trivial: a `cdc_durability: memory` table does the full deletion merge and visible-segment build on every miss, and today it misses every time.

## 🔗 Related

None.

## 🚨 Breaking Changes

None. No user-facing surface changes: no config, no metric, no log line, and query results are unchanged.

## 📚 Docs

None required.

## 👀 Notes for Reviewers

**The main thing worth a careful read is what this change makes load-bearing.** With the address churning, the cache never hit, which means no *other* insufficiency in `ScanViewKey` could ever produce a stale serve — a key that is too weak is harmless if no two keys ever match. This change makes the remaining components (`snapshot_id`, `structural_version`, `structural_epoch`, `maintained_aggregate_epoch`, `mem_tier_versions`, `deletion_index_ptr`, `protected_map_ptr`) actually decide reuse for the first time. I believe the key is complete — every mutation funnel either mints a new snapshot id or swaps one of those pointers — but that is the claim to challenge here, not the one-line diff.

**One case worth knowing about, found while writing the test.** An append into the *current* snapshot moves no key component at all — it mints no snapshot id and touches neither the deletion snapshot, the protected map, the inline corpus nor the mem tier — so after this change the capture keys the same and the bundle IS reused across that write. That is correct rather than a stale read, because the bundle carries no file list: scan planning resolves the listing eagerly against the pinned snapshot id on every scan (see the comment at the `create_snapshot_scan_plan_with_config` call site). The test therefore asserts the behaviour — a scan after the append reads 128 rows, its own write included — instead of asserting that the bundle's identity changed, which would have encoded an implementation detail that is not the property anyone depends on.

The new test covers both halves: an unchanged table serves the same `ScanView` instance, and a scan after a write still reads that write. The first half fails without the change (the two scans get distinct `Arc`s).
