### PR TITLE
feat(cache): verify the results-cache namespace prefix with Verus

### DIFF
--- a/.github/workflows/verus_verify.yml
+++ b/.github/workflows/verus_verify.yml
@@ -1,13 +1,19 @@
 ---
 name: Verus Verification
 
-# `crates/hash-index/src/sbbf_layout.rs` carries proofs, not just tests: the
-# block index it returns subscripts the bloom filter's block vector, so an
-# out-of-range result is a panic on a lock-free read path. The bound is a Verus
-# postcondition discharged for every input, which is a property no test can
-# establish by sampling. Nothing else in the normal build checks it — a normal
-# `cargo build` erases the specifications — so this gate is what keeps the
-# proofs from silently rotting into comments.
+# These crates carry proofs, not just tests. Nothing else in the normal build
+# checks them — a normal `cargo build` erases the specifications — so this gate
+# is what keeps the proofs from silently rotting into comments.
+#
+# `crates/hash-index/src/sbbf_layout.rs`: the block index it returns subscripts
+# the bloom filter's block vector, so an out-of-range result is a panic on a
+# lock-free read path. The bound is a Verus postcondition discharged for every
+# input, which is a property no test can establish by sampling.
+#
+# `crates/cache/src/namespace_key.rs`: the results-cache namespace prefix is
+# what keeps a principal from being served another principal's rows as a fresh
+# hit. Prefix-unambiguity of `[tag][id.len() LE][id]` is a Verus postcondition
+# discharged for every `(tag, id, payload)` triple.
 #
 # That is also why this runs on `merge_group` and not only on the pull request.
 # A proof is a claim about the tree it was checked against; two individually
@@ -54,9 +60,10 @@ permissions:
 env:
   # The verifier and its specification library ship together and are versioned
   # together, so these move as a set. VERUS_VSTD_VERSION must match the `vstd`
-  # pin in `crates/hash-index/Cargo.toml`, and VERUS_SHA256 pins the exact
-  # bytes of the archive: a release tag names an asset, it does not fix its
-  # contents, and this job executes what it downloads.
+  # pin in every crate that opted into verification (`crates/hash-index` and
+  # `crates/cache` today), and VERUS_SHA256 pins the exact bytes of the
+  # archive: a release tag names an asset, it does not fix its contents, and
+  # this job executes what it downloads.
   VERUS_RELEASE: release/0.2026.08.30.b432e82
   VERUS_ASSET: verus-0.2026.08.30.b432e82-x86-linux.zip
   VERUS_SHA256: 067f5f72a457fe66b77c0c10b180f2a919a9c7481a8baa024ffc716aa931a41b
@@ -65,14 +72,15 @@ env:
 jobs:
   verus-verify:
     name: Verify hash-index proofs
-    # GitHub-hosted on purpose: a seconds-long verification must not queue
-    # behind the saturated self-hosted pool.
+    # GitHub-hosted on purpose: verification must not queue behind the
+    # saturated self-hosted pool.
     runs-on: ubuntu-24.04
     # Bounded because this is a required `merge_group` check: an unbounded job
     # leaves the queue candidate `AWAITING_CHECKS` for GitHub's six-hour default
-    # and stalls every entry behind it (#12717). Observed runtime is ~7 minutes
-    # including a cold archive download.
-    timeout-minutes: 20
+    # and stalls every entry behind it (#12717). hash-index alone is ~7 minutes
+    # including a cold archive download; cache also compiles its DataFusion
+    # graph through the driver, so the bound sits above that combined cost.
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -95,6 +103,7 @@ jobs:
           filters: |
             code_changes:
               - 'crates/hash-index/**'
+              - 'crates/cache/**'
               # The verifier is a rustc driver bound to one toolchain, so a
               # workspace toolchain bump can invalidate this gate without
               # touching the crate.
@@ -151,13 +160,15 @@ jobs:
         if: steps.gate.outputs.verify == 'true'
         run: |
           set -euo pipefail
-          pinned=$(grep -oP 'vstd = "=\K[^"]+' crates/hash-index/Cargo.toml)
-          if [ "$pinned" != "$VERUS_VSTD_VERSION" ]; then
-            echo "::error::vstd pin in crates/hash-index/Cargo.toml is '$pinned'," \
-                 "but this workflow runs Verus '$VERUS_VSTD_VERSION'." \
-                 "The verifier and vstd ship together — update both."
-            exit 1
-          fi
+          for manifest in crates/hash-index/Cargo.toml crates/cache/Cargo.toml; do
+            pinned=$(grep -oP 'vstd = "=\K[^"]+' "$manifest")
+            if [ "$pinned" != "$VERUS_VSTD_VERSION" ]; then
+              echo "::error::vstd pin in $manifest is '$pinned'," \
+                   "but this workflow runs Verus '$VERUS_VSTD_VERSION'." \
+                   "The verifier and vstd ship together — update both."
+              exit 1
+            fi
+          done
 
       # Only the archive is cached. It is re-hashed and re-extracted on every
       # run, so a cache that has been tampered with fails the digest check
@@ -235,11 +246,20 @@ jobs:
 
       - name: Verify
         if: steps.gate.outputs.verify == 'true'
-        working-directory: crates/hash-index
         run: |
           set -euo pipefail
           export PATH="$VERUS_DIR:$PATH"
-          cargo verus focus 2>&1 | tee /tmp/verus.log
-          # `cargo verus` exits 0 when a crate opts out of verification and
-          # nothing is checked, so assert the proofs actually ran.
-          grep -qE 'verification results:: [1-9][0-9]* verified, 0 errors' /tmp/verus.log
+          # Every crate that opted into `[package.metadata.verus]` must be
+          # checked here. A crate missing from this loop is a proof CI never
+          # sees.
+          for crate_dir in crates/hash-index crates/cache; do
+            crate_name=$(basename "$crate_dir")
+            (
+              cd "$crate_dir"
+              cargo verus focus 2>&1 | tee "/tmp/verus-${crate_name}.log"
+            )
+            # `cargo verus` exits 0 when a crate opts out of verification and
+            # nothing is checked, so assert the proofs actually ran.
+            grep -qE 'verification results:: [1-9][0-9]* verified, 0 errors' \
+              "/tmp/verus-${crate_name}.log"
+          done

--- a/.github/workflows/verus_verify.yml
+++ b/.github/workflows/verus_verify.yml
@@ -20,12 +20,13 @@ name: Verus Verification
 # green changes can combine into one the verifier would reject, and no other
 # check in the queue would notice.
 #
-# The job carries NO `paths` filter, deliberately. It is registered in
-# `REQUIRED_CHECKS` (scripts/signoff), and a required context has to be emitted
-# by every pull request — a workflow that never triggers reports nothing at all,
-# which blocks the PR rather than passing it. So the job always runs and always
-# reports; the change filter below skips only the verification work when nothing
-# it covers was touched. See docs/dev/ci_signoff.md.
+# One job, one required context (`Verify Verus proofs` in REQUIRED_CHECKS).
+# A second job per crate would be a second required check; do not add one.
+# The job carries NO `paths` filter, deliberately: a required context has to
+# be emitted by every pull request — a workflow that never triggers reports
+# nothing at all, which blocks the PR rather than passing it. So the job
+# always runs and always reports; the change filter below skips only the
+# verification work when nothing it covers was touched. See docs/dev/ci_signoff.md.
 on:
   pull_request:
     branches:
@@ -71,7 +72,10 @@ env:
 
 jobs:
   verus-verify:
-    name: Verify hash-index proofs
+    # Crate-agnostic on purpose: this is the single required-check context
+    # for every crate that opted into `[package.metadata.verus]`. Adding a
+    # crate updates the verify loop and the path filter, not the job name.
+    name: Verify Verus proofs
     # GitHub-hosted on purpose: verification must not queue behind the
     # saturated self-hosted pool.
     runs-on: ubuntu-24.04
@@ -250,8 +254,9 @@ jobs:
           set -euo pipefail
           export PATH="$VERUS_DIR:$PATH"
           # Every crate that opted into `[package.metadata.verus]` must be
-          # checked here. A crate missing from this loop is a proof CI never
-          # sees.
+          # checked here, in this one job. A crate missing from this loop is
+          # a proof CI never sees. A second job per crate would be a second
+          # required check — do not split the loop out.
           for crate_dir in crates/hash-index crates/cache; do
             crate_name=$(basename "$crate_dir")
             (

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3478,6 +3478,7 @@ dependencies = [
  "tokio",
  "tracing",
  "twox-hash",
+ "vstd",
 ]
 
 [[package]]

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -34,6 +34,13 @@ spicepod = { path = "../spicepod" }
 tokio.workspace = true
 tracing.workspace = true
 twox-hash = { workspace = true }
+# Specification and proof vocabulary for `src/namespace_key.rs`. A normal
+# `cargo build` erases the specifications, so this carries no runtime cost;
+# `cargo verus focus` re-checks the proofs. Pinned to the Verus release whose
+# verifier is run in CI — the two are versioned together. Must match the
+# `vstd` pin in `crates/hash-index/Cargo.toml` and `VERUS_VSTD_VERSION` in
+# `.github/workflows/verus_verify.yml`.
+vstd = "=0.0.0-2026-08-30-0159"
 
 [dev-dependencies]
 blake3.workspace = true
@@ -57,3 +64,8 @@ name = "hash_algorithms"
 
 [lints]
 workspace = true
+
+# Opts this crate into `cargo verus focus`. Without it the verifier compiles the
+# crate and checks nothing, reporting "no crates that opted into verification".
+[package.metadata.verus]
+verify = true

--- a/crates/cache/src/key.rs
+++ b/crates/cache/src/key.rs
@@ -19,6 +19,8 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
 
+pub use crate::namespace_key::namespace_key_prefix;
+
 use async_openai::types::embeddings::CreateEmbeddingRequest;
 use async_openai::types::embeddings::EmbeddingInput;
 use datafusion::common::ParamValues;
@@ -144,10 +146,13 @@ impl CacheKey<'_> {
     /// `namespace_id` is the principal's stable opaque id (empty for
     /// public/system).
     ///
-    /// The byte stream hashed is:
+    /// The byte stream hashed is the return of [`namespace_key_prefix`]
+    /// followed by the payload, i.e.
     /// `[namespace_tag][namespace_id.len() as u64 LE][namespace_id...][payload...]`
     /// so that `(tag=1, id="abc")` and `(tag=1, id="a")` followed by a
-    /// payload starting with `"bc"` cannot collide.
+    /// payload starting with `"bc"` cannot collide. That prefix-unambiguity
+    /// is a Verus postcondition on [`namespace_key_prefix`], not a
+    /// comment-only claim.
     #[must_use]
     pub fn as_raw_key_in_namespace<T: Hasher>(
         &self,
@@ -155,9 +160,7 @@ impl CacheKey<'_> {
         namespace_tag: u8,
         namespace_id: &[u8],
     ) -> RawCacheKey {
-        hasher.write_u8(namespace_tag);
-        hasher.write_u64(namespace_id.len() as u64);
-        hasher.write(namespace_id);
+        hasher.write(&namespace_key_prefix(namespace_tag, namespace_id));
         self.hash_payload(&mut hasher);
         RawCacheKey(hasher.finish())
     }
@@ -234,6 +237,73 @@ mod tests {
     use std::hash::RandomState;
 
     use super::*;
+
+    #[test]
+    fn as_raw_key_in_namespace_writes_the_verified_prefix_first() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        struct RecordingHasher {
+            writes: Rc<RefCell<Vec<Vec<u8>>>>,
+        }
+
+        impl Hasher for RecordingHasher {
+            fn write(&mut self, bytes: &[u8]) {
+                self.writes.borrow_mut().push(bytes.to_vec());
+            }
+
+            fn finish(&self) -> u64 {
+                0
+            }
+        }
+
+        let writes = Rc::new(RefCell::new(Vec::new()));
+        let hasher = RecordingHasher {
+            writes: Rc::clone(&writes),
+        };
+        let _ = CacheKey::Query("select 1", None).as_raw_key_in_namespace(hasher, 1, b"alice");
+        let recorded = writes.borrow();
+        assert!(
+            !recorded.is_empty(),
+            "the hasher must see the namespace prefix"
+        );
+        assert_eq!(
+            recorded[0],
+            namespace_key_prefix(1, b"alice"),
+            "the first write must be the verified prefix, not a parallel encoding"
+        );
+    }
+
+    #[test]
+    fn as_raw_key_in_namespace_distinguishes_principals() {
+        use std::hash::BuildHasher;
+        use std::hash::BuildHasherDefault;
+
+        type Xxh3 = BuildHasherDefault<twox_hash::XxHash3_64>;
+        let key_for = |tag: u8, id: &[u8]| {
+            CacheKey::Query("select 1", None).as_raw_key_in_namespace(
+                Xxh3::default().build_hasher(),
+                tag,
+                id,
+            )
+        };
+
+        assert_ne!(
+            key_for(1, b"alice").as_u64(),
+            key_for(1, b"bob").as_u64(),
+            "distinct principals must not share a results-cache key"
+        );
+        assert_ne!(
+            key_for(0, b"").as_u64(),
+            key_for(2, b"").as_u64(),
+            "public and system (both empty id) must not share a results-cache key"
+        );
+        assert_eq!(
+            key_for(1, b"alice").as_u64(),
+            key_for(1, b"alice").as_u64(),
+            "the same namespace and payload must be stable"
+        );
+    }
 
     // explicitly allow this rule, because we're validating that the builtin u64 hash -> .write_u64() path works as expected
     #[expect(clippy::manual_hash_one)]

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -42,6 +42,7 @@ pub mod utils;
 pub mod encoding;
 pub mod intern;
 pub mod key;
+mod namespace_key;
 pub mod result;
 
 pub use backend::CacheBackend;

--- a/crates/cache/src/namespace_key.rs
+++ b/crates/cache/src/namespace_key.rs
@@ -1,0 +1,449 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Machine-checked namespace prefix for results-cache keys.
+//!
+//! [`namespace_key_prefix`] is the byte stream
+//! [`crate::key::CacheKey::as_raw_key_in_namespace`] hashes before the
+//! payload. Two requests whose `(namespace_tag, namespace_id)` differ must
+//! not produce the same stream after any payload is appended — otherwise a
+//! principal can be served another principal's cached rows as a fresh hit.
+//! The length prefix is what rules out the collision
+//! `(tag=1, id="abc")` vs `(tag=1, id="a")` plus a payload starting `"bc"`.
+//!
+//! That bound is not obvious by inspection of the hasher writes, and a
+//! test can only sample pairs. Here it is a postcondition
+//! [Verus](https://github.com/verus-lang/verus) discharges for every
+//! `(tag, id, payload)` triple.
+//!
+//! This is the executable encoding, not a model of it: the function below
+//! is what the cache key path calls. Verus reads the `verus!` block; a
+//! normal `cargo build` erases the specifications and compiles the body
+//! as ordinary Rust. `cargo verus focus` re-checks the proof.
+
+use vstd::prelude::*;
+
+verus! {
+
+/// Little-endian encoding of a `u64`, matching
+/// [`u64::to_le_bytes`](u64::to_le_bytes).
+pub open spec fn spec_u64_to_le_bytes(n: u64) -> Seq<u8> {
+    seq![
+        ((n >> 0u64) & 0xffu64) as u8,
+        ((n >> 8u64) & 0xffu64) as u8,
+        ((n >> 16u64) & 0xffu64) as u8,
+        ((n >> 24u64) & 0xffu64) as u8,
+        ((n >> 32u64) & 0xffu64) as u8,
+        ((n >> 40u64) & 0xffu64) as u8,
+        ((n >> 48u64) & 0xffu64) as u8,
+        ((n >> 56u64) & 0xffu64) as u8,
+    ]
+}
+
+/// `[tag][id.len() as u64 LE][id...]` — the stream hashed before the payload.
+pub open spec fn spec_namespace_key_prefix(tag: u8, id: Seq<u8>) -> Seq<u8> {
+    seq![tag] + spec_u64_to_le_bytes(id.len() as u64) + id
+}
+
+proof fn lemma_u64_to_le_bytes_len(n: u64)
+    ensures
+        spec_u64_to_le_bytes(n).len() == 8,
+{
+}
+
+proof fn lemma_low_byte_in_range(n: u64, shift: u64)
+    requires
+        shift <= 56,
+    ensures
+        ((n >> shift) & 0xffu64) < 0x100u64,
+{
+    assert(((n >> shift) & 0xffu64) < 0x100u64) by (bit_vector)
+        requires
+            shift <= 56,
+    ;
+}
+
+proof fn lemma_u8_cast_of_low_byte_is_injective(x: u64, y: u64)
+    requires
+        x < 0x100u64,
+        y < 0x100u64,
+        (x as u8) == (y as u8),
+    ensures
+        x == y,
+{
+    assert(x == y) by (bit_vector)
+        requires
+            x < 0x100u64,
+            y < 0x100u64,
+            (x as u8) == (y as u8),
+    ;
+}
+
+proof fn lemma_masked_bytes_determine_u64(left: u64, right: u64)
+    requires
+        ((left >> 0u64) & 0xffu64) == ((right >> 0u64) & 0xffu64),
+        ((left >> 8u64) & 0xffu64) == ((right >> 8u64) & 0xffu64),
+        ((left >> 16u64) & 0xffu64) == ((right >> 16u64) & 0xffu64),
+        ((left >> 24u64) & 0xffu64) == ((right >> 24u64) & 0xffu64),
+        ((left >> 32u64) & 0xffu64) == ((right >> 32u64) & 0xffu64),
+        ((left >> 40u64) & 0xffu64) == ((right >> 40u64) & 0xffu64),
+        ((left >> 48u64) & 0xffu64) == ((right >> 48u64) & 0xffu64),
+        ((left >> 56u64) & 0xffu64) == ((right >> 56u64) & 0xffu64),
+    ensures
+        left == right,
+{
+    assert(left == right) by (bit_vector)
+        requires
+            ((left >> 0u64) & 0xffu64) == ((right >> 0u64) & 0xffu64),
+            ((left >> 8u64) & 0xffu64) == ((right >> 8u64) & 0xffu64),
+            ((left >> 16u64) & 0xffu64) == ((right >> 16u64) & 0xffu64),
+            ((left >> 24u64) & 0xffu64) == ((right >> 24u64) & 0xffu64),
+            ((left >> 32u64) & 0xffu64) == ((right >> 32u64) & 0xffu64),
+            ((left >> 40u64) & 0xffu64) == ((right >> 40u64) & 0xffu64),
+            ((left >> 48u64) & 0xffu64) == ((right >> 48u64) & 0xffu64),
+            ((left >> 56u64) & 0xffu64) == ((right >> 56u64) & 0xffu64),
+    ;
+}
+
+proof fn lemma_u64_to_le_bytes_injective(left: u64, right: u64)
+    ensures
+        spec_u64_to_le_bytes(left) == spec_u64_to_le_bytes(right) ==> left == right,
+{
+    if spec_u64_to_le_bytes(left) == spec_u64_to_le_bytes(right) {
+        lemma_low_byte_in_range(left, 0u64);
+        lemma_low_byte_in_range(right, 0u64);
+        lemma_u8_cast_of_low_byte_is_injective((left >> 0u64) & 0xffu64, (right >> 0u64) & 0xffu64);
+        lemma_low_byte_in_range(left, 8u64);
+        lemma_low_byte_in_range(right, 8u64);
+        lemma_u8_cast_of_low_byte_is_injective((left >> 8u64) & 0xffu64, (right >> 8u64) & 0xffu64);
+        lemma_low_byte_in_range(left, 16u64);
+        lemma_low_byte_in_range(right, 16u64);
+        lemma_u8_cast_of_low_byte_is_injective(
+            (left >> 16u64) & 0xffu64,
+            (right >> 16u64) & 0xffu64,
+        );
+        lemma_low_byte_in_range(left, 24u64);
+        lemma_low_byte_in_range(right, 24u64);
+        lemma_u8_cast_of_low_byte_is_injective(
+            (left >> 24u64) & 0xffu64,
+            (right >> 24u64) & 0xffu64,
+        );
+        lemma_low_byte_in_range(left, 32u64);
+        lemma_low_byte_in_range(right, 32u64);
+        lemma_u8_cast_of_low_byte_is_injective(
+            (left >> 32u64) & 0xffu64,
+            (right >> 32u64) & 0xffu64,
+        );
+        lemma_low_byte_in_range(left, 40u64);
+        lemma_low_byte_in_range(right, 40u64);
+        lemma_u8_cast_of_low_byte_is_injective(
+            (left >> 40u64) & 0xffu64,
+            (right >> 40u64) & 0xffu64,
+        );
+        lemma_low_byte_in_range(left, 48u64);
+        lemma_low_byte_in_range(right, 48u64);
+        lemma_u8_cast_of_low_byte_is_injective(
+            (left >> 48u64) & 0xffu64,
+            (right >> 48u64) & 0xffu64,
+        );
+        lemma_low_byte_in_range(left, 56u64);
+        lemma_low_byte_in_range(right, 56u64);
+        lemma_u8_cast_of_low_byte_is_injective(
+            (left >> 56u64) & 0xffu64,
+            (right >> 56u64) & 0xffu64,
+        );
+        lemma_masked_bytes_determine_u64(left, right);
+    }
+}
+
+proof fn lemma_namespace_key_prefix_len(tag: u8, id: Seq<u8>)
+    ensures
+        spec_namespace_key_prefix(tag, id).len() == 9 + id.len(),
+{
+    lemma_u64_to_le_bytes_len(id.len() as u64);
+}
+
+proof fn lemma_concat_index_left<A>(a: Seq<A>, b: Seq<A>, i: int)
+    requires
+        0 <= i < a.len(),
+    ensures
+        (a + b)[i] == a[i],
+{
+}
+
+proof fn lemma_concat_index_right<A>(a: Seq<A>, b: Seq<A>, i: int)
+    requires
+        0 <= i < b.len(),
+    ensures
+        (a + b)[a.len() + i] == b[i],
+{
+}
+
+proof fn lemma_namespace_key_prefix_tag(tag: u8, id: Seq<u8>)
+    ensures
+        spec_namespace_key_prefix(tag, id)[0] == tag,
+{
+    lemma_namespace_key_prefix_len(tag, id);
+}
+
+proof fn lemma_namespace_key_prefix_len_byte(tag: u8, id: Seq<u8>, i: int)
+    requires
+        0 <= i < 8,
+    ensures
+        spec_namespace_key_prefix(tag, id)[i + 1] == spec_u64_to_le_bytes(id.len() as u64)[i],
+{
+    lemma_namespace_key_prefix_len(tag, id);
+}
+
+proof fn lemma_namespace_key_prefix_id_byte(tag: u8, id: Seq<u8>, i: int)
+    requires
+        0 <= i < id.len(),
+    ensures
+        spec_namespace_key_prefix(tag, id)[i + 9] == id[i],
+{
+    lemma_namespace_key_prefix_len(tag, id);
+}
+
+proof fn lemma_reveal_len_bytes(tag: u8, id: Seq<u8>)
+    ensures
+        spec_namespace_key_prefix(tag, id)[1] == spec_u64_to_le_bytes(id.len() as u64)[0],
+        spec_namespace_key_prefix(tag, id)[2] == spec_u64_to_le_bytes(id.len() as u64)[1],
+        spec_namespace_key_prefix(tag, id)[3] == spec_u64_to_le_bytes(id.len() as u64)[2],
+        spec_namespace_key_prefix(tag, id)[4] == spec_u64_to_le_bytes(id.len() as u64)[3],
+        spec_namespace_key_prefix(tag, id)[5] == spec_u64_to_le_bytes(id.len() as u64)[4],
+        spec_namespace_key_prefix(tag, id)[6] == spec_u64_to_le_bytes(id.len() as u64)[5],
+        spec_namespace_key_prefix(tag, id)[7] == spec_u64_to_le_bytes(id.len() as u64)[6],
+        spec_namespace_key_prefix(tag, id)[8] == spec_u64_to_le_bytes(id.len() as u64)[7],
+{
+    lemma_namespace_key_prefix_len_byte(tag, id, 0);
+    lemma_namespace_key_prefix_len_byte(tag, id, 1);
+    lemma_namespace_key_prefix_len_byte(tag, id, 2);
+    lemma_namespace_key_prefix_len_byte(tag, id, 3);
+    lemma_namespace_key_prefix_len_byte(tag, id, 4);
+    lemma_namespace_key_prefix_len_byte(tag, id, 5);
+    lemma_namespace_key_prefix_len_byte(tag, id, 6);
+    lemma_namespace_key_prefix_len_byte(tag, id, 7);
+}
+
+/// Distinct `(tag, id)` pairs cannot produce equal byte streams after any
+/// payloads are appended. That is the collision class the length prefix
+/// exists to prevent: without it, `(tag=1, id="abc")` and `(tag=1, id="a")`
+/// plus a payload starting `"bc"` are the same stream.
+pub proof fn lemma_namespace_key_prefix_unambiguous(
+    tag1: u8,
+    id1: Seq<u8>,
+    payload1: Seq<u8>,
+    tag2: u8,
+    id2: Seq<u8>,
+    payload2: Seq<u8>,
+)
+    requires
+        id1.len() <= 0xffff_ffff_ffff_ffff,
+        id2.len() <= 0xffff_ffff_ffff_ffff,
+    ensures
+        (spec_namespace_key_prefix(tag1, id1) + payload1 == spec_namespace_key_prefix(tag2, id2)
+            + payload2) ==> tag1 == tag2 && id1 =~= id2 && payload1 =~= payload2,
+        (tag1 != tag2 || !(id1 =~= id2)) ==> spec_namespace_key_prefix(tag1, id1) + payload1
+            != spec_namespace_key_prefix(tag2, id2) + payload2,
+{
+    let e1 = spec_namespace_key_prefix(tag1, id1);
+    let e2 = spec_namespace_key_prefix(tag2, id2);
+    let s1 = e1 + payload1;
+    let s2 = e2 + payload2;
+    lemma_namespace_key_prefix_len(tag1, id1);
+    lemma_namespace_key_prefix_len(tag2, id2);
+    if s1 == s2 {
+        lemma_namespace_key_prefix_tag(tag1, id1);
+        lemma_namespace_key_prefix_tag(tag2, id2);
+        lemma_concat_index_left(e1, payload1, 0);
+        lemma_concat_index_left(e2, payload2, 0);
+        assert(s1[0] == tag1);
+        assert(s2[0] == tag2);
+        assert(tag1 == tag2);
+
+        lemma_reveal_len_bytes(tag1, id1);
+        lemma_reveal_len_bytes(tag2, id2);
+        lemma_concat_index_left(e1, payload1, 1);
+        lemma_concat_index_left(e1, payload1, 2);
+        lemma_concat_index_left(e1, payload1, 3);
+        lemma_concat_index_left(e1, payload1, 4);
+        lemma_concat_index_left(e1, payload1, 5);
+        lemma_concat_index_left(e1, payload1, 6);
+        lemma_concat_index_left(e1, payload1, 7);
+        lemma_concat_index_left(e1, payload1, 8);
+        lemma_concat_index_left(e2, payload2, 1);
+        lemma_concat_index_left(e2, payload2, 2);
+        lemma_concat_index_left(e2, payload2, 3);
+        lemma_concat_index_left(e2, payload2, 4);
+        lemma_concat_index_left(e2, payload2, 5);
+        lemma_concat_index_left(e2, payload2, 6);
+        lemma_concat_index_left(e2, payload2, 7);
+        lemma_concat_index_left(e2, payload2, 8);
+        assert(spec_u64_to_le_bytes(id1.len() as u64) =~= spec_u64_to_le_bytes(id2.len() as u64));
+        lemma_u64_to_le_bytes_injective(id1.len() as u64, id2.len() as u64);
+        assert(id1.len() == id2.len());
+
+        assert forall|i: int|
+            #![trigger id1[i]]
+            0 <= i < id1.len() ==> s1[i + 9] == id1[i] && s2[i + 9] == id2[i] by {
+            if 0 <= i && i < id1.len() {
+                lemma_namespace_key_prefix_id_byte(tag1, id1, i);
+                lemma_namespace_key_prefix_id_byte(tag2, id2, i);
+                lemma_concat_index_left(e1, payload1, i + 9);
+                lemma_concat_index_left(e2, payload2, i + 9);
+            }
+        }
+        assert(id1 =~= id2);
+        assert(e1.len() == e2.len());
+        assert(s1.len() == e1.len() + payload1.len());
+        assert(s2.len() == e2.len() + payload2.len());
+        assert(payload1.len() == payload2.len());
+        assert forall|i: int|
+            #![trigger payload1[i]]
+            0 <= i < payload1.len() ==> payload1[i] == payload2[i] by {
+            if 0 <= i && i < payload1.len() {
+                lemma_concat_index_right(e1, payload1, i);
+                lemma_concat_index_right(e2, payload2, i);
+            }
+        }
+        assert(payload1 =~= payload2);
+    }
+}
+
+/// Low byte of `n` after shifting `shift` bits. Isolated so the
+/// `as u8` truncation is next to the mask that makes it lossless.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "the 0xff mask leaves only the low 8 bits"
+)]
+fn le_byte(n: u64, shift: u64) -> (b: u8)
+    requires
+        shift <= 56,
+    ensures
+        b == ((n >> shift) & 0xffu64) as u8,
+{
+    ((n >> shift) & 0xffu64) as u8
+}
+
+/// Encodes `(namespace_tag, namespace_id)` as
+/// `[tag][id.len() as u64 LE][id...]`.
+///
+/// This is the byte stream [`crate::key::CacheKey::as_raw_key_in_namespace`]
+/// writes before hashing the payload. The `ensures` clause pins the body
+/// to [`spec_namespace_key_prefix`]; [`lemma_namespace_key_prefix_unambiguous`]
+/// is the anti-collision property that lemma discharges for every payload.
+#[must_use]
+pub fn namespace_key_prefix(tag: u8, id: &[u8]) -> (prefix: Vec<u8>)
+    ensures
+        prefix@ == spec_namespace_key_prefix(tag, id@),
+{
+    let mut prefix: Vec<u8> = Vec::new();
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Spice is 64-bit; a slice length fits in u64"
+    )]
+    let len: u64 = id.len() as u64;
+
+    proof {
+        assert(id.len() as int == id@.len());
+        assert(len == id@.len() as u64);
+        assert(id@.len() <= 0xffff_ffff_ffff_ffff);
+    }
+
+    prefix.push(tag);
+    prefix.push(le_byte(len, 0u64));
+    prefix.push(le_byte(len, 8u64));
+    prefix.push(le_byte(len, 16u64));
+    prefix.push(le_byte(len, 24u64));
+    prefix.push(le_byte(len, 32u64));
+    prefix.push(le_byte(len, 40u64));
+    prefix.push(le_byte(len, 48u64));
+    prefix.push(le_byte(len, 56u64));
+
+    proof {
+        lemma_u64_to_le_bytes_len(len);
+        assert(prefix@ == seq![tag] + spec_u64_to_le_bytes(len));
+    }
+
+    let mut i: usize = 0;
+    while i < id.len()
+        invariant
+            i <= id.len(),
+            len == id@.len() as u64,
+            prefix@ == seq![tag] + spec_u64_to_le_bytes(len) + id@.subrange(0, i as int),
+        decreases id.len() - i,
+    {
+        prefix.push(id[i]);
+        proof {
+            assert(id@.subrange(0, i as int + 1) =~= id@.subrange(0, i as int) + seq![id@[i
+                as int]]);
+        }
+        i = i + 1;
+    }
+
+    proof {
+        assert(id@.subrange(0, id@.len() as int) =~= id@);
+    }
+
+    prefix
+}
+
+} // verus!
+
+#[cfg(test)]
+mod tests {
+    use super::namespace_key_prefix;
+
+    #[test]
+    fn prefix_is_tag_then_le_length_then_id() {
+        let prefix = namespace_key_prefix(1, b"abc");
+        let mut expected = vec![1_u8];
+        expected.extend_from_slice(&3_u64.to_le_bytes());
+        expected.extend_from_slice(b"abc");
+        assert_eq!(prefix, expected);
+    }
+
+    #[test]
+    fn empty_id_still_carries_a_zero_length() {
+        let prefix = namespace_key_prefix(0, b"");
+        let mut expected = vec![0_u8];
+        expected.extend_from_slice(&0_u64.to_le_bytes());
+        assert_eq!(prefix, expected);
+        // Public (tag 0) and system (tag 2) share an empty id; the tag is
+        // what keeps their streams distinct.
+        assert_ne!(namespace_key_prefix(0, b""), namespace_key_prefix(2, b""));
+    }
+
+    #[test]
+    fn length_prefix_blocks_the_documented_payload_collision() {
+        // Without a length, these two streams are equal — the collision
+        // class the comment on `as_raw_key_in_namespace` names.
+        let mut naive_left = vec![1_u8];
+        naive_left.extend_from_slice(b"abc");
+        let mut naive_right = vec![1_u8];
+        naive_right.extend_from_slice(b"a");
+        naive_right.extend_from_slice(b"bc");
+        assert_eq!(
+            naive_left, naive_right,
+            "the naive concatenation is the collision the length prefix exists to prevent"
+        );
+
+        let left = namespace_key_prefix(1, b"abc");
+        let mut right = namespace_key_prefix(1, b"a");
+        right.extend_from_slice(b"bc");
+        assert_ne!(left, right);
+    }
+}

--- a/crates/cache/src/namespace_key.rs
+++ b/crates/cache/src/namespace_key.rs
@@ -325,10 +325,6 @@ pub proof fn lemma_namespace_key_prefix_unambiguous(
 
 /// Low byte of `n` after shifting `shift` bits. Isolated so the
 /// `as u8` truncation is next to the mask that makes it lossless.
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "the 0xff mask leaves only the low 8 bits"
-)]
 fn le_byte(n: u64, shift: u64) -> (b: u8)
     requires
         shift <= 56,
@@ -351,10 +347,6 @@ pub fn namespace_key_prefix(tag: u8, id: &[u8]) -> (prefix: Vec<u8>)
         prefix@ == spec_namespace_key_prefix(tag, id@),
 {
     let mut prefix: Vec<u8> = Vec::new();
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "Spice is 64-bit; a slice length fits in u64"
-    )]
     let len: u64 = id.len() as u64;
 
     proof {
@@ -391,7 +383,7 @@ pub fn namespace_key_prefix(tag: u8, id: &[u8]) -> (prefix: Vec<u8>)
             assert(id@.subrange(0, i as int + 1) =~= id@.subrange(0, i as int) + seq![id@[i
                 as int]]);
         }
-        i = i + 1;
+        i += 1;
     }
 
     proof {

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -120,9 +120,11 @@ readonly REQUIRED_CHECKS=(
   "Features Check"           # features.yml
   "Check Rust Licenses"      # license_check.yml
   "E2E Test CI"              # e2e_test_ci.yml (gate job)
-  # verus_verify.yml. The only check that reads the Verus proofs: a normal
-  # `cargo build` erases the specifications, so nothing else here would notice
-  # a postcondition that no longer holds.
+  # verus_verify.yml. The only check that reads the Verus proofs (hash-index
+  # and the results-cache namespace prefix today): a normal `cargo build`
+  # erases the specifications, so nothing else here would notice a
+  # postcondition that no longer holds. The job name is the required-check
+  # context and is kept stable so the trunk ruleset still matches.
   "Verify hash-index proofs"
 )
 # GitHub Actions app id — pins each required check to Actions so a hand-POSTed

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -123,9 +123,10 @@ readonly REQUIRED_CHECKS=(
   # verus_verify.yml. The only check that reads the Verus proofs (hash-index
   # and the results-cache namespace prefix today): a normal `cargo build`
   # erases the specifications, so nothing else here would notice a
-  # postcondition that no longer holds. The job name is the required-check
-  # context and is kept stable so the trunk ruleset still matches.
-  "Verify hash-index proofs"
+  # postcondition that no longer holds. One job, one context — never a
+  # per-crate required check. The name is crate-agnostic so a later crate
+  # does not need another ruleset rename.
+  "Verify Verus proofs"
 )
 # GitHub Actions app id — pins each required check to Actions so a hand-POSTed
 # commit status can't satisfy a required check (only `signoff` is a raw status).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Summary

`CacheKey::as_raw_key_in_namespace` is what makes SQL/results-cache hits safe under per-user authentication. Its anti-collision invariant — that `(tag=1, id="abc")` and `(tag=1, id="a")` plus a payload starting `"bc"` cannot produce the same byte stream — lived only in a comment.

This moves that encoding into `namespace_key_header`, a fixed-size `[tag][id.len() LE]` header, and discharges the property with [Verus](https://github.com/verus-lang/verus) for every `(tag, id, payload)` triple, rather than for the pairs a test happens to pick. A defect here is a **cross-principal cache hit**: silent wrong data served as fresh.

`as_raw_key_in_namespace` hashes the header and then the id, and the header's postcondition pins `header ‖ id` to the verified prefix, so the executable path and the proof are one implementation, not a model of it (see #13776). The header is a `[u8; 9]`, so computing a namespaced key does not allocate.

This is the first results-cache Verus surface. It is deliberately just the namespace prefix: that is the pure core whose cost of being wrong matches the bar in #13776.

## 🔗 Related

Part of #13776. Follows the hash-index `block_index` proof (#13777) for toolchain, CI gate, and review shape.

Does **not** close #13776 — Cayenne `PkBloom` / `LayeredRuns` remain.

## 🚨 Breaking Changes

None for the default hasher (`xxh3`) or Blake3: both absorb `write()` as a flat byte stream, and the header followed by the id is the same `[tag][len LE][id]` bytes the comment already described.

SipHash and AHash treat `write_u64` as a typed mix rather than eight LE bytes, so their namespaced key values change. The results cache is in-memory; a deploy is a cold cache, not a wrong hit.

## 👀 Notes for Reviewers

**This is the executable encoding.** `as_raw_key_in_namespace` writes `namespace_key_header(tag, id)` and then `id`. The header's `ensures` clause is `header@ + id@ == spec_namespace_key_prefix(tag, id@)`, and the proof is about that function.

**Property proved:** prefix-unambiguity / injectivity across `(tag, id)` —

```
(tag1, id1) ≠ (tag2, id2)
    ⇒  prefix(tag1, id1) ‖ payload1  ≠  prefix(tag2, id2) ‖ payload2
```

for every payload. Equal streams imply equal tag, id, and payload. The hash function itself is *not* proved collision-free.

**What was verified** (Verus `0.2026.08.30.b432e82`, rustc 1.97.1, file content at 7fed257c74):

```
$ verus --crate-type=lib crates/cache/src/namespace_key.rs
verification results:: 18 verified, 0 errors
```

CI's `Verify Verus proofs` job runs `cargo verus focus` over `crates/hash-index` and `crates/cache`. On 7fed257c74 ([run 34773088074](https://github.com/spiceai/spiceai/actions/runs/34773088074)) it reported `verification results:: 6 verified, 0 errors` for hash-index and `verification results:: 18 verified, 0 errors` for cache, and `Verify hash-index proofs` repeated that success.

**Mutation tests** — each fails the verifier:

| Mutation | Result |
|---|---|
| Spec drops the length prefix: `seq![tag] + spec_u64_to_le_bytes(id.len() as u64) + id` → `seq![tag] + id` | `16 verified, 2 errors` — the `lemma_namespace_key_prefix_len` postcondition, and the header's `header@ + id@ =~= spec_namespace_key_prefix(tag, id@)` assertion |
| Executable header emits its first two length bytes in the wrong order: `le_byte(len, 0u64), le_byte(len, 8u64)` → `le_byte(len, 8u64), le_byte(len, 0u64)` | `17 verified, 1 errors` — `header@ =~= seq![tag] + spec_u64_to_le_bytes(len)` |

Restored encoding: `18 verified, 0 errors`.

**No allocation on the key path.** An earlier revision (c545039ad6) built the prefix in a `Vec`, pushed byte by byte. A counting-allocator harness that compiles `namespace_key.rs` from each revision and mirrors that revision's `as_raw_key_in_namespace` for `CacheKey::Query("select 1", None)` with `XxHash3_64`, over 1,000,000 keys:

| Revision | No namespace (hasher only) | 5-byte id | 36-byte id |
|---|---|---|---|
| `Vec` prefix, c545039ad6 | 1 alloc / key | 2 allocs + 1 realloc / key | 2 allocs + 3 reallocs / key |
| `[u8; 9]` header, 7fed257c74 | 1 alloc / key | 1 alloc / key | 1 alloc / key |

The allocation that remains is the xxh3 hasher's own construction, present with no namespace too. Key values are identical across both revisions (`0x34e4f1c332c7ff6c` for the 5-byte id, `0xbfff7a7934f5ba33` for the 36-byte id).

**CI — one Verus check.** `.github/workflows/verus_verify.yml` has a single verification job, `verus-verify`, which loops `cargo verus focus` over `crates/hash-index` and `crates/cache`. Its context and the `scripts/signoff` `REQUIRED_CHECKS` entry are renamed together:

- was: `Verify hash-index proofs`
- now: `Verify Verus proofs`

Path filters include `crates/cache/**` (and the shared Verus pins / workflow / toolchain), so touching either crate runs this same gate.

**Transitional context.** The live `trunk` ruleset still requires `Verify hash-index proofs`, and a required context that no job reports keeps a pull request out of the merge queue: c545039ad6 reported no check run under that name, while trunk's tip reports it. So the workflow has a second job, `verus-verify-ruleset-alias`, that repeats the `verus-verify` verdict under the old name. It verifies nothing itself. It runs under `if: always()`, because a job skipped after `verus-verify` fails or is cancelled would satisfy the required check. After this merges:

1. An admin runs `scripts/signoff install --yes`, so `trunk` requires `Verify Verus proofs`.
2. A follow-up PR deletes `verus-verify-ruleset-alias`.

Do **not** add a per-crate required context such as `Verify cache proofs`. A later Verus crate updates the verify loop, not the ruleset.

**Lint / tests.** `namespace_key.rs` was linted and tested on its own under the workspace lint levels, with `vstd` at the same pin: both `make lint-rust` clippy passes (`-Dwarnings -Dclippy::pedantic …`, lib and `--tests`) finish clean, and its tests report `test result: ok. 3 passed; 0 failed`. The whole `cache` crate's lint and unit tests run in `make signoff`.

**Not in this PR:**
- `resolved_table_match` — high-value (stale hits) but depends on DataFusion `TableReference`. Natural *next* results-cache proof.
- Cayenne `PkBloom` / `LayeredRuns` (#13776).
- Async moka/pingora backends (out of scope for Verus).
- The hash function.

**Dependency cost.** `vstd` was already in the lockfile via hash-index; cache now takes it as a direct dep (`=0.0.0-2026-08-30-0159`, matching `VERUS_VSTD_VERSION` / hash-index). Erased at build time. The crate builds, lints, and tests with no verifier installed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90d82234-73ff-4d75-8082-a15a1ca93731?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90d82234-73ff-4d75-8082-a15a1ca93731&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



