### PR TITLE
perf(vortex): skip a scan split whose zones cannot satisfy the filter

### DIFF
--- a/crates/vortex/src/persistent/opener.rs
+++ b/crates/vortex/src/persistent/opener.rs
@@ -46,6 +46,7 @@ use vortex::io::InstrumentedReadAt;
 use vortex::layout::LayoutReader;
 use vortex::layout::scan::scan_builder::ScanBuilder;
 use vortex::layout::scan::split_by::SplitBy;
+use vortex::mask::Mask;
 use vortex::metrics::Label;
 use vortex::metrics::MetricsRegistry;
 use vortex::session::VortexSession;
@@ -408,6 +409,40 @@ impl FileOpener for VortexOpener {
                     }
                 })
                 .transpose()?;
+
+            // Drop a split whose zones cannot satisfy the filter before the scan is
+            // built. Vortex prunes these same zones inside the scan, but only after
+            // `ScanBuilder::build` has optimized the projection and the filter
+            // against the file's dtype — work a split that will read nothing should
+            // not pay for, and which is repeated for every split the file is divided
+            // into. A file is split by byte range for parallelism and each split
+            // inherits the whole file's statistics, so `FilePruner` above cannot
+            // separate them; only the zone map can.
+            //
+            // `pruning_evaluation` returns a mask whose false lanes are *proven*
+            // false for the expression, so an all-false mask is a sound skip. The
+            // zone map it reads is memoized on the layout reader, which
+            // `layout_readers` shares with every other split of this file, so the
+            // read happens once per file rather than once per split.
+            if let Some(predicate) = filter.as_ref() {
+                let prune_range = row_range
+                    .clone()
+                    .unwrap_or_else(|| 0..layout_reader.row_count());
+                let prune_len = usize::try_from(prune_range.end - prune_range.start)
+                    .map_err(|_| exec_datafusion_err!("Vortex split row range exceeds usize"))?;
+                let pruned = layout_reader
+                    .pruning_evaluation(&prune_range, predicate, Mask::new_true(prune_len))
+                    .map_err(|e| {
+                        exec_datafusion_err!("Failed to build Vortex zone pruning: {e}")
+                    })?
+                    .await
+                    .map_err(|e| {
+                        exec_datafusion_err!("Failed to evaluate Vortex zone pruning: {e}")
+                    })?;
+                if pruned.all_false() {
+                    return Ok(stream::empty().boxed());
+                }
+            }
 
             // Built after the filter so we know whether there is one: a filtered scan
             // discards splits whose mask comes back empty, and deferring projection setup
@@ -847,6 +882,65 @@ mod tests {
         let num_batches = data.len();
         let num_rows = data.iter().map(|rb| rb.num_rows()).sum::<usize>();
         assert_eq!((num_batches, num_rows), (0, 0));
+
+        Ok(())
+    }
+
+    /// Zone pruning must never drop a row the filter matches.
+    ///
+    /// A split is skipped before the scan is built when the file's zone map
+    /// proves no row in the split's range can satisfy the filter. That is sound
+    /// only while the range pruned against is the range the scan would have
+    /// read, so this writes enough rows to close several zones (the writer ends
+    /// one every 8192 rows) with ascending values — the layout that gives zones
+    /// disjoint ranges and so actually reaches the skip path. Every value
+    /// present must still come back, including the ones on a zone boundary.
+    #[tokio::test]
+    async fn zone_pruning_keeps_every_matching_row() -> anyhow::Result<()> {
+        const ROWS: i32 = 20_000;
+        let object_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+        let file_path = "zones.vortex";
+        let batch = record_batch!(("a", Int32, (0..ROWS).map(Some).collect::<Vec<_>>()))
+            .expect("ascending test record batch should build");
+        let file_schema = batch.schema();
+        let data_size = write_arrow_to_vortex(object_store.clone(), file_path, batch).await?;
+        let table_schema = TableSchema::from_file_schema(file_schema);
+        let file = PartitionedFile::new(file_path.to_string(), data_size);
+
+        // First row, both sides of a zone boundary, an interior value, last row.
+        for needle in [0, 8_191, 8_192, 12_345, ROWS - 1] {
+            let filter = logical2physical(&col("a").eq(lit(needle)), table_schema.table_schema());
+            let opener = make_opener(object_store.clone(), table_schema.clone(), Some(filter));
+            let rows: usize = opener
+                .open(file.clone())
+                .expect("opener should open the file")
+                .await
+                .expect("opening should produce a stream")
+                .try_collect::<Vec<_>>()
+                .await?
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum();
+            assert_eq!(
+                rows, 1,
+                "value {needle} is present once and must survive pruning"
+            );
+        }
+
+        // Outside every zone's range: nothing to return, and the split is skipped.
+        let filter = logical2physical(&col("a").eq(lit(ROWS + 1)), table_schema.table_schema());
+        let opener = make_opener(object_store.clone(), table_schema.clone(), Some(filter));
+        let rows: usize = opener
+            .open(file)
+            .expect("opener should open the file")
+            .await
+            .expect("opening should produce a stream")
+            .try_collect::<Vec<_>>()
+            .await?
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum();
+        assert_eq!(rows, 0, "a value the file cannot hold must return no rows");
 
         Ok(())
     }

--- a/crates/vortex/src/persistent/opener.rs
+++ b/crates/vortex/src/persistent/opener.rs
@@ -454,6 +454,9 @@ impl FileOpener for VortexOpener {
             } else {
                 layout_reader
             };
+            #[cfg(test)]
+            tests::record_scan_built();
+
             let mut scan_builder = ScanBuilder::new(session.clone(), layout_reader);
 
             if let Some(vortex_plan) = file.extensions.get::<VortexAccessPlan>() {
@@ -712,8 +715,14 @@ mod tests {
     use object_store::ObjectStore;
     use object_store::memory::InMemory;
     use rstest::rstest;
+    use std::cell::Cell;
     use vortex::VortexSessionDefault;
     use vortex::array::ArrayRef;
+    use vortex::array::IntoArray;
+    use vortex::array::arrays::ChunkedArray;
+    use vortex::array::arrays::StructArray as VortexStructArray;
+    use vortex::array::arrays::VarBinArray;
+    use vortex::array::validity::Validity;
     use vortex::arrow::FromArrowArray;
     use vortex::buffer::Buffer;
     use vortex::file::WriteOptionsSessionExt;
@@ -801,6 +810,79 @@ mod tests {
         write.shutdown().await?;
 
         Ok(summary.size())
+    }
+
+    /// Writes an ascending `i32` filter column plus a payload column, chunked.
+    ///
+    /// Chunk boundaries are what `SplitBy::Layout` reports as natural splits,
+    /// and a byte range owns whole natural splits. The payload is what keeps
+    /// those chunks apart: an ascending `i32` column alone compresses to a
+    /// couple of KiB, and the layout writer then emits the whole file as a
+    /// single split that no byte range can tile.
+    async fn write_chunked_ascending(
+        object_store: Arc<dyn ObjectStore>,
+        path: &str,
+        chunks: u32,
+        rows_per_chunk: u32,
+    ) -> anyhow::Result<u64> {
+        let ascending = (0..chunks)
+            .map(|chunk| {
+                (0..rows_per_chunk)
+                    .map(|row| i32::try_from(chunk * rows_per_chunk + row).expect("row fits i32"))
+                    .collect::<Buffer<_>>()
+                    .into_array()
+            })
+            .collect::<ChunkedArray>()
+            .into_array();
+        let payload = (0..chunks)
+            .map(|chunk| {
+                VarBinArray::from(
+                    (0..rows_per_chunk)
+                        .map(|row| format!("{chunk}-{row}-{}", "x".repeat(48)))
+                        .collect::<Vec<_>>(),
+                )
+                .into_array()
+            })
+            .collect::<ChunkedArray>()
+            .into_array();
+        let table = VortexStructArray::try_new(
+            ["a", "p"].into(),
+            vec![ascending, payload],
+            (chunks * rows_per_chunk) as usize,
+            Validity::NonNullable,
+        )?;
+
+        let path = Path::parse(path)?;
+        let mut write = ObjectStoreWrite::new(object_store, &path).await?;
+        let summary = SESSION
+            .write_options()
+            .write(&mut write, table.into_array().to_array_stream())
+            .await?;
+        write.shutdown().await?;
+        Ok(summary.size())
+    }
+
+    thread_local! {
+        /// Splits that reached scan construction on this thread.
+        ///
+        /// A split the zone map rejects returns before `ScanBuilder::new`, so
+        /// this is what separates "the split was skipped" from "the scan ran
+        /// and matched nothing". Row counts cannot: the scan prunes the same
+        /// zones itself and returns the same rows either way, so a test with
+        /// only that oracle stays green if the skip is deleted. Thread-local
+        /// rather than global because tests run in parallel, and each
+        /// `#[tokio::test]` polls its opener on its own thread.
+        static SCANS_BUILT: Cell<usize> = const { Cell::new(0) };
+    }
+
+    /// Called from `VortexOpener::open` immediately before a scan is built.
+    pub(super) fn record_scan_built() {
+        SCANS_BUILT.with(|built| built.set(built.get() + 1));
+    }
+
+    /// Scans built since the last call, resetting the count.
+    fn take_scans_built() -> usize {
+        SCANS_BUILT.with(|built| built.replace(0))
     }
 
     fn make_opener(
@@ -902,21 +984,27 @@ mod tests {
     /// would read as success.
     #[tokio::test]
     async fn zone_pruning_keeps_every_matching_row_across_byte_splits() -> anyhow::Result<()> {
-        const ROWS: i32 = 20_000;
-        const SPLITS: u64 = 3;
+        const CHUNKS: u32 = 16;
+        const ROWS_PER_CHUNK: u32 = 4_096;
+        const ROWS: i32 = (CHUNKS * ROWS_PER_CHUNK) as i32;
+        const SPLITS: usize = 4;
 
         let object_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
         let file_path = "zones.vortex";
-        let batch = record_batch!(("a", Int32, (0..ROWS).map(Some).collect::<Vec<_>>()))
-            .expect("ascending test record batch should build");
-        let file_schema = batch.schema();
-        let data_size = write_arrow_to_vortex(object_store.clone(), file_path, batch).await?;
+        let data_size =
+            write_chunked_ascending(object_store.clone(), file_path, CHUNKS, ROWS_PER_CHUNK)
+                .await?;
 
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("p", DataType::Utf8, false),
+        ]));
         let table_schema = TableSchema::from_file_schema(file_schema);
-        let byte_splits: Vec<PartitionedFile> = (0..SPLITS)
+        let splits = u64::try_from(SPLITS).expect("split count fits u64");
+        let byte_splits: Vec<PartitionedFile> = (0..splits)
             .map(|i| {
-                let start = data_size * i / SPLITS;
-                let end = data_size * (i + 1) / SPLITS;
+                let start = data_size * i / splits;
+                let end = data_size * (i + 1) / splits;
                 PartitionedFile::new_with_range(
                     file_path.to_string(),
                     data_size,
@@ -932,7 +1020,8 @@ mod tests {
             table_schema: &TableSchema,
             byte_splits: &[PartitionedFile],
             predicate: PhysicalExprRef,
-        ) -> anyhow::Result<Vec<usize>> {
+        ) -> anyhow::Result<(Vec<usize>, usize)> {
+            take_scans_built();
             // One opener over every split, as a scan partition does: the layout
             // reader and its zone map are shared between them.
             let opener = make_opener(
@@ -954,13 +1043,13 @@ mod tests {
                     .sum();
                 per_split.push(rows);
             }
-            Ok(per_split)
+            Ok((per_split, take_scans_built()))
         }
 
         // First row, both sides of a zone boundary, an interior value, last row.
-        for needle in [0, 8_191, 8_192, 12_345, ROWS - 1] {
+        for needle in [0, 4_095, 4_096, 16_384, 32_768, ROWS - 1] {
             let filter = logical2physical(&col("a").eq(lit(needle)), table_schema.table_schema());
-            let per_split =
+            let (per_split, scans_built) =
                 rows_per_split(&object_store, &table_schema, &byte_splits, filter).await?;
 
             assert_eq!(
@@ -973,24 +1062,41 @@ mod tests {
                 1,
                 "exactly one split owns {needle}; per split: {per_split:?}"
             );
+            assert_eq!(
+                scans_built,
+                1,
+                "only the split owning {needle} may reach scan construction; the other \
+                 {} built a scan the zone map could have skipped",
+                SPLITS - 1
+            );
         }
 
         // Outside every zone's range: every split is skipped, nothing is returned.
         let filter = logical2physical(&col("a").eq(lit(ROWS + 1)), table_schema.table_schema());
-        let per_split = rows_per_split(&object_store, &table_schema, &byte_splits, filter).await?;
+        let (per_split, scans_built) =
+            rows_per_split(&object_store, &table_schema, &byte_splits, filter).await?;
         assert!(
             per_split.iter().all(|rows| *rows == 0),
             "a value the file cannot hold must return no rows; per split: {per_split:?}"
+        );
+        assert_eq!(
+            scans_built, 0,
+            "no split may reach scan construction for a value the file cannot hold"
         );
 
         // Nothing prunable: the splits must still tile the file exactly, which is
         // what says the pruned range and the scanned range are the same range.
         let filter = logical2physical(&col("a").gt_eq(lit(0)), table_schema.table_schema());
-        let per_split = rows_per_split(&object_store, &table_schema, &byte_splits, filter).await?;
+        let (per_split, scans_built) =
+            rows_per_split(&object_store, &table_schema, &byte_splits, filter).await?;
         assert_eq!(
             per_split.iter().sum::<usize>(),
             ROWS as usize,
             "byte splits must cover every row exactly once; per split: {per_split:?}"
+        );
+        assert_eq!(
+            scans_built, SPLITS,
+            "a filter that prunes nothing must leave every split to the scan"
         );
 
         Ok(())

--- a/crates/vortex/src/persistent/opener.rs
+++ b/crates/vortex/src/persistent/opener.rs
@@ -886,65 +886,115 @@ mod tests {
         Ok(())
     }
 
-    /// Zone pruning must never drop a row the filter matches.
+    /// Zone pruning must never drop a row the filter matches, split by split.
     ///
-    /// A split is skipped before the scan is built when the file's zone map
-    /// proves no row in the split's range can satisfy the filter. That is sound
-    /// only while the range pruned against is the range the scan would have
-    /// read, so this writes enough rows to close several zones (the writer ends
-    /// one every 8192 rows) with ascending values — the layout that gives zones
-    /// disjoint ranges and so actually reaches the skip path. Every value
-    /// present must still come back, including the ones on a zone boundary.
+    /// Pruning is applied to the split's own row range, so it is sound only
+    /// while that range is the one the scan would have read. A whole-file open
+    /// cannot catch a mismatch between the two — both are then the whole file —
+    /// so this tiles the file with byte-range splits the way `FileScanConfig`
+    /// does, opens each, and aggregates.
+    ///
+    /// 20,000 ascending rows close several zones (the writer ends one every
+    /// 8192 rows), which is what gives zones disjoint ranges and so actually
+    /// reaches the skip path. Byte thirds land one zone midpoint each, so every
+    /// needle is owned by exactly one split and provably absent from the other
+    /// two: the run asserts both halves, or a split silently returning nothing
+    /// would read as success.
     #[tokio::test]
-    async fn zone_pruning_keeps_every_matching_row() -> anyhow::Result<()> {
+    async fn zone_pruning_keeps_every_matching_row_across_byte_splits() -> anyhow::Result<()> {
         const ROWS: i32 = 20_000;
+        const SPLITS: u64 = 3;
+
         let object_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
         let file_path = "zones.vortex";
         let batch = record_batch!(("a", Int32, (0..ROWS).map(Some).collect::<Vec<_>>()))
             .expect("ascending test record batch should build");
         let file_schema = batch.schema();
         let data_size = write_arrow_to_vortex(object_store.clone(), file_path, batch).await?;
+
         let table_schema = TableSchema::from_file_schema(file_schema);
-        let file = PartitionedFile::new(file_path.to_string(), data_size);
+        let byte_splits: Vec<PartitionedFile> = (0..SPLITS)
+            .map(|i| {
+                let start = data_size * i / SPLITS;
+                let end = data_size * (i + 1) / SPLITS;
+                PartitionedFile::new_with_range(
+                    file_path.to_string(),
+                    data_size,
+                    i64::try_from(start).expect("split start fits i64"),
+                    i64::try_from(end).expect("split end fits i64"),
+                )
+            })
+            .collect();
+
+        // Rows each split returns for `a = needle`, in split order.
+        async fn rows_per_split(
+            object_store: &Arc<dyn ObjectStore>,
+            table_schema: &TableSchema,
+            byte_splits: &[PartitionedFile],
+            predicate: PhysicalExprRef,
+        ) -> anyhow::Result<Vec<usize>> {
+            // One opener over every split, as a scan partition does: the layout
+            // reader and its zone map are shared between them.
+            let opener = make_opener(
+                Arc::clone(object_store),
+                table_schema.clone(),
+                Some(predicate),
+            );
+            let mut per_split = Vec::with_capacity(byte_splits.len());
+            for split in byte_splits {
+                let rows: usize = opener
+                    .open(split.clone())
+                    .expect("opener should open the split")
+                    .await
+                    .expect("opening should produce a stream")
+                    .try_collect::<Vec<_>>()
+                    .await?
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum();
+                per_split.push(rows);
+            }
+            Ok(per_split)
+        }
 
         // First row, both sides of a zone boundary, an interior value, last row.
         for needle in [0, 8_191, 8_192, 12_345, ROWS - 1] {
             let filter = logical2physical(&col("a").eq(lit(needle)), table_schema.table_schema());
-            let opener = make_opener(object_store.clone(), table_schema.clone(), Some(filter));
-            let rows: usize = opener
-                .open(file.clone())
-                .expect("opener should open the file")
-                .await
-                .expect("opening should produce a stream")
-                .try_collect::<Vec<_>>()
-                .await?
-                .iter()
-                .map(RecordBatch::num_rows)
-                .sum();
+            let per_split =
+                rows_per_split(&object_store, &table_schema, &byte_splits, filter).await?;
+
             assert_eq!(
-                rows, 1,
-                "value {needle} is present once and must survive pruning"
+                per_split.iter().sum::<usize>(),
+                1,
+                "value {needle} is present once and must survive pruning; per split: {per_split:?}"
+            );
+            assert_eq!(
+                per_split.iter().filter(|rows| **rows > 0).count(),
+                1,
+                "exactly one split owns {needle}; per split: {per_split:?}"
             );
         }
 
-        // Outside every zone's range: nothing to return, and the split is skipped.
+        // Outside every zone's range: every split is skipped, nothing is returned.
         let filter = logical2physical(&col("a").eq(lit(ROWS + 1)), table_schema.table_schema());
-        let opener = make_opener(object_store.clone(), table_schema.clone(), Some(filter));
-        let rows: usize = opener
-            .open(file)
-            .expect("opener should open the file")
-            .await
-            .expect("opening should produce a stream")
-            .try_collect::<Vec<_>>()
-            .await?
-            .iter()
-            .map(RecordBatch::num_rows)
-            .sum();
-        assert_eq!(rows, 0, "a value the file cannot hold must return no rows");
+        let per_split = rows_per_split(&object_store, &table_schema, &byte_splits, filter).await?;
+        assert!(
+            per_split.iter().all(|rows| *rows == 0),
+            "a value the file cannot hold must return no rows; per split: {per_split:?}"
+        );
+
+        // Nothing prunable: the splits must still tile the file exactly, which is
+        // what says the pruned range and the scanned range are the same range.
+        let filter = logical2physical(&col("a").gt_eq(lit(0)), table_schema.table_schema());
+        let per_split = rows_per_split(&object_store, &table_schema, &byte_splits, filter).await?;
+        assert_eq!(
+            per_split.iter().sum::<usize>(),
+            ROWS as usize,
+            "byte splits must cover every row exactly once; per split: {per_split:?}"
+        );
 
         Ok(())
     }
-
     #[tokio::test]
     async fn test_open_empty_file() -> anyhow::Result<()> {
         use futures::TryStreamExt;


### PR DESCRIPTION
## 📝 Summary

### Problem

- DataFusion cuts a Vortex file into byte-range splits and hands each split the *whole file's* `Statistics`. `FilePruner` cannot tell the splits apart, so if the file might hold the key, every split is opened.
- Vortex already knows better. The zoned layout carries per-zone statistics at 8192 rows — finer than a parquet row group — but nothing consulted them before the scan was built.
- A point lookup therefore paid full scan setup on all 22 splits (layout open, filter conversion and optimization, projection split), then read matching rows from one of them.

### Changes

- `VortexOpener::open` runs the layout's zone pruning over the split's own row range before building the scan, and returns an empty stream when the zone map proves no row in that range can match.

### Evidence

TPC-H SF1, `spiced` release build, HTTP `/v1/sql`, SQL results cache off, 20s measured after a 15s warm at the same key distribution, fresh `.spice` per arm. Measured on top of ordered writes, which is what gives zones a narrow range to prove against.

Point lookup on `lineitem` by `l_orderkey`:

|            | before  | after            |
| ---------- | ------- | ---------------- |
| p50        | 7.6 ms  | 6.7 ms (−12%)    |
| CPU/query  | 35.1 ms | 16.5 ms (−53%)   |

Two-table join, `orders ⋈ lineitem`:

|            | before  | after            |
| ---------- | ------- | ---------------- |
| p50        | 9.9 ms  | 9.4 ms (−5%)     |
| CPU/query  | 54.6 ms | 29.0 ms (−47%)   |

- The CPU/query drop is the mechanism showing through: a split the zone map rules out returns before any scan setup, and a point lookup rules out all but one of them.
- Non-selective scans, where nothing can be pruned, are unchanged: +0.5% and +1.9% across two query shapes, inside run-to-run noise.
- Result sets are byte-identical before and after, including the boundary needles at a zone edge (8191, 8192) and a value outside the key range.

## 👀 Notes for Reviewers

- The gain scales with how tightly the data is ordered — zones on interleaved data span a wider range and prove less. A standalone measurement against unordered data is in a follow-up comment.
