### PR TITLE
Harden HuggingFace E2E chat against Metal generation timeouts

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -649,6 +649,12 @@ jobs:
         run: |
           ./test/models/search_01.exp
 
+      # No step retry: the 30s timeout in merge-queue job 103597842965 fired
+      # while Qwen2.5-3B was still streaming a long answer on Metal, not on a
+      # Hub download (config probe HTTP 200; `search_01.exp` had already
+      # passed). chat_01_simple.exp now waits 120s per turn (override with
+      # SPICE_CHAT_EXPECT_TIMEOUT) and spicepod_hf.yml caps
+      # hf_max_completion_tokens at 64. A timeout after that is a hang.
       - name: Test chat
         run: |
           ./test/models/chat_01_simple.exp

--- a/test/models/chat_01_simple.exp
+++ b/test/models/chat_01_simple.exp
@@ -2,8 +2,12 @@
 
 source [file join [file dirname [info script]] repl_helpers.exp]
 
-# Runtime response timeout
-set timeout 30
+# Local Hugging Face / Metal inference can stream well past 30s after the model
+# is already loaded: merge-queue job 103597842965 spent the whole 30s budget on
+# one long Qwen2.5-3B answer and never reached `chat>`. 120s is the default so a
+# slow generation still finishes; override with SPICE_CHAT_EXPECT_TIMEOUT
+# (seconds) for CI or a local run. Search stays on its own 5s timeout.
+set timeout [repl_timeout_seconds 120]
 
 spawn spice chat {*}[repl_endpoint_args]
 
@@ -48,9 +52,9 @@ expect {
     }
 }
 
-chat "What datasets you have access to?"
+chat "Reply in one short sentence: what datasets do you have access to?"
 
-chat "How many issues stored in database?"
+chat "Reply in one short sentence: how many issues are stored in the database?"
 
 # Every verification passed, so the REPL must still be sitting at its prompt.
 repl_assert_running "Checking the chat REPL is still running"

--- a/test/models/expect_test.sh
+++ b/test/models/expect_test.sh
@@ -169,6 +169,38 @@ assert_reports 'Sending "how many issues?"'
 assert_reports 'exited with status 3'
 assert_silent_about 'REACHED THE END'
 
+# SPICE_CHAT_EXPECT_TIMEOUT overrides the script default when it is a positive
+# integer, and is rejected when it is not.
+helper_case 'SPICE_CHAT_EXPECT_TIMEOUT overrides the default' '
+set ::env(SPICE_CHAT_EXPECT_TIMEOUT) 7
+set t [repl_timeout_seconds 120]
+if {$t != 7} { send_user "got $t\n"; exit 1 }
+send_user "OVERRIDE_OK\n"
+exit 0
+'
+assert_status 0
+assert_reports 'OVERRIDE_OK'
+
+helper_case 'absent SPICE_CHAT_EXPECT_TIMEOUT keeps the default' '
+unset -nocomplain ::env(SPICE_CHAT_EXPECT_TIMEOUT)
+set t [repl_timeout_seconds 120]
+if {$t != 120} { send_user "got $t\n"; exit 1 }
+send_user "DEFAULT_OK\n"
+exit 0
+'
+assert_status 0
+assert_reports 'DEFAULT_OK'
+
+helper_case 'rejects a non-integer SPICE_CHAT_EXPECT_TIMEOUT' '
+set ::env(SPICE_CHAT_EXPECT_TIMEOUT) not-a-number
+repl_timeout_seconds 30
+send_user "REACHED THE END\n"
+exit 0
+'
+assert_status 1
+assert_reports 'SPICE_CHAT_EXPECT_TIMEOUT must be a positive integer'
+assert_silent_about 'REACHED THE END'
+
 # A healthy exchange still runs to completion: the helpers must not turn a
 # working interaction into a failure.
 helper_case 'healthy exchange' '
@@ -219,6 +251,7 @@ set -u
 mode=$1
 exit_before=${SPICE_FAKE_EXIT_BEFORE_TURN:-0}
 exit_after=${SPICE_FAKE_EXIT_AFTER_TURN:-0}
+sleep_secs=${SPICE_FAKE_SLEEP_SECONDS:-0}
 
 # Records how the script invoked us, so a test can check that the runtime
 # endpoint was passed through rather than left at the CLI default.
@@ -239,6 +272,10 @@ while IFS= read -r line; do
 
   if [ "$exit_before" -ne 0 ] && [ "$turn" -ge "$exit_before" ]; then
     exit 44
+  fi
+
+  if [ "$sleep_secs" -gt 0 ]; then
+    sleep "$sleep_secs"
   fi
 
   if [ "$mode" = 'search' ]; then
@@ -295,6 +332,15 @@ script_case 'chat_01_simple.exp when the REPL exits before answering' chat_01_si
 assert_status 1
 assert_reports 'Waiting for the response to'
 assert_reports 'exited with status 44'
+assert_silent_about 'Model returned expected response'
+
+# A generation that outlives the chat expect budget must fail as a timeout, not
+# as a hang of the 120s default. The stand-in sleeps 3s; 1s is enough to trip.
+script_case 'chat_01_simple.exp times out when generation exceeds SPICE_CHAT_EXPECT_TIMEOUT' chat_01_simple.exp \
+  SPICE_CHAT_EXPECT_TIMEOUT=1 \
+  SPICE_FAKE_SLEEP_SECONDS=3
+assert_status 1
+assert_reports 'Timeout waiting for expected response'
 assert_silent_about 'Model returned expected response'
 
 script_case 'search_01.exp when the REPL exits before answering' search_01.exp \

--- a/test/models/repl_helpers.exp
+++ b/test/models/repl_helpers.exp
@@ -85,6 +85,23 @@ proc repl_endpoint_args {} {
     return [list]
 }
 
+# Seconds to wait for a REPL response. `SPICE_CHAT_EXPECT_TIMEOUT` overrides
+# `default` when set to a positive integer so CI or a local run can raise the
+# budget without editing the script.
+proc repl_timeout_seconds {default} {
+    if {![info exists ::env(SPICE_CHAT_EXPECT_TIMEOUT)] || $::env(SPICE_CHAT_EXPECT_TIMEOUT) eq ""} {
+        return $default
+    }
+
+    set raw [string trim $::env(SPICE_CHAT_EXPECT_TIMEOUT)]
+    if {![string is integer -strict $raw] || $raw < 1} {
+        send_user "SPICE_CHAT_EXPECT_TIMEOUT must be a positive integer (seconds); got \"$raw\"\n"
+        exit 1
+    }
+
+    return $raw
+}
+
 # Fails the script if the spawned process has exited. Writing to the pty of an
 # exited process succeeds silently, so a REPL that crashes while sitting idle at
 # its prompt is invisible to `repl_send` alone; reading finds the eof. Output

--- a/test/models/spicepod_hf.yml
+++ b/test/models/spicepod_hf.yml
@@ -56,8 +56,15 @@ models:
   - name: hf_local_model
     from: huggingface:huggingface.co/Qwen/Qwen2.5-3B-Instruct
     params:
+      # Bound Metal generation so a long lecture cannot consume the chat expect
+      # budget (https://github.com/spiceai/spiceai/actions/runs/34707044620/job/103597842965).
+      # `hf_*` is the Hugging Face form of the chat-completion overrides; the
+      # runtime applies them as `max_completion_tokens` / `temperature`.
+      hf_max_completion_tokens: 64
+      hf_temperature: 0
       system_prompt: |
         Instructions for Responses:
+          - Answer in one short sentence.
           - Do not include any private metadata provided to the model as context such as \"reference_url_template\" or \"instructions\" in your responses.
 
 embeddings:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Summary

The Hugging Face E2E `Test chat` step (`./test/models/chat_01_simple.exp`) is flaky on `darwin-aarch64` because local Metal inference of Qwen2.5-3B-Instruct can stream a long answer past the 30s expect budget — after the model is already loaded.

This change makes that path resilient without loosening the OpenAI `chat_01.exp` dataset-name assertions:

- Raise the HF chat expect timeout from **30s to 120s**, overridable via `SPICE_CHAT_EXPECT_TIMEOUT`.
- Cap generation in `spicepod_hf.yml` (`hf_max_completion_tokens: 64`, `hf_temperature: 0`) and ask for one-sentence replies.
- Leave `search_01.exp` at 5s and `chat_01.exp` unchanged.
- No CI step retry: a timeout after 120s plus the token cap is a hang, not a Hub flake.

## 🔗 Related

Failure: [huggingface model (darwin-aarch64) / Test chat](https://github.com/spiceai/spiceai/actions/runs/34707044620/job/103597842965) (merge queue for #13918).

Evidence from that job (not invented):

- Pre-flight: `ok Qwen/Qwen2.5-3B-Instruct @ main (HTTP 200, attempt 1)`
- Runtime: `Model [hf_local_model] deployed, ready for inferencing` at 18:11:23; ready after 27s
- `search_01.exp` passed (`Search returned expected result`)
- `chat_01_simple.exp` sent `What datasets you have access to?` at 18:12:09, streamed a lecture through 18:12:39, then `Timeout waiting for expected response` (exit 1) — never reached the closing `chat>` prompt

## 📚 Docs

No user-facing docs. `test/models/` has no README mentioning the 30s HF timeout; the new timeout is documented on the expect script, the helper, and the HF `Test chat` step.

## 👀 Notes for Reviewers

**Spicepod generation params are available.** Hugging Face models accept `hf_max_completion_tokens` / `hf_temperature` (see `PREFIXED_COMMON` and `get_openai_request_overrides`). The local mistral-rs path applies `max_completion_tokens` as `SamplingParams.max_len`. Values are YAML numbers so they deserialize as JSON numbers (`serde_json::from_value` into the request fields).

**No step retry** on `Test chat`. The HF job already retries Hub probes; this failure was generation latency. Retrying the assertion would hide a real hang and, at 120s × 2 turns × 3 attempts, could trip the 10-minute job timeout.

`chat_01.exp` (OpenAI) is untouched so dataset-name assertions stay strict.

**Harness:** `./test/models/expect_test.sh` (after installing `expect`) — all checks passed, including `SPICE_CHAT_EXPECT_TIMEOUT` override/reject cases, `chat_01_simple.exp` timing out when a stand-in sleeps past a 1s budget, and unchanged OpenAI/`search_01.exp` paths. This environment cannot run Metal / `spiced` Hugging Face inference, so the original 30s mid-stream timeout was reproduced from the job logs above, not re-run here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41edc2c5-f69d-445f-879e-458c28eed090?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41edc2c5-f69d-445f-879e-458c28eed090&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

