### PR TITLE
fix(caching): project SchemaCastScanExec statistics onto its output schema

### DIFF
--- a/v2.2.0.md
+++ b/v2.2.0.md
@@ -1,0 +1,309 @@
+# v2.2.0 Endgame — @Jeadie Checklist
+
+Tracking issue: [spiceai/spiceai#13214](https://github.com/spiceai/spiceai/issues/13214)
+spiced SUT: `~/.spice/bin/spiced_v_2_2_0_test`.
+CI running for docker image: https://github.com/spiceai/spiceai/actions/runs/32216977592
+
+## Cookbook Recipes
+
+### Data Connectors
+- [x] [Databricks](https://github.com/spiceai/cookbook/blob/trunk/databricks/README.md) — sql_warehouse ✅, delta_lake ✅, spark_connect ✅
+- [ ] [SharePoint](https://github.com/spiceai/cookbook/blob/trunk/sharepoint/README.md)
+- [ ] [ODBC](https://github.com/spiceai/cookbook/blob/trunk/odbc/README.md)
+- [x] [Oracle](https://github.com/spiceai/cookbook/blob/trunk/oracle/README.md)
+
+### Data Accelerators
+- [x] [SQLite Accelerator](https://github.com/spiceai/cookbook/blob/trunk/sqlite/accelerator/README.md)
+- [x] [Arrow Accelerator](https://github.com/spiceai/cookbook/blob/trunk/arrow/README.md)
+
+### Catalog Connectors
+- [x] [MySQL Catalog](https://github.com/spiceai/cookbook/blob/trunk/catalogs/mysql/README.md)
+
+### AI/ML Models
+- [x] [Searching GitHub files with Spice](https://github.com/spiceai/cookbook/tree/trunk/search_github_files)
+- [x] [Nvidia NIM](https://github.com/spiceai/cookbook/tree/trunk/nvidia-nim)
+- [x] [Hybrid Search & Real Time Indexing](https://github.com/spiceai/cookbook/blob/trunk/search/README.md)
+- [x] [xAI Model](https://github.com/spiceai/cookbook/blob/trunk/models/xai/README.md)
+
+### Other Recipes
+- [x] [Indexes on Accelerated Data](https://github.com/spiceai/cookbook/blob/trunk/acceleration/indexes/README.md)
+- [x] [SQL Results Caching](https://github.com/spiceai/cookbook/blob/trunk/caching/sql_results/README.md)
+- [x] [CQRS](https://github.com/spiceai/cookbook/blob/trunk/cqrs/README.md)
+- [x] [Dual Dataset Registration](https://github.com/spiceai/cookbook/blob/trunk/acceleration/dual-dataset-registration/README.md)
+
+Each recipe: run the recipe's `spicepod.yaml` as-is against current `trunk`/release branch, confirm the README steps and sample queries still work verbatim, and fix or flag drift.
+
+---
+
+## Focus Area 3: CPU Entitlements + Vortex (with @phillipleblanc)
+
+Refs: [#12328](https://github.com/spiceai/spiceai/issues/12328), [#12489](https://github.com/spiceai/spiceai/issues/12489), [#13173](https://github.com/spiceai/spiceai/pull/13173)
+
+### Docker test image and commands
+
+Use the native ARM64 image built by the Docker linker fix PR for all local Docker checks in this focus area:
+
+```shell
+export SPICED_IMAGE=ghcr.io/spiceai/spiceai-dev:docker-arm64-linker-13266
+```
+
+From a directory containing the focus Spicepod as `spicepod.yaml`, run the following exact commands. Keep the process attached so its startup log can be inspected.
+
+```shell
+# A: no CPU limit or request-derived environment variable.
+docker run --rm --name spice-cpu-affinity --platform linux/arm64 \
+  -p 8090:8090 -p 50051:50051 \
+  -v "$PWD/spicepod.yaml:/app/spicepod.yaml:ro" \
+  "$SPICED_IMAGE" /app/spicepod.yaml \
+  --http 0.0.0.0:8090 --flight 0.0.0.0:50051
+
+# A: CPU shares only; deliberately omit --cpus.
+docker run --rm --name spice-cpu-shares --platform linux/arm64 \
+  --cpu-shares 1024 -p 8090:8090 -p 50051:50051 \
+  -v "$PWD/spicepod.yaml:/app/spicepod.yaml:ro" \
+  "$SPICED_IMAGE" /app/spicepod.yaml \
+  --http 0.0.0.0:8090 --flight 0.0.0.0:50051
+
+# A: a hard four-core cgroup quota.
+docker run --rm --name spice-cpu-quota --platform linux/arm64 \
+  --cpus=4 -p 8090:8090 -p 50051:50051 \
+  -v "$PWD/spicepod.yaml:/app/spicepod.yaml:ro" \
+  "$SPICED_IMAGE" /app/spicepod.yaml \
+  --http 0.0.0.0:8090 --flight 0.0.0.0:50051
+```
+
+### Spicepod A — bare metal / Docker, no CPU limits set
+
+```yaml
+runtime:
+  cpu: {} # cores unset (auto)
+```
+
+- [ ] Start `spiced` with **no** `SPICE_CPU_REQUEST_MILLICORES` and no cgroup quota. Confirm startup log reports rung `affinity` and entitlement equals the host's full core count (`nproc`).
+- [ ] Confirm `main_runtime_worker_threads` and `target_partitions` in the "CPU budget derived sizing" log line equal the host core count — the no-request path must not be slowed by this change.
+- [ ] `docker run --cpu-shares 1024 ...` (share only, no quota): confirm rung still resolves to `affinity`, **not** an inferred core count from the share (this was the bug — cgroup share must never be a sizing input).
+- [ ] `docker run --cpus=4 ...` (a hard quota): confirm rung resolves to `cgroup_quota` = 4, capped by affinity.
+
+### Spicepod B — Kubernetes, burstable pod (request set, no limit), chart-wired
+
+```yaml
+runtime:
+  cpu:
+    cores: auto
+```
+Deploy via `deploy/chart` with `resources.requests.cpu: 4` and no `resources.limits.cpu`.
+
+- [ ] Confirm `SPICE_CPU_REQUEST_MILLICORES=4000` is present in the container env (downward API, `divisor: 1m`).
+- [ ] Confirm startup log rung is `request_burst`, entitlement = `min(max(2, 4*2), affinity)` = 8 (on a node with ≥8 cores).
+- [ ] Confirm `target_partitions` / worker thread counts derive from 8, not the node's total core count.
+- [ ] Query via `spice sql` and inspect the query plan (`EXPLAIN`) partition count matches the derived entitlement.
+- [ ] Redeploy with `resources.requests.cpu: 100m` (sub-1-core): confirm the 2-core floor holds — entitlement is exactly 2, not 1 or 0, and no derived quantity is zero.
+- [ ] Redeploy with **both** `requests.cpu: 4` and `limits.cpu: 6`: confirm rung is `cgroup_quota` = 6 (quota beats the request-derived rung).
+
+### Spicepod C — Kubernetes, `cores: all` (pack-dense / efficiency mode)
+
+```yaml
+runtime:
+  cpu:
+    cores: all
+```
+Deploy with small `requests.cpu` (e.g. `250m`), no `limits.cpu`.
+
+- [ ] Confirm rung reports `all_cores` and entitlement equals the node's full affinity, not derived from the request.
+- [ ] Redeploy the same pod with `limits.cpu: 8` added: confirm `all` still respects the hard quota (entitlement = 8, not full node) — `all` opts out of the request rung only, not the quota rung.
+- [ ] Confirm `Handle::metrics().num_workers()` on the dedicated tokio runtimes reflects the full-width worker count when unconstrained by a quota.
+
+### Spicepod D — Kubernetes, hand-rolled manifest (no chart, no operator wiring)
+
+- [ ] Deploy a pod with `requests.cpu` set via raw YAML but **without** the `SPICE_CPU_REQUEST_MILLICORES` env passthrough. Confirm a WARN fires naming `SPICE_CPU_REQUEST_MILLICORES`, the missing `resourceFieldRef` block, and that the rung fell back to `affinity` (sizing for the whole node — the exact gap being surfaced).
+- [ ] Confirm the same WARN is silent outside Kubernetes (no `KUBERNETES_SERVICE_HOST`) and silent once the env var is correctly wired.
+
+### Spicepod E — explicit override
+
+```yaml
+runtime:
+  cpu:
+    cores: 6
+```
+
+- [ ] Confirm rung `configured`, entitlement exactly 6 regardless of request/quota/affinity, on any of the above deployment shapes.
+- [ ] Confirm CLI flag `--cpu-cores` and env `SPICE_CPU_CORES` take precedence over `runtime.cpu.cores` in the spicepod.
+
+### Vortex propagation (all spicepods above)
+
+- [ ] On Spicepod B (constrained pod), run a scan-heavy query over a large Parquet/Vortex-encoded dataset and confirm Vortex scan worker count matches the derived entitlement (not the host's `available_parallelism()`), e.g. via thread count sampling or Vortex debug logging during the scan.
+- [ ] Trigger a Cayenne encode/compaction pass on the same constrained pod; confirm zone-writer concurrency also matches the entitlement.
+- [ ] Confirm no "late declaration" error is logged under normal startup (Vortex parallelism is declared once, right after `CpuBudget::install()`, before any read).
+
+### Perf regression gate
+
+- [ ] Run TPC-H SF1/SF100 and ClickBench on the unconstrained default path (Spicepod A shape) before/after; confirm no throughput regression.
+- [ ] Run CH-benCHmark HTAP SF1000 before/after on the same unconstrained path; confirm no regression in QPH/freshness.
+- [ ] On Spicepod B, compare p99 latency and `container_cpu_cfs_throttled_seconds_total` against an equivalent `limits.cpu`-only deployment — the burst-derived config should show materially less throttling for comparable throughput.
+
+---
+
+## Focus Area 6: Cayenne Serializable Transactions (with @peasee, @bjchambers)
+
+Refs: [#11830](https://github.com/spiceai/spiceai/issues/11830), [#11870](https://github.com/spiceai/spiceai/pull/11870), [#12051](https://github.com/spiceai/spiceai/pull/12051)
+
+**Status:** Core transaction semantics (gates, OCC, atomicity) are working and testable. Durable federated write-back is **deliberately disabled** per [PR #12051](https://github.com/spiceai/spiceai/pull/12051) (data-loss bug fix); no connector implements `supports_durable_write_back_delivery()` yet. Spicepods F, H, I, J (write-back scenarios) are **blocked and deferred** until connector-level delivery primitives land.
+
+### Test-harness setup
+
+Use a local Cayenne-accelerated file-backed table. For reference tests, optionally use Postgres as a source.
+
+```shell
+export SPICED_IMAGE=ghcr.io/spiceai/spiceai-dev:docker-arm64-linker-13266
+docker network create focus6-net
+docker volume create focus6-spice-data
+
+# Optional: Postgres source for reference tests
+docker volume create focus6-postgres-data
+docker run -d --name focus6-postgres --network focus6-net \
+  -e POSTGRES_USER=spice -e POSTGRES_PASSWORD=spice -e POSTGRES_DB=spice \
+  -v focus6-postgres-data:/var/lib/postgresql/data \
+  postgres:16
+
+# Run from the directory containing the Focus Area 6 Spicepod.
+docker run --rm --name focus6-spiced --network focus6-net --platform linux/arm64 \
+  -p 8090:8090 -p 50051:50051 \
+  -v "$PWD/spicepod.yaml:/app/spicepod.yaml:ro" \
+  -v focus6-spice-data:/app/.spice \
+  "$SPICED_IMAGE" /app/spicepod.yaml \
+  --http 0.0.0.0:8090 --flight 0.0.0.0:50051
+```
+
+### Spicepod F — Cayenne-accelerated table, transaction gates and OCC (file-backed, no write-back)
+
+```yaml
+datasets:
+  - from: file:///app/accounts.csv  # or postgres:accounts (reference only, not for write-back)
+    name: accounts
+    access: read_write
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      on_conflict:
+        id: upsert
+```
+
+**Note:** `on_conflict` configures per-key OCC; it does NOT enable write-back (which requires `refresh_mode: changes` + connector support, currently unavailable).
+
+#### F1: Basic gated transfer over `/v1/sql`
+
+- [x] Submit the canonical gated-transfer body:
+  ```sql
+  BEGIN;
+  SELECT assert((SELECT balance FROM accounts WHERE id = $1) >= $2);
+  UPDATE accounts SET balance = balance - $2 WHERE id = $1;
+  UPDATE accounts SET balance = balance + $2 WHERE id = $3;
+  COMMIT;
+  ```
+  **Result:** ❌ **Unsupported operation: more than one write to a table in one transaction**. Transactions can write to multiple *tables*, but not multiple rows of the same table in one transaction. This is a v2.2.0 limitation: single-table multi-row writes in transactions are rejected.
+
+- [x] Repeat with `$2` set larger than the sender's balance — confirm `assert()` aborts the transaction.
+  **Result:** ✅ Assertion fails with error "gate expression was false or NULL"; neither UPDATE executed; balance unchanged.
+
+- [ ] Repeat the same body over **FlightSQL** instead of `/v1/sql` — confirm identical commit/abort behavior.
+
+- [ ] Replace the gate with a comparison-style predicate (`< cap`); confirm it gates correctly.
+  **Known limitation (#11832):** NULL-producing predicates (`IS NULL`/`COALESCE`) are mis-optimized; comparison gates (`<`, `>=`, etc.) are NULL-safe.
+
+#### F2: Gate error classes and diagnostics
+
+- [x] Confirm `assert()` failure returns a distinct error class from OCC conflicts.
+  **Result:** ✅ Assert failure: `Execution error: assertion failed: gate expression was false or NULL`. OCC conflict: `transaction write conflict on 'accounts': a participant table changed since the transaction started`. Distinct error classes confirmed.
+- [x] Confirm the error message names the gate expression and gives actionable context.
+  **Result:** ✅ Assert error clearly identifies gate failure; OCC error identifies the table and the cause.
+
+### Spicepod G — same-key and disjoint-key concurrency (per-key OCC)
+
+Same spicepod as F.
+
+#### G1: Same-key concurrency (10-way)
+
+- [x] Fire 10 concurrent gated-decrement transactions against the **same** `id`.
+  **Result:** ✅ Per-key OCC working correctly: 1 transaction succeeded; 9 received clear OCC conflict errors (`transaction write conflict on 'accounts': a participant table changed since the transaction started`). Final balance reflects only 1 execution (no lost updates, no duplicates).
+
+- [ ] Repeat with a larger starting balance (e.g., 2000) so multiple can succeed. Confirm all that succeed respect the gate and the gate-failure transactions abort cleanly.
+
+- [ ] Fire 100 same-key concurrent transactions; confirm exactly one wins and rest fail with conflict errors (no silent drops, no duplicates).
+
+#### G2: Disjoint-key concurrency
+
+- [ ] Fire 10 concurrent transactions against **different** `id`s (same balance/decrement). Confirm all commit with no conflicts and no false contention across keys.
+
+- [ ] Fire mixed workload: 5 transactions on key A, 5 on key B, 5 on key C. Confirm transactions on different keys are truly independent (no waits between them).
+
+### Spicepod H — multi-table atomicity
+
+```yaml
+datasets:
+  - from: file:///app/accounts.csv
+    name: accounts
+    access: read_write
+    acceleration: { enabled: true, engine: cayenne, mode: file, on_conflict: { id: upsert } }
+  - from: file:///app/allocations.csv
+    name: allocations
+    access: read_write
+    acceleration: { enabled: true, engine: cayenne, mode: file, on_conflict: { allocation_id: upsert } }
+```
+
+- [x] Run a transaction body that writes to both tables:
+  ```sql
+  BEGIN;
+  UPDATE accounts SET balance = 500 WHERE id = 1;
+  UPDATE allocations SET amount = 500 WHERE allocation_id = 1;
+  COMMIT;
+  ```
+  **Result:** ✅ **Multi-table writes ARE atomic and working.** Both UPDATE statements execute in one transaction; the metastore commits both or neither. However, **Cayenne's upsert consolidation has a bug:** with `on_conflict: id: upsert`, duplicate primary keys are appended as new rows instead of updating existing ones (creates duplicate rows with different values, not consolidated). This is a Cayenne acceleration issue, not a transaction issue.
+
+- [ ] Confirm durability: Kill `spiced` between the two table writes. Restart and confirm neither partial write is visible — both tables committed or neither.
+
+- [ ] Construct a write-skew scenario: two concurrent transactions each read table A to validate a write to table B. If the combination violates an invariant, one must be rejected.
+
+### Spicepod I — crash/durability windows (deferred: write-back unavailable)
+
+Durability windows (pre-commit, post-commit-pre-delivery, post-delivery) require write-back delivery to be testable. Deferred until connector support lands.
+
+### Spicepod J — write-back convergence + CDC echo (deferred: write-back unavailable)
+
+Write-back delivery and CDC echo semantics require connector support. Deferred until write-back delivery primitives are implemented.
+
+### Known Limitations (v2.2.0)
+
+These limitations are confirmed during testing and should be documented:
+
+1. **Single-write-per-table (v1 design)** — Transactions allow exactly one write operation per table. Multiple writes to the *same* table in one transaction are rejected: "Unsupported operation: more than one write to a table in one transaction." However, writing to different tables in the same transaction is fully supported and atomic. This is intentional v1 scope. Workaround for same-table multi-writes: split into separate transactions, or use a single `UPDATE ... WHERE` covering all target rows.
+
+2. **NULL-predicate optimization gap (#11832)** — `IS NULL` / `IS NOT NULL` / `COALESCE` gates are mis-optimized. Comparison gates (`<`, `>=`, etc.) are NULL-safe and work correctly.
+
+3. **Write-back disabled** — No connector implements `supports_durable_write_back_delivery()` (PR #12051). Async delivery of committed accelerator writes to the federated source is not available.
+
+
+### Spicepod K — known-limitation boundaries and rejection cases (partially testable)
+
+#### K1: OCC rejection on concurrent writes to same key
+
+- [x] Attempt two concurrent writes to the same key; confirm one succeeds and the other fails with a clear OCC conflict error (no silent drop or corruption).
+  **Result:** ✅ Confirmed above in Spicepod G1.
+
+#### K2: Unsupported operation rejection (no flaky/silent failures)
+
+- [ ] Attempt a gated `DELETE` inside a transaction body — confirm it is rejected with a clear error, not executed silently.
+
+- [ ] Attempt a gated `MERGE` inside a transaction body — confirm it is rejected, not partially applied.
+
+- [ ] Attempt against a table with a composite/multi-column primary key — confirm `on_conflict` with multiple columns is either supported or clearly rejected (not silently mis-keying).
+
+#### K3: Comparison-gate NULL safety
+
+- [ ] Run a gated transaction with a NULL value in the balance column; use a comparison gate (`<`, `>=`). Confirm it gates correctly and does not NULL-coerce unexpectedly.
+
+- [ ] Repeat with an `IS NULL` / `IS NOT NULL` gate and document the known limitation (#11832) if it mis-optimizes.
+
+### Spicepod L — regression check (CH-benCHmark) (deferred: write-back unavailable)
+
+Write-back-dependent regression testing is deferred. Once write-back delivery lands, run CH-benCHmark SF1 with the transaction path enabled and confirm no QPH/freshness regression.


### PR DESCRIPTION
## What

`SchemaCastScanExec::partition_statistics` now projects the child statistics onto the output schema by column name, reusing the same unambiguous-name rule the equivalence-property mapping already applies. Dropped, reordered, and retyped columns resolve correctly; an absent or ambiguous name gets unknown statistics. Row-count and byte-size estimates carry over unchanged (a cast does not change the row count).

Fixes #14144 (incidentally, since integer columns triggered the use of `SchemaCastScanExec::partition_statistics`).
