### PR TITLE
ci: run Substrait Mode A TPC-H on pull requests and the merge queue

### DIFF
--- a/.github/workflows/substrait_compliance.yml
+++ b/.github/workflows/substrait_compliance.yml
@@ -17,10 +17,16 @@ on:
       - release-*
       - release/*
       - feature-*
-    # Docs-only and unrelated-crate PRs must not pay for a 90m compile.
-    # Keep this list in lockstep with the check_changes filter below.
+    # Docs-only PRs (repo docs and harness Markdown) must not pay for a
+    # 90m compile. Harness globs omit `*.md` so README/RESULTS edits do
+    # not start this workflow. Keep this list in lockstep with the
+    # check_changes filter below.
     paths:
-      - 'tools/substrait-compliance/**'
+      - 'tools/substrait-compliance/src/**'
+      - 'tools/substrait-compliance/scripts/**'
+      - 'tools/substrait-compliance/Cargo.toml'
+      - 'tools/substrait-compliance/.gitignore'
+      - 'tools/substrait-compliance/NOTICE'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
@@ -85,7 +91,11 @@ jobs:
           # reports the merge-queue job green without running Mode A.
           filters: |
             code_changes:
-              - 'tools/substrait-compliance/**'
+              - 'tools/substrait-compliance/src/**'
+              - 'tools/substrait-compliance/scripts/**'
+              - 'tools/substrait-compliance/Cargo.toml'
+              - 'tools/substrait-compliance/.gitignore'
+              - 'tools/substrait-compliance/NOTICE'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
@@ -141,7 +151,7 @@ jobs:
             --out-json tools/substrait-compliance/results/mode-a-tpch.json \
             --out-csv tools/substrait-compliance/results/mode-a-tpch.csv
 
-      - name: Upload JSON report
+      - name: Upload JSON and CSV reports
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/substrait_compliance.yml
+++ b/.github/workflows/substrait_compliance.yml
@@ -1,21 +1,55 @@
-name: Substrait compliance (report-only)
+name: Substrait compliance
 
-# Nightly + manual only. Not on pull_request or merge_group — this is a
-# DataFusion consumer baseline, not a merge gate. Per-query FAIL/ERROR
-# exit 0; do not fail the repository on pass rate until a threshold is
-# set from the Mode A numbers. A harness/build crash must still fail.
+# Mode A TPC-H on pull_request, merge_group, nightly, and manual dispatch.
+# Per-query FAIL/ERROR still exit 0 (report-only pass rate). Do not fail
+# the repository on pass rate until a threshold is set. A harness/build
+# crash must still fail the job.
+#
+# Not a required check (`scripts/signoff` REQUIRED_CHECKS): the job is
+# visible on PRs that touch the paths below and runs in the merge queue,
+# but a low pass rate does not block merge. `merge_group` cannot honour
+# `paths`, so that event is gated with check-code-changes instead.
 
 on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    # Docs-only and unrelated-crate PRs must not pay for a 90m compile.
+    # Keep this list in lockstep with the check_changes filter below.
+    paths:
+      - 'tools/substrait-compliance/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'rust-toolchain'
+      - '.cargo/**'
+      - '.github/workflows/substrait_compliance.yml'
+      - '.github/actions/setup-rust/**'
+      - '.github/actions/install-protoc/**'
+      - '.github/actions/check-code-changes/**'
+      - 'crates/yaml/**'
+  merge_group:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
   schedule:
     - cron: '30 8 * * *' # 08:30 UTC daily
   workflow_dispatch:
 
 concurrency:
-  group: substrait-compliance-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
   cancel-in-progress: true
 
+# `dorny/paths-filter` (via check-code-changes) reads the changed-file
+# list for a pull request from the REST API, not from the checkout.
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -24,8 +58,50 @@ env:
   SUBSTRAIT_COMPLIANCE_REF: 43d31411c69ef7594887c7d759037bcf8244eeed
 
 jobs:
+  # merge_group cannot path-filter, so decide here whether Mode A should
+  # run. Path-filtered pull_request, schedule, and workflow_dispatch
+  # always run — dispatch has no useful base to diff (see verus_verify.yml).
+  check_changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      relevant_changes: ${{ steps.check.outputs.relevant_changes == 'true' || github.event_name != 'merge_group' }}
+    steps:
+      - name: Non-merge-group events always run Mode A
+        if: ${{ github.event_name != 'merge_group' }}
+        run: echo "Mode A TPC-H runs on pull_request, schedule, and workflow_dispatch"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check for relevant changes
+        if: ${{ github.event_name == 'merge_group' }}
+        id: check
+        uses: ./.github/actions/check-code-changes
+        with:
+          # Same globs as on.pull_request.paths — a path missing here
+          # reports the merge-queue job green without running Mode A.
+          filters: |
+            code_changes:
+              - 'tools/substrait-compliance/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'rust-toolchain'
+              - '.cargo/**'
+              - '.github/workflows/substrait_compliance.yml'
+              - '.github/actions/setup-rust/**'
+              - '.github/actions/install-protoc/**'
+              - '.github/actions/check-code-changes/**'
+              - 'crates/yaml/**'
+
   mode_a_tpch:
-    name: Mode A TPC-H (DataFusion consumer)
+    name: Mode A TPC-H
+    needs: check_changes
+    if: ${{ needs.check_changes.outputs.relevant_changes == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     steps:

--- a/.github/workflows/substrait_compliance.yml
+++ b/.github/workflows/substrait_compliance.yml
@@ -45,11 +45,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
   cancel-in-progress: true
 
-# `dorny/paths-filter` (via check-code-changes) reads the changed-file
-# list for a pull request from the REST API, not from the checkout.
+# check-code-changes only runs on merge_group here, where dorny/paths-filter
+# diffs the checkout (`git diff <base>..<head>`). No pull-request REST API.
 permissions:
   contents: read
-  pull-requests: read
 
 env:
   CARGO_TERM_COLOR: always

--- a/tools/substrait-compliance/README.md
+++ b/tools/substrait-compliance/README.md
@@ -4,8 +4,10 @@ Measures [IBM/substrait-compliance](https://github.com/IBM/substrait-compliance)
 TPC-H pass rate against the Spice `DataFusion` fork (Mode A) and sketches the
 product path through FlightSQL `CommandStatementSubstraitPlan` (Mode B).
 
-This is a **DataFusion consumer baseline**, not product CI. Nightly is
-report-only; it does not fail the repository on a low pass rate.
+This is a **DataFusion consumer baseline**. CI (`pull_request`,
+`merge_group`, and nightly) is report-only on pass rate: it does not
+fail the repository on a low pass rate. A harness or build crash still
+fails the job.
 
 ## Pins
 
@@ -18,7 +20,7 @@ report-only; it does not fail the repository on a low pass rate.
 The IBM `examples/datafusion-rust` tree on **`main`** pins
 `datafusion` / `datafusion-substrait` **54.1** and is the layout Mode A
 follows. Test suites and expected-output CSVs come from the pinned
-fork commit; `scripts/fetch-ibm.sh`, the nightly workflow and `SUITE_REF`
+fork commit; `scripts/fetch-ibm.sh`, the CI workflow and `SUITE_REF`
 in `src/main.rs` carry the same pin and move together.
 
 Nothing from the IBM repository is vendored. The suite is cloned at run
@@ -115,13 +117,16 @@ Server: `crates/runtime/src/flight/flightsql/statement_substrait_plan.rs`.
 Open work: catalog mapping from `spice.public.lineitem` onto unqualified
 Isthmus names; `spiced` bring-up in this harness; auth.
 
-## Nightly CI
+## CI
 
-`.github/workflows/substrait_compliance.yml` — `schedule` +
-`workflow_dispatch` only. Per-query FAIL/ERROR already exit 0; a
-harness/build crash fails the job (no `continue-on-error`). Uploads
-the JSON report as an artifact. Do not gate merge on pass rate until
-a threshold is set from this baseline.
+`.github/workflows/substrait_compliance.yml` runs on `pull_request` and
+`merge_group` (gated to the harness, DataFusion pin, toolchain, and
+workflow paths so docs-only changes skip the job), plus nightly
+`schedule` and `workflow_dispatch`. Per-query FAIL/ERROR already exit
+0; a harness/build crash fails the job (no `continue-on-error`).
+Uploads the JSON report as an artifact. Do not gate merge on pass rate
+until a threshold is set from this baseline. The job is not in
+`REQUIRED_CHECKS`.
 
 ## License
 

--- a/tools/substrait-compliance/README.md
+++ b/tools/substrait-compliance/README.md
@@ -120,13 +120,13 @@ Isthmus names; `spiced` bring-up in this harness; auth.
 ## CI
 
 `.github/workflows/substrait_compliance.yml` runs on `pull_request` and
-`merge_group` (gated to the harness, DataFusion pin, toolchain, and
-workflow paths so docs-only changes skip the job), plus nightly
-`schedule` and `workflow_dispatch`. Per-query FAIL/ERROR already exit
-0; a harness/build crash fails the job (no `continue-on-error`).
-Uploads the JSON report as an artifact. Do not gate merge on pass rate
-until a threshold is set from this baseline. The job is not in
-`REQUIRED_CHECKS`.
+`merge_group` (gated to harness source, scripts, DataFusion pin,
+toolchain, and workflow paths so repo docs and harness Markdown skip
+the job), plus nightly `schedule` and `workflow_dispatch`. Per-query
+FAIL/ERROR already exit 0; a harness/build crash fails the job (no
+`continue-on-error`). Uploads the JSON and CSV reports as an artifact.
+Do not gate merge on pass rate until a threshold is set from this
+baseline. The job is not in `REQUIRED_CHECKS`.
 
 ## License
 

--- a/tools/substrait-compliance/RESULTS.md
+++ b/tools/substrait-compliance/RESULTS.md
@@ -123,5 +123,6 @@ of the golden.
 | q21 | PASS | subquery scan qualifier (fork #226) |
 | q22 | PASS | string↔numeric type labels reach value compare |
 
-Do not treat these counts as a merge gate. Nightly CI is report-only until a
+Do not treat these counts as a merge gate. CI (`pull_request`,
+`merge_group`, and nightly) is report-only on pass rate until a
 threshold is set from this baseline (and preferably from Mode B).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Summary

Enables the Mode A TPC-H Substrait compliance job (landed in #13879) on `pull_request` and `merge_group` so it shows up as a normal CI check, while keeping nightly `schedule` and `workflow_dispatch`.

Per-query FAIL/ERROR still exit 0 (report-only pass rate). A harness, build, or I/O crash still fails the job. This does **not** add the job to `REQUIRED_CHECKS` and does **not** fail the PR on pass rate < 100%.

## 🔗 Related

Follow-up to https://github.com/spiceai/spiceai/pull/13879.

## Trigger and gating changes

| Event | Before | After |
|-------|--------|-------|
| `schedule` (08:30 UTC daily) | Runs Mode A | Unchanged — always runs |
| `workflow_dispatch` | Runs Mode A | Unchanged — always runs |
| `pull_request` | Not triggered | Triggered when the paths below change; Mode A runs |
| `merge_group` | Not triggered | Always triggered; Mode A runs only when `check-code-changes` matches the same paths |

**Path filter** (workflow-level on `pull_request`; `check-code-changes` on `merge_group`, which cannot honour `paths`):

- `tools/substrait-compliance/src/**`, `scripts/**`, `Cargo.toml`, `.gitignore`, `NOTICE` (harness Markdown is omitted)
- `Cargo.toml` / `Cargo.lock` (workspace DataFusion pins)
- `rust-toolchain.toml` / `rust-toolchain`
- `.cargo/**`
- `.github/workflows/substrait_compliance.yml`
- `.github/actions/setup-rust/**`, `install-protoc/**`, `check-code-changes/**`
- `crates/yaml/**` (direct harness path dependency)

Repo docs and harness Markdown (`README.md`, `RESULTS.md`) do not start the workflow. Unrelated merge-queue entries skip the 90m compile and still report the `check_changes` job.

The workflow is renamed from `Substrait compliance (report-only)` to `Substrait compliance`. The Mode A job is named `Mode A TPC-H`. Report-only **exit** semantics are unchanged (`ExitCode::SUCCESS` after writing the report; nonzero is reserved for harness I/O / load errors).

`pr.yml` / `REQUIRED_CHECKS` are not touched: sibling expensive workflows that are not merge gates stay as standalone workflows. The check appears on PRs that hit the path filter.

Permissions are `contents: read` only. `check-code-changes` runs on `merge_group` against the checkout (`git diff <base>..<head>`), so `pull-requests: read` is not needed.

## 📚 Docs

- `tools/substrait-compliance/README.md` — CI now includes PR and merge queue; JSON and CSV artifacts
- `tools/substrait-compliance/RESULTS.md` — same pass-rate note

## 👀 Notes for Reviewers

- First `pull_request` run of this workflow (HEAD `b94ccdd7c`) succeeded: [Mode A TPC-H](https://github.com/spiceai/spiceai/actions/runs/34710182937/job/103597423070) reported `22/0/0  pass/fail/skip+error  total=22  pass_rate=100.0%`.
- GitHub still labels the check `Substrait compliance (report-only)` until this workflow name change is on `trunk`.
- Including `Cargo.toml` / `Cargo.lock` means a DataFusion pin bump pays for Mode A on the PR and in the queue. If that is too broad, the filter can shrink to the harness + workflow only.
- Draft so the CI wiring (PR vs merge-queue execution, path set, not-required) can get a second look before marking ready.
- Enforce Pulls with Spice needs an assignee; this token cannot set one. Assign `lukekim` and toggle a label to re-run that check.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90ae45ee-d277-4587-be3a-aa5982574cd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90ae45ee-d277-4587-be3a-aa5982574cd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

