### PR TITLE
test(s3): run the parquet-overwrite fixtures on RustFS

### DIFF
--- a/crates/runtime/tests/s3_parquet_overwrite/mod.rs
+++ b/crates/runtime/tests/s3_parquet_overwrite/mod.rs
@@ -62,10 +62,10 @@ use crate::{
     utils::{runtime_ready_check, test_request_context},
 };
 
-const MINIO_HOST_PORT: u16 = 19_137;
+const S3_HOST_PORT: u16 = 19_137;
 const PROXY_PORT: u16 = 19_138;
-const ACCESS_KEY: &str = "minioadmin";
-const SECRET_KEY: &str = "minioadmin";
+const ACCESS_KEY: &str = "rustfsadmin";
+const SECRET_KEY: &str = "rustfsadmin";
 const BUCKET: &str = "overwrite-race";
 const OBJECT_KEY: &str = "listing/data.parquet";
 const ROWS: i64 = 20_000;
@@ -325,17 +325,23 @@ async fn overwrite_object(
     Ok(())
 }
 
-async fn start_minio() -> Result<RunningContainer<'static>, anyhow::Error> {
-    let container = ContainerRunnerBuilder::new("spice_test_minio_parquet_overwrite")
-        .image("minio/minio:latest".to_string())
-        .add_port_binding(9000, MINIO_HOST_PORT)
-        .add_env_var("MINIO_ROOT_USER", ACCESS_KEY)
-        .add_env_var("MINIO_ROOT_PASSWORD", SECRET_KEY)
-        .command(["server", "/data", "--console-address", ":9001"])
+/// An S3-compatible object store for the fixtures these tests overwrite.
+///
+/// The store has to serve the two things the generation pin relies on: buckets
+/// with versioning enabled, so a replaced object keeps a fetchable `versionId`,
+/// and `If-Match` on GET, so a read pinned to a stale `ETag` fails with 412
+/// rather than returning the replacement's bytes.
+async fn start_object_store() -> Result<RunningContainer<'static>, anyhow::Error> {
+    let container = ContainerRunnerBuilder::new("spice_test_rustfs_parquet_overwrite")
+        .image("rustfs/rustfs:latest".to_string())
+        .add_port_binding(9000, S3_HOST_PORT)
+        .add_env_var("RUSTFS_ACCESS_KEY", ACCESS_KEY)
+        .add_env_var("RUSTFS_SECRET_KEY", SECRET_KEY)
+        .command(["/data"])
         .healthcheck(HealthConfig {
             test: Some(vec![
                 "CMD-SHELL".to_string(),
-                "curl -f http://127.0.0.1:9000/minio/health/live || exit 1".to_string(),
+                "netstat -tulpn | grep 9000 || exit 1".to_string(),
             ]),
             interval: Some(500_000_000),
             timeout: Some(1_000_000_000),
@@ -346,7 +352,7 @@ async fn start_minio() -> Result<RunningContainer<'static>, anyhow::Error> {
         .build()?
         .run(Some(Duration::from_mins(2)))
         .await?;
-    wait_for_tcp_port("127.0.0.1", MINIO_HOST_PORT, Duration::from_mins(1)).await?;
+    wait_for_tcp_port("127.0.0.1", S3_HOST_PORT, Duration::from_mins(1)).await?;
     Ok(container)
 }
 
@@ -504,7 +510,7 @@ async fn proxy_connection(
         if delay_later_gets {
             tokio::time::sleep(Duration::from_millis(400)).await;
         }
-        let mut upstream = TcpStream::connect(("127.0.0.1", MINIO_HOST_PORT)).await?;
+        let mut upstream = TcpStream::connect(("127.0.0.1", S3_HOST_PORT)).await?;
         upstream.write_all(&headers).await?;
         upstream.write_all(&body).await?;
         let Some((resp_headers, resp_body)) = read_http_message(&mut upstream, !is_head).await?
@@ -690,12 +696,18 @@ struct GenerationPair {
 async fn race_listing_scan(
     mix: &MixProxy,
     proxy: &str,
-    minio: &str,
+    store_endpoint: &str,
     bucket: &str,
     generations: &GenerationPair,
     versioned: bool,
 ) -> Result<(), anyhow::Error> {
-    ensure_bucket_and_object(minio, bucket, generations.bytes_a.clone(), versioned).await?;
+    ensure_bucket_and_object(
+        store_endpoint,
+        bucket,
+        generations.bytes_a.clone(),
+        versioned,
+    )
+    .await?;
     mix.reset();
     let rt = run_runtime(proxy, bucket).await?;
     mix.reset();
@@ -718,7 +730,7 @@ async fn race_listing_scan(
         async move { scan_payload_char_len(rt.as_ref()).await }
     });
     mix.wait_for_first_pinned_object_get().await?;
-    overwrite_object(minio, bucket, generations.bytes_b.clone()).await?;
+    overwrite_object(store_endpoint, bucket, generations.bytes_b.clone()).await?;
     let raced = query
         .await
         .map_err(|e| anyhow::anyhow!("scan task join: {e}"))?;
@@ -791,7 +803,7 @@ fn accelerated_append_fixture_sets_append_and_a_time_column() {
 
 async fn corrupt_parquet_is_not_classified_as_generation_change(
     endpoint: &str,
-    minio: &str,
+    store_endpoint: &str,
     bucket: &str,
     mut bytes: Vec<u8>,
 ) -> Result<(), anyhow::Error> {
@@ -800,7 +812,7 @@ async fn corrupt_parquet_is_not_classified_as_generation_change(
     for byte in bytes.iter_mut().skip(start).take(64) {
         *byte ^= 0xff;
     }
-    ensure_bucket_and_object(minio, bucket, bytes, false).await?;
+    ensure_bucket_and_object(store_endpoint, bucket, bytes, false).await?;
     configure_test_datafusion();
     let rt = Arc::new(
         Runtime::builder()
@@ -846,11 +858,11 @@ async fn corrupt_parquet_is_not_classified_as_generation_change(
 async fn accelerated_refresh_retries_a_replaced_object(
     mix: &MixProxy,
     proxy: &str,
-    minio: &str,
+    store_endpoint: &str,
     bucket: &str,
     generations: &GenerationPair,
 ) -> Result<(), anyhow::Error> {
-    ensure_bucket_and_object(minio, bucket, generations.bytes_a.clone(), false).await?;
+    ensure_bucket_and_object(store_endpoint, bucket, generations.bytes_a.clone(), false).await?;
     mix.reset();
     let load = tokio::spawn({
         let proxy = proxy.to_string();
@@ -865,7 +877,7 @@ async fn accelerated_refresh_retries_a_replaced_object(
         "schema inference must GET '{OBJECT_KEY}' without If-Match/versionId before the refresh scan pins it; \
          otherwise waiting for any object GET would overwrite during inference"
     );
-    overwrite_object(minio, bucket, generations.bytes_b.clone()).await?;
+    overwrite_object(store_endpoint, bucket, generations.bytes_b.clone()).await?;
     let rt = load
         .await
         .map_err(|e| anyhow::anyhow!("accelerated load join: {e}"))?
@@ -893,11 +905,11 @@ async fn accelerated_refresh_retries_a_replaced_object(
 async fn accelerated_append_refresh_retries_without_partial_or_duplicate_rows(
     mix: &MixProxy,
     proxy: &str,
-    minio: &str,
+    store_endpoint: &str,
     bucket: &str,
     generations: &GenerationPair,
 ) -> Result<(), anyhow::Error> {
-    ensure_bucket_and_object(minio, bucket, generations.bytes_a.clone(), false).await?;
+    ensure_bucket_and_object(store_endpoint, bucket, generations.bytes_a.clone(), false).await?;
     mix.reset();
     let load = tokio::spawn({
         let proxy = proxy.to_string();
@@ -912,7 +924,7 @@ async fn accelerated_append_refresh_retries_without_partial_or_duplicate_rows(
         "schema inference must GET '{OBJECT_KEY}' without If-Match/versionId before the append refresh scan pins it; \
          otherwise waiting for any object GET would overwrite during inference"
     );
-    overwrite_object(minio, bucket, generations.bytes_b.clone()).await?;
+    overwrite_object(store_endpoint, bucket, generations.bytes_b.clone()).await?;
     let rt = load
         .await
         .map_err(|e| anyhow::anyhow!("append load join: {e}"))?
@@ -958,8 +970,8 @@ async fn listing_table_scan_does_not_decode_a_replaced_object() -> Result<(), an
     let _tracing = init_tracing(Some("integration=debug,info"));
     test_request_context()
         .scope(async {
-            let container = start_minio().await?;
-            let minio = format!("http://127.0.0.1:{MINIO_HOST_PORT}");
+            let container = start_object_store().await?;
+            let store_endpoint = format!("http://127.0.0.1:{S3_HOST_PORT}");
             let proxy = format!("http://127.0.0.1:{PROXY_PORT}");
             let mix = MixProxy::start();
             wait_for_tcp_port("127.0.0.1", PROXY_PORT, Duration::from_secs(5)).await?;
@@ -988,11 +1000,12 @@ async fn listing_table_scan_does_not_decode_a_replaced_object() -> Result<(), an
             );
 
             let result = async {
-                race_listing_scan(&mix, &proxy, &minio, BUCKET, &generations, false).await?;
+                race_listing_scan(&mix, &proxy, &store_endpoint, BUCKET, &generations, false)
+                    .await?;
                 race_listing_scan(
                     &mix,
                     &proxy,
-                    &minio,
+                    &store_endpoint,
                     "overwrite-race-versioned",
                     &generations,
                     true,
@@ -1000,7 +1013,7 @@ async fn listing_table_scan_does_not_decode_a_replaced_object() -> Result<(), an
                 .await?;
                 corrupt_parquet_is_not_classified_as_generation_change(
                     &proxy,
-                    &minio,
+                    &store_endpoint,
                     "overwrite-race-corrupt",
                     generations.bytes_a.clone(),
                 )
@@ -1008,7 +1021,7 @@ async fn listing_table_scan_does_not_decode_a_replaced_object() -> Result<(), an
                 accelerated_refresh_retries_a_replaced_object(
                     &mix,
                     &proxy,
-                    &minio,
+                    &store_endpoint,
                     "overwrite-race-accel",
                     &generations,
                 )
@@ -1016,7 +1029,7 @@ async fn listing_table_scan_does_not_decode_a_replaced_object() -> Result<(), an
                 accelerated_append_refresh_retries_without_partial_or_duplicate_rows(
                     &mix,
                     &proxy,
-                    &minio,
+                    &store_endpoint,
                     "overwrite-race-accel-append",
                     &append_generations,
                 )


### PR DESCRIPTION
## 📝 Summary

`s3_parquet_overwrite::listing_table_scan_does_not_decode_a_replaced_object` fails on `trunk`
before it runs a single assertion: its MinIO container cannot be pulled.

```
Error: Docker responded with status code 404: pull access denied for minio/minio,
repository does not exist or may require 'docker login'
```

`minio/minio` is no longer publicly available on Docker Hub. The repository 404s on the Hub API,
and the registry returns 401 to an anonymous request for the tag list and for every tag tried,
while every other image this suite uses answers 200 through the identical anonymous-token flow:

```console
$ # Docker Hub repository API
minio/minio    -> HTTP 404          rustfs/rustfs -> HTTP 200
$ # registry manifest, anonymous pull token
minio/minio:latest                        -> HTTP 401
minio/minio:RELEASE.2025-04-22T22-12-26Z  -> HTTP 401
minio/minio  tags/list                    -> HTTP 401
rustfs/rustfs:latest                      -> HTTP 200
amazon/dynamodb-local:latest              -> HTTP 200
library/postgres:latest                   -> HTTP 200
library/mysql:latest                      -> HTTP 200
```

Authenticating does not help. In the failing `Integration Tests (part 3)` job the Docker Hub login
step succeeds and the pull is still denied:

```
success  Login to DockerHub
success  Pull database images
failure  Run integration test
         pull access denied for minio/minio, repository does not exist or may require 'docker login'
```

So this switches the fixtures to RustFS, the S3-compatible store `s3_location_pruning` already runs
against.

## 🔗 Related

Integration tests on `trunk` have been red on this since it started failing between
`4c7b254d6c` (passing) and `ecd92a5122` (failing).

## 👀 Notes for Reviewers

The concern worth checking is whether RustFS actually serves what the generation pin depends on,
since this test is specifically about a replacement landing mid-scan. It needs versioned buckets
(so a replaced object keeps a fetchable `versionId`) and `If-Match` on GET (so a read pinned to a
stale `ETag` fails with 412 rather than returning the replacement's bytes). Probed directly:

```console
$ aws s3api put-bucket-versioning --bucket probe --versioning-configuration Status=Enabled ; echo $?
0
$ aws s3api get-bucket-versioning --bucket probe
{ "Status": "Enabled" }
$ aws s3api list-object-versions --bucket probe --prefix obj
[('0e208390-…', 6, True), ('f48a3dad-…', 4, False)]      # version ids + IsLatest
$ aws s3api get-object --key obj --if-match "$CURRENT_ETAG" /tmp/out ; echo $?
0
$ aws s3api get-object --key obj --if-match "$STALE_ETAG" /tmp/out
An error occurred (PreconditionFailed) when calling the GetObject operation
$ aws s3api get-object --key obj --version-id f48a3dad-… /tmp/out3 && wc -c < /tmp/out3
4                                                         # the superseded version, not the replacement
```

The credentials moved from `minioadmin` to `rustfsadmin` with the image, and `MINIO_HOST_PORT`
became `S3_HOST_PORT`; the `minio` parameter is now `store_endpoint`, which also removes the
collision with the existing `endpoint` parameter (the URL the dataset reads through the proxy)
in `corrupt_parquet_is_not_classified_as_generation_change`.

## ✅ Test plan

The failing test against a real RustFS container. Same command on trunk and on this branch:

```console
$ # before, on trunk
$ cargo nextest run -p runtime --test integration -E 'test(listing_table_scan_does_not_decode_a_replaced_object)'
  stderr ───
    Error: Docker responded with status code 404: pull access denied for minio/minio, …
     Summary [ 58.302s] 1 test run: 0 passed, 1 failed, 351 skipped

$ # after, on this branch
$ cargo nextest run -p runtime --test integration -E 'test(listing_table_scan_does_not_decode_a_replaced_object)'
        PASS [  36.849s] (1/1) runtime::integration s3_parquet_overwrite::listing_table_scan_does_not_decode_a_replaced_object
     Summary [  36.849s] 1 test run: 1 passed, 351 skipped
```

The whole module, so the renames are covered too:

```console
$ cargo nextest run -p runtime --test integration -E 'test(s3_parquet_overwrite)'
        PASS [   0.196s] (1/5) s3_parquet_overwrite::http_response_status_reads_412_from_the_status_line
        PASS [   0.197s] (2/5) s3_parquet_overwrite::accelerated_append_fixture_sets_append_and_a_time_column
        PASS [   0.197s] (3/5) s3_parquet_overwrite::generation_pin_is_only_if_match_or_version_id
        PASS [   0.207s] (4/5) s3_parquet_overwrite::a_mixed_row_group_does_not_share_either_generation_payload_sum
        PASS [  36.236s] (5/5) s3_parquet_overwrite::listing_table_scan_does_not_decode_a_replaced_object
     Summary [  36.237s] 5 tests run: 5 passed, 347 skipped
```

```console
$ cargo fmt -p runtime -- --check ; echo $?
0
```

Both runs were on macOS/aarch64 against the published `rustfs/rustfs:latest`. The 412 and
`versionId` paths are the ones the passing test exercises, so the versioned and unversioned halves
are both covered rather than inferred.
