### PR TITLE
fix(cayenne): move accelerator filesystem I/O off Tokio workers

### DIFF
--- a/crates/accelerators/accelerator-cayenne/Cargo.toml
+++ b/crates/accelerators/accelerator-cayenne/Cargo.toml
@@ -72,7 +72,7 @@ rusqlite.workspace = true
 turso-shared.workspace = true
 itertools.workspace = true
 snafu.workspace = true
-tokio = { workspace = true, features = ["sync", "rt"] }
+tokio = { workspace = true, features = ["sync", "rt", "fs"] }
 
 [dev-dependencies]
 # Test-only, and deliberately dev-only: these sit in the `runtime` tier, so a normal

--- a/crates/accelerators/accelerator-cayenne/src/lib.rs
+++ b/crates/accelerators/accelerator-cayenne/src/lib.rs
@@ -1090,9 +1090,13 @@ async fn metastore_file_under(data_dir: &Path) -> std::io::Result<Option<PathBuf
         // live — which is the same loss as a catalog directly inside the directory, and
         // is refused the same way.
         Ok(metadata) if metadata.is_symlink() => match tokio::fs::canonicalize(data_dir).await {
-            Ok(resolved) if resolved.is_dir() => resolved,
-            // Dangling, or naming a file: no catalog is reachable through it.
-            Ok(_) => return Ok(None),
+            Ok(resolved) => match tokio::fs::metadata(&resolved).await {
+                Ok(resolved_meta) if resolved_meta.is_dir() => resolved,
+                // Dangling, or naming a file: no catalog is reachable through it.
+                Ok(_) => return Ok(None),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(error) => return Err(error),
+            },
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(error) => return Err(error),
         },
@@ -1184,6 +1188,13 @@ async fn catalog_directly_inside(link: &Path) -> std::io::Result<Option<PathBuf>
         }
     }
     Ok(None)
+}
+
+/// Async equivalent of [`Path::exists`]: `true` only when the path is present.
+/// I/O errors (including permission denied) are `false`, matching `Path::exists`,
+/// so converting the accelerator's existence gates does not change who proceeds.
+async fn path_exists(path: impl AsRef<Path>) -> bool {
+    matches!(tokio::fs::try_exists(path).await, Ok(true))
 }
 
 /// Process-wide counter giving each [`CayenneAccelerator`] instance a unique id,
@@ -1453,7 +1464,7 @@ impl CayenneAccelerator {
     /// proof describe a different tree from the one that gets deleted: `is_local_path` is
     /// a substring test, so a local directory whose name merely contains `://` would be
     /// waved through while `remove_dir_all` still walked it; and `remove_dir_all` — like
-    /// the `exists()` test each delete is gated on — is handed the string itself. A path that
+    /// the existence test each delete is gated on — is handed the string itself. A path that
     /// is genuinely remote is simply absent from the filesystem, and the walk answers
     /// `None` for it at the cost of one `stat`.
     async fn ensure_no_catalog_under_data_dir(
@@ -2411,15 +2422,16 @@ impl CayenneAccelerator {
         Ok(Arc::new(transformed_schema))
     }
 
-    fn ensure_directory(dir_path: &str) -> Result<PathBuf> {
+    async fn ensure_directory(dir_path: &str) -> Result<PathBuf> {
         // Skip directory creation for S3 object store URLs
         if dir_path.starts_with("s3://") {
             return Ok(PathBuf::from(dir_path));
         }
 
         let path_buf = PathBuf::from(dir_path);
-        if !path_buf.exists() {
-            std::fs::create_dir_all(&path_buf)
+        if !path_exists(&path_buf).await {
+            tokio::fs::create_dir_all(&path_buf)
+                .await
                 .boxed()
                 .context(AccelerationCreationFailedSnafu)?;
         }
@@ -2605,7 +2617,8 @@ impl CayenneAccelerator {
             self.get_or_create_memory_catalog().await?
         } else {
             // Ensure metadata directory exists
-            std::fs::create_dir_all(&metadata_dir)
+            tokio::fs::create_dir_all(&metadata_dir)
+                .await
                 .boxed()
                 .context(AccelerationCreationFailedSnafu)?;
             // Get or create the shared catalog (lazy initialization)
@@ -3422,9 +3435,7 @@ impl DataAccelerator for CayenneAccelerator {
             let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
             let metadata_db_path = format!("{metadata_dir}/cayenne.db");
 
-            if open_option == OpenOption::OpenExisting
-                && !std::path::Path::new(&metadata_db_path).exists()
-            {
+            if open_option == OpenOption::OpenExisting && !path_exists(&metadata_db_path).await {
                 return Err(CheckpointError::Store {
                     source: format!(
                         "Cayenne metadata directory does not exist at {metadata_db_path}"
@@ -3645,7 +3656,7 @@ impl DataAccelerator for CayenneAccelerator {
             && acceleration.mode == Mode::FileCreate
         {
             let path_buf = PathBuf::from(&dir_path);
-            if path_buf.exists() {
+            if path_exists(&path_buf).await {
                 let metadata_dir_for_snapshot =
                     PathBuf::from(Self::resolve_metadata_dir(Some(acceleration)));
                 let snapshot_layout = runtime_acceleration::snapshot::AccelerationLayout::cayenne(
@@ -3704,7 +3715,7 @@ impl DataAccelerator for CayenneAccelerator {
                 );
             }
 
-            if path_buf.exists() {
+            if path_exists(&path_buf).await {
                 // The proofs run here rather than earlier because
                 // `snapshot_before_recreate` creates both directories, so an overlap
                 // only a symlink reveals is resolvable now even though the open-time
@@ -3719,7 +3730,7 @@ impl DataAccelerator for CayenneAccelerator {
 
         // Create the vortex data directory if it doesn't exist
         let path_buf = PathBuf::from(&dir_path);
-        if !path_buf.exists() {
+        if !path_exists(&path_buf).await {
             tokio::fs::create_dir_all(&path_buf)
                 .await
                 .boxed()
@@ -3813,7 +3824,7 @@ impl DataAccelerator for CayenneAccelerator {
             Self::resolve_default_data_path(&source.name().to_string().replace(['.', '/'], "_"))
         } else {
             let dir_path = self.resolve_storage_config(source).boxed()?;
-            let _ = Self::ensure_directory(&dir_path).boxed()?;
+            Self::ensure_directory(&dir_path).await.boxed()?;
             dir_path
         };
         let arrow_schema = Self::transformed_arrow_schema(&cmd, source).boxed()?;
@@ -3949,7 +3960,8 @@ impl DataAccelerator for CayenneAccelerator {
             let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
 
             // Ensure metadata directory exists
-            std::fs::create_dir_all(&metadata_dir)
+            tokio::fs::create_dir_all(&metadata_dir)
+                .await
                 .boxed()
                 .context(AccelerationCreationFailedSnafu)?;
 
@@ -4249,7 +4261,7 @@ impl DataAccelerator for CayenneAccelerator {
             catalog.drop_table(table_name).await.boxed()?;
         }
 
-        if path_buf.exists() {
+        if path_exists(&path_buf).await {
             Self::remove_acceleration_data_dir(source, &dir_path).await?;
             tracing::info!(
                 "Removed Cayenne data directory '{dir_path}' for schema recreation (file_update mode)"
@@ -5738,6 +5750,46 @@ mod tests {
             "`://` inside a metadata path does not put it on object storage, and the \
              delete still reaches it"
         );
+    }
+
+    /// `ensure_directory` is the `create_external_table` mkdir. Creating a missing
+    /// local path, repeating that create, and leaving an `s3://` URL untouched are
+    /// the three cases that path handles — and must not block a Tokio worker.
+    #[tokio::test]
+    async fn ensure_directory_creates_a_missing_local_path_and_skips_object_stores() {
+        let base = tempfile::tempdir().expect("temp dir");
+        let dir = base.path().join("vortex").join("nested");
+
+        assert!(
+            !path_exists(&dir).await,
+            "the test directory must start absent"
+        );
+
+        let created = CayenneAccelerator::ensure_directory(&dir.to_string_lossy())
+            .await
+            .expect("create a missing local directory");
+        assert_eq!(created, dir);
+        assert!(dir.is_dir(), "ensure_directory must create the local path");
+
+        CayenneAccelerator::ensure_directory(&dir.to_string_lossy())
+            .await
+            .expect("creating an existing directory is a no-op");
+
+        let s3 = CayenneAccelerator::ensure_directory("s3://bucket/prefix")
+            .await
+            .expect("object-store URLs are not created on disk");
+        assert_eq!(s3, PathBuf::from("s3://bucket/prefix"));
+    }
+
+    #[tokio::test]
+    async fn path_exists_matches_std_path_exists() {
+        let base = tempfile::tempdir().expect("temp dir");
+        let present = base.path().join("present");
+        std::fs::create_dir_all(&present).expect("present dir");
+        let missing = base.path().join("missing");
+
+        assert_eq!(path_exists(&present).await, present.exists());
+        assert_eq!(path_exists(&missing).await, missing.exists());
     }
 
     /// `mode: file_create` must refuse the configuration at open time, before the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Summary

The Cayenne accelerator performed synchronous filesystem I/O (`Path::exists`, `std::fs::create_dir_all`) inside `async fn`s on the runtime's worker threads. A slow or network-mounted data directory can stall those workers; project guidance is that blocking I/O belongs off the async runtime (`tokio::fs` or `spawn_blocking`), and async code must reach an `.await` roughly every 100µs.

This change converts the remaining production existence and mkdir sites in `accelerator-cayenne` to `tokio::fs`, matching the crate's existing `create_dir_all` / `remove_dir_all` / `canonicalize` / directory-walk style.

**Converted sites**

| Site | Was | Now |
|---|---|---|
| `ensure_directory` (called from `create_external_table`) | `Path::exists` + `std::fs::create_dir_all` | `path_exists` (`tokio::fs::try_exists`) + `tokio::fs::create_dir_all` |
| `create_cayenne_table_provider` | `std::fs::create_dir_all` (metadata dir) | `tokio::fs::create_dir_all` |
| `create_external_table` (partitioned path) | `std::fs::create_dir_all` (metadata dir) | `tokio::fs::create_dir_all` |
| `init` (file_create snapshot / delete / mkdir) | `PathBuf::exists` | `path_exists` |
| `drop_table` | `PathBuf::exists` | `path_exists` |
| `sidecar` (`OpenExisting` metadata-db check) | `Path::exists` | `path_exists` |
| `metastore_file_under` (symlink target) | `Path::is_dir` after `canonicalize` | `tokio::fs::metadata` |

`path_exists` matches `Path::exists` semantics: I/O errors including permission denied are `false`, so the conversion does not change who proceeds through an existence gate.

**Already async (not changed)**

The metastore-overlap guard from #13106 (`overlapping_metastore_dir` / `resolve_in_filesystem_order`) already uses `tokio::fs::canonicalize`. `init` / `drop_table` already `await` that helper; this PR leaves it as-is so the module is consistent rather than half-converted.

**Left sync on purpose**

`DataAccelerator::is_initialized` is a synchronous trait method, so its `Path::exists` checks stay. Converting them would be a trait-surface change, not this bug.

`tokio::fs` was chosen over a `spawn_blocking` hop because this crate already uses `tokio::fs` for the same class of calls (`create_dir_all`, `remove_dir_all`, `read_dir`, `canonicalize`), and each site is a single stat/mkdir rather than a grouped check that benefits from one blocking hop.

## 🔗 Related

Fixes #13108

Raised by review on #13106.

## 👀 Notes for Reviewers

- New tests: `ensure_directory_creates_a_missing_local_path_and_skips_object_stores` and `path_exists_matches_std_path_exists`. Existing `init` / `drop_table` overlap-guard tests cover the converted teardown gates.
- `is_initialized` is the one remaining `Path::exists` in this module's production code; it is sync by trait.

**Verification**

- `cargo check -p accelerator-cayenne` — passed
- `cargo test -p accelerator-cayenne --lib` — `ok. 136 passed; 0 failed`
- `cargo clippy -p accelerator-cayenne --no-deps` and `--tests` with the `make lint-rust` deny set — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93e9cd01-fc52-4b58-9031-fdbcb4dba9dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93e9cd01-fc52-4b58-9031-fdbcb4dba9dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

